### PR TITLE
Add MEP BAT Report workflow

### DIFF
--- a/.github/workflows/mep_bat_report.yml
+++ b/.github/workflows/mep_bat_report.yml
@@ -1,0 +1,126 @@
+name: MEP BAT Report (Stage0)
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [labeled, synchronize, opened, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  bat-report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set UTF-8 & git quotepath off
+        run: |
+          git config --global core.quotepath false
+          echo "LC_ALL=C.UTF-8" >> $GITHUB_ENV
+          echo "LANG=C.UTF-8" >> $GITHUB_ENV
+
+      - name: Decide whether to run (label gate)
+        id: gate
+        run: |
+          set -e
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            LABELS='${{ toJson(github.event.pull_request.labels) }}'
+            echo "$LABELS" | python3 - << 'PY'
+import json,sys
+labels=json.loads(sys.stdin.read() or "[]")
+names=set([x.get("name","") for x in labels])
+print("run" if "run-bat" in names else "skip")
+PY
+          else
+            echo "run"
+          fi > .mep_bat_gate.txt
+          echo "gate=$(cat .mep_bat_gate.txt)" >> $GITHUB_OUTPUT
+
+      - name: Skip (no label)
+        if: steps.gate.outputs.gate == 'skip'
+        run: |
+          echo "No run-bat label -> SKIP (success)"
+          exit 0
+
+      - name: Collect changed files (git diff -z)
+        run: |
+          set -e
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          python3 tools/mep_integration_compiler/collect_changed_files.py \
+            --base "$BASE_SHA" \
+            --head "$HEAD_SHA" \
+            --out-dir ".mep/tmp"
+
+      - name: Build report
+        run: |
+          set -e
+          python3 - << 'PY'
+import json, pathlib
+d=json.load(open(".mep/tmp/counts.json","r",encoding="utf-8"))
+def read(fp):
+    p=pathlib.Path(fp)
+    if not p.exists(): return []
+    return [x.strip() for x in p.read_text(encoding="utf-8").splitlines() if x.strip()]
+
+lines=[]
+lines.append("# MEP BAT Report (Stage0)")
+lines.append("")
+lines.append("## Summary")
+lines.append(f"- CORE: all={d['core']['all_count']} audit={d['core']['audit_count']} binary={d['core']['binary_count']} deleted={d['core']['deleted_count']}")
+lines.append(f"- BUSINESS: all={d['business']['all_count']} audit={d['business']['audit_count']} binary={d['business']['binary_count']} deleted={d['business']['deleted_count']}")
+lines.append("")
+
+warn=[]
+if d["core"]["all_count"]>0 and (d["core"]["audit_count"] + d["core"]["binary_count"])==0:
+    warn.append("CORE changes exist but both audit/binary inputs are empty (classification failure risk)")
+if d["business"]["all_count"]>0 and (d["business"]["audit_count"] + d["business"]["binary_count"])==0:
+    warn.append("BUSINESS changes exist but both audit/binary inputs are empty (classification failure risk)")
+if warn:
+    lines.append("## Warnings")
+    for w in warn:
+        lines.append(f"- {w}")
+    lines.append("")
+
+def section(title, items, maxn=60):
+    lines.append(f"## {title}")
+    if not items:
+        lines.append("(none)\n")
+        return
+    for x in items[:maxn]:
+        lines.append(f"- {x}")
+    if len(items)>maxn:
+        lines.append(f"- ... and {len(items)-maxn} more")
+    lines.append("")
+
+section("CORE - text targets (semantic audit)", read(".mep/tmp/core_audit.txt"))
+section("CORE - binary targets (binary guard)", read(".mep/tmp/core_binary.txt"))
+section("BUSINESS - text targets (semantic audit)", read(".mep/tmp/biz_audit.txt"))
+section("BUSINESS - binary targets (binary guard)", read(".mep/tmp/biz_binary.txt"))
+
+pathlib.Path(".mep/tmp/report.md").write_text("\n".join(lines)+ "\n", encoding="utf-8")
+PY
+
+      - name: Upload report artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: mep-bat-report
+          path: .mep/tmp/report.md
+
+      - name: Comment on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('.mep/tmp/report.md', 'utf8');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body
+            });


### PR DESCRIPTION
This workflow generates a MEP BAT report for pull requests, collecting changed files, building a report, and commenting on the PR with the results.

﻿# Purpose
(What is this PR changing? Keep it short.)

# Required checks
- [ ] semantic-audit is GREEN (required)
- [ ] If semantic-audit is SKIP, confirm this PR does not change platform/MEP/01_CORE/**/*.md

# If semantic-audit is NG (paste this as a PR comment)
## Template A (standard)
@copilot
Fix this PR so that the required check "semantic-audit" passes.

Constraints:
- Make minimal diffs only. Do NOT rewrite whole documents.
- Only touch files necessary to fix the audit.
- Primary scope: platform/MEP/01_CORE/**/*.md
- Use the audit log from the "MEP Semantic Audit" comment/summary as the source of truth.
- After making changes, push commits to this PR (or open a sub-PR targeting this branch) until checks pass.

Output:
- Briefly state what you changed and why, linked to the audit failure.

## Template B (tight scope)
@copilot
Only modify the exact lines/files referenced by the semantic-audit failure.
Do not refactor, do not reformat, do not touch unrelated files.
One failing point = one minimal fix.

## Template C (no sub-PR)
@copilot
Do NOT create a separate pull request.
Commit directly to this PR branch only.

# Notes for GPT (this chat)
If Copilot loops or the failure reason is unclear, paste:
- the MEP Semantic Audit comment (audit.log section), or
- a screenshot of the failing check log.
