### PR TITLE
fix: mep_bat_report workflow

### DIFF
--- a/.github/workflows/mep_bat_report.yml
+++ b/.github/workflows/mep_bat_report.yml
@@ -1,4 +1,4 @@
-﻿name: MEP BAT Report (Stage0)
+name: MEP BAT Report (Stage0)
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Fix invalid workflow YAML so BAT report runs only on PR (label gate) / workflow_dispatch.