### PR TITLE
fix: bat report trigger

### DIFF
--- a/.github/workflows/mep_bat_report.yml
+++ b/.github/workflows/mep_bat_report.yml
@@ -1,8 +1,8 @@
-name: MEP BAT Report (Stage0)
+﻿name: MEP BAT Report (Stage0)
 
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
     types: [labeled, synchronize, opened, reopened]
 
 permissions:


### PR DESCRIPTION
Switch BAT report workflow trigger to pull_request_target so labeled/synchronize reliably run and can comment on PR.