### PR TITLE
fix: bat report trigger (pull_request_target)

### DIFF
--- a/.github/workflows/mep_bat_report.yml
+++ b/.github/workflows/mep_bat_report.yml
@@ -29,7 +29,7 @@ jobs:
         id: gate
         run: |
           set -e
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
+          if [ "${{ github.event_name }}" = "pull_request_target" ] || [ "${{ github.event_name }}" = "pull_request" ]; then
             LABELS='${{ toJson(github.event.pull_request.labels) }}'
             echo "$LABELS" | python3 - << 'PY'
 import json,sys
@@ -114,7 +114,7 @@ PY
           path: .mep/tmp/report.md
 
       - name: Comment on PR
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request_target' || github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
Use pull_request_target so BAT report can comment on PR reliably. Still gated by run-bat label.