### PR TITLE
fix: remove BOM from mep_bat_report workflow

### DIFF
--- a/.github/workflows/mep_bat_report.yml
+++ b/.github/workflows/mep_bat_report.yml
@@ -1,3 +1,3 @@
-﻿          BASE_SHA=
+          BASE_SHA=
           HEAD_SHA=
 


### PR DESCRIPTION
Remove UTF-8 BOM so GitHub parses workflow correctly.