### PR TITLE
BUSINESS: add CURRENT_SCOPE index entrypoint (no meaning change)

### DIFF
--- a/platform/MEP/03_BUSINESS/よりそい堂/01_INDEX.md
+++ b/platform/MEP/03_BUSINESS/よりそい堂/01_INDEX.md
@@ -1,0 +1,12 @@
+﻿# INDEX (CURRENT_SCOPE: Yorisoidou BUSINESS)
+
+This file is navigation-only. It does NOT change the meaning of business specifications.
+
+Entry points:
+- master_spec: ./master_spec
+- ui_spec: ./ui_spec.md
+- scope note: ./00_CURRENT_SCOPE_NOTE.md
+
+Rule:
+- 1 theme = 1 branch = 1 PR
+- Canonical is main after merge (not this PR conversation)


### PR DESCRIPTION
﻿## 目的（1テーマ）
CURRENT_SCOPE直下に INDEX を追加（ナビゲーション用途のみ）。意味仕様は変更しない。

## 変更範囲（CURRENT_SCOPE内）
- platform/MEP/03_BUSINESS/よりそい堂/01_INDEX.md
