### PR TITLE
PROTO: add text integrity guard (LF/UTF-8/large-diff tripwire)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{bat,cmd}]
+end_of_line = crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,26 @@
+# Normalize text files to LF in repository (reduce CRLF churn accidents)
+* text=auto eol=lf
+
+# Explicit LF for common text formats
+*.md    text eol=lf
+*.yml   text eol=lf
+*.yaml  text eol=lf
+*.json  text eol=lf
+*.js    text eol=lf
+*.ts    text eol=lf
+*.tsx   text eol=lf
+*.css   text eol=lf
+*.html  text eol=lf
+*.sh    text eol=lf
+*.ps1   text eol=lf
+
+# Windows script files stay CRLF
+*.bat   text eol=crlf
+*.cmd   text eol=crlf
+
+# Binary
+*.png  binary
+*.jpg  binary
+*.jpeg binary
+*.gif  binary
+*.pdf  binary

--- a/.github/workflows/text_integrity_guard.yml
+++ b/.github/workflows/text_integrity_guard.yml
@@ -1,0 +1,101 @@
+name: Text Integrity Guard
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full history)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed files
+        id: changed
+        run: |
+          set -euo pipefail
+          BASE="${{ github.event.pull_request.base.sha }}"
+          HEAD="${{ github.sha }}"
+          echo "base=$BASE" >> "$GITHUB_OUTPUT"
+          echo "head=$HEAD" >> "$GITHUB_OUTPUT"
+          git diff --name-only "$BASE...$HEAD" > changed_files.txt
+          echo "Changed files:"
+          cat changed_files.txt || true
+
+      - name: Validate encoding / EOL / newline and tripwire on large diffs
+        run: |
+          set -euo pipefail
+          BASE="${{ steps.changed.outputs.base }}"
+
+          # Files that are extremely sensitive to accidental rewrites
+          SENSITIVE_REGEX='^(platform/MEP/03_BUSINESS/よりそい堂/master_spec|platform/MEP/03_BUSINESS/よりそい堂/ui_spec\.md)$'
+
+          fail=0
+
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            [ ! -f "$f" ] && continue
+
+            # Only check text-like files (md + sensitive)
+            if [[ "$f" == *.md ]] || [[ "$f" =~ $SENSITIVE_REGEX ]]; then
+              # 1) CR (\r) must not exist
+              if python3 - <<'PY' "$f"
+import sys
+p=sys.argv[1]
+b=open(p,'rb').read()
+sys.exit(1 if b.find(b'\r')!=-1 else 0)
+PY
+              then
+                :
+              else
+                echo "NG: CRLF/CR detected in $f"
+                fail=1
+              fi
+
+              # 2) Must be valid UTF-8
+              python3 - <<'PY' "$f" || (echo "NG: invalid UTF-8 in $f"; exit 1)
+import sys
+p=sys.argv[1]
+open(p,'rb').read().decode('utf-8')
+PY
+
+              # 3) Must end with newline (if non-empty)
+              python3 - <<'PY' "$f" || (echo "NG: missing final newline in $f"; exit 1)
+import sys
+p=sys.argv[1]
+b=open(p,'rb').read()
+if len(b)>0 and b[-1:]!=b'\n':
+  raise SystemExit(1)
+PY
+            fi
+
+            # 4) Tripwire: if sensitive file changed, block huge diff (accidental rewrite)
+            if [[ "$f" =~ $SENSITIVE_REGEX ]]; then
+              numstat=$(git diff --numstat "$BASE...HEAD" -- "$f" | awk '{print $1" "$2}')
+              ins=$(echo "$numstat" | awk '{print $1}')
+              del=$(echo "$numstat" | awk '{print $2}')
+              ins=${ins:-0}; del=${del:-0}
+              total=$((ins+del))
+              echo "SENSITIVE_DIFF $f: +$ins -$del (total=$total)"
+
+              # threshold: adjust if truly intended, but this stops mojibake/full-rewrite accidents
+              if [ "$total" -gt 200 ]; then
+                echo "NG: large diff detected on sensitive file ($f). total=$total > 200"
+                fail=1
+              fi
+            fi
+
+          done < changed_files.txt
+
+          if [ "$fail" -ne 0 ]; then
+            echo "Text Integrity Guard: FAILED"
+            exit 1
+          fi
+
+          echo "Text Integrity Guard: OK"


### PR DESCRIPTION
﻿## 目的（1テーマ）
改行/文字コード/全文置換級差分の事故を構造で防ぐため、リポジトリにテキスト整合ガード（LF/UTF-8/巨大差分トリガ）を追加する。

## 変更内容（意味仕様は変更しない）
- .gitattributes: text=auto + LF固定（.bat/.cmdはCRLF）
- .editorconfig: LF/UTF-8/最終改行の統一
- CI: Text Integrity Guard（CRLF混入・UTF-8不正・sensitive巨大差分をNG）

## 変更範囲
- .gitattributes
- .editorconfig
- .github/workflows/text_integrity_guard.yml
