### PR TITLE
PROTO: fix Text Integrity Guard to support push/PR

### DIFF
--- a/.github/workflows/text_integrity_guard.yml
+++ b/.github/workflows/text_integrity_guard.yml
@@ -3,6 +3,7 @@ name: Text Integrity Guard
 on:
   pull_request:
   workflow_dispatch:
+  push:
 
 permissions:
   contents: read
@@ -16,22 +17,63 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Detect changed files
-        id: changed
+      - name: Compute base/head
+        id: revs
+        shell: bash
         run: |
           set -euo pipefail
-          BASE="${{ github.event.pull_request.base.sha }}"
-          HEAD="${{ github.sha }}"
+
+          # Default
+          HEAD="${GITHUB_SHA}"
+          BASE=""
+
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+          elif [ "${GITHUB_EVENT_NAME}" = "push" ]; then
+            # push event has "before"
+            BASE="${{ github.event.before }}"
+            # In some cases (first push/new branch), BASE can be 0000...; fallback to HEAD^
+            if [ -z "$BASE" ] || echo "$BASE" | grep -qE '^0+$'; then
+              BASE="$(git rev-parse "${HEAD}^" 2>/dev/null || true)"
+            fi
+          fi
+
+          if [ -z "$BASE" ]; then
+            echo "BASE is empty (cannot diff). Treat as OK and exit."
+            echo "base=" >> "$GITHUB_OUTPUT"
+            echo "head=$HEAD" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           echo "base=$BASE" >> "$GITHUB_OUTPUT"
           echo "head=$HEAD" >> "$GITHUB_OUTPUT"
+          echo "BASE=$BASE"
+          echo "HEAD=$HEAD"
+
+      - name: Detect changed files
+        id: changed
+        shell: bash
+        run: |
+          set -euo pipefail
+          BASE="${{ steps.revs.outputs.base }}"
+          HEAD="${{ steps.revs.outputs.head }}"
+
+          if [ -z "$BASE" ]; then
+            echo "No base -> no changed files"
+            : > changed_files.txt
+            exit 0
+          fi
+
           git diff --name-only "$BASE...$HEAD" > changed_files.txt
           echo "Changed files:"
           cat changed_files.txt || true
 
       - name: Validate encoding / EOL / newline and tripwire on large diffs
+        shell: bash
         run: |
           set -euo pipefail
-          BASE="${{ steps.changed.outputs.base }}"
+          BASE="${{ steps.revs.outputs.base }}"
+          HEAD="${{ steps.revs.outputs.head }}"
 
           # Files that are extremely sensitive to accidental rewrites
           SENSITIVE_REGEX='^(platform/MEP/03_BUSINESS/よりそい堂/master_spec|platform/MEP/03_BUSINESS/よりそい堂/ui_spec\.md)$'
@@ -76,15 +118,15 @@ PY
             fi
 
             # 4) Tripwire: if sensitive file changed, block huge diff (accidental rewrite)
-            if [[ "$f" =~ $SENSITIVE_REGEX ]]; then
-              numstat=$(git diff --numstat "$BASE...HEAD" -- "$f" | awk '{print $1" "$2}')
+            if [[ "$f" =~ $SENSITIVE_REGEX ]] && [ -n "$BASE" ]; then
+              numstat=$(git diff --numstat "$BASE...$HEAD" -- "$f" | awk '{print $1" "$2}')
               ins=$(echo "$numstat" | awk '{print $1}')
               del=$(echo "$numstat" | awk '{print $2}')
               ins=${ins:-0}; del=${del:-0}
               total=$((ins+del))
               echo "SENSITIVE_DIFF $f: +$ins -$del (total=$total)"
 
-              # threshold: adjust if truly intended, but this stops mojibake/full-rewrite accidents
+              # threshold: stops mojibake/full-rewrite accidents
               if [ "$total" -gt 200 ]; then
                 echo "NG: large diff detected on sensitive file ($f). total=$total > 200"
                 fail=1


### PR DESCRIPTION
﻿## 目的（1テーマ）
Text Integrity Guard が push でも pull_request でも確実に動作し、ログ・PR checks に出るように修正する（仕様の意味変更なし）。

## 変更範囲
- .github/workflows/text_integrity_guard.yml
