### PR TITLE
PROTO: fix Text Integrity Guard regex (ASCII-only)

### DIFF
--- a/.github/workflows/text_integrity_guard.yml
+++ b/.github/workflows/text_integrity_guard.yml
@@ -76,7 +76,71 @@ jobs:
           HEAD="${{ steps.revs.outputs.head }}"
 
           # Files that are extremely sensitive to accidental rewrites
-          SENSITIVE_REGEX='^(platform/MEP/03_BUSINESS/よりそい堂/master_spec|platform/MEP/03_BUSINESS/よりそい堂/ui_spec\.md)$'
+          SENSITIVE_REGEX='(^|/)(master_spec|ui_spec\.md)
+
+          fail=0
+
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            [ ! -f "$f" ] && continue
+
+            # Only check text-like files (md + sensitive)
+            if [[ "$f" == *.md ]] || [[ "$f" =~ $SENSITIVE_REGEX ]]; then
+              # 1) CR (\r) must not exist
+              if python3 - <<'PY' "$f"
+import sys
+p=sys.argv[1]
+b=open(p,'rb').read()
+sys.exit(1 if b.find(b'\r')!=-1 else 0)
+PY
+              then
+                :
+              else
+                echo "NG: CRLF/CR detected in $f"
+                fail=1
+              fi
+
+              # 2) Must be valid UTF-8
+              python3 - <<'PY' "$f" || (echo "NG: invalid UTF-8 in $f"; exit 1)
+import sys
+p=sys.argv[1]
+open(p,'rb').read().decode('utf-8')
+PY
+
+              # 3) Must end with newline (if non-empty)
+              python3 - <<'PY' "$f" || (echo "NG: missing final newline in $f"; exit 1)
+import sys
+p=sys.argv[1]
+b=open(p,'rb').read()
+if len(b)>0 and b[-1:]!=b'\n':
+  raise SystemExit(1)
+PY
+            fi
+
+            # 4) Tripwire: if sensitive file changed, block huge diff (accidental rewrite)
+            if [[ "$f" =~ $SENSITIVE_REGEX ]] && [ -n "$BASE" ]; then
+              numstat=$(git diff --numstat "$BASE...$HEAD" -- "$f" | awk '{print $1" "$2}')
+              ins=$(echo "$numstat" | awk '{print $1}')
+              del=$(echo "$numstat" | awk '{print $2}')
+              ins=${ins:-0}; del=${del:-0}
+              total=$((ins+del))
+              echo "SENSITIVE_DIFF $f: +$ins -$del (total=$total)"
+
+              # threshold: stops mojibake/full-rewrite accidents
+              if [ "$total" -gt 200 ]; then
+                echo "NG: large diff detected on sensitive file ($f). total=$total > 200"
+                fail=1
+              fi
+            fi
+
+          done < changed_files.txt
+
+          if [ "$fail" -ne 0 ]; then
+            echo "Text Integrity Guard: FAILED"
+            exit 1
+          fi
+
+          echo "Text Integrity Guard: OK"
 
           fail=0
 


### PR DESCRIPTION
Fix workflow parsing risk by removing JP-path regex. No meaning change.