### PR TITLE
PROTO: fix Text Integrity Guard regex (ASCII-only)

### DIFF
--- a/.github/workflows/text_integrity_guard.yml
+++ b/.github/workflows/text_integrity_guard.yml
@@ -76,7 +76,7 @@ jobs:
           HEAD="${{ steps.revs.outputs.head }}"
 
           # Files that are extremely sensitive to accidental rewrites
-          SENSITIVE_REGEX='^(platform/MEP/03_BUSINESS/よりそい堂/master_spec|platform/MEP/03_BUSINESS/よりそい堂/ui_spec\.md)$'
+          SENSITIVE_REGEX='(^|/)(master_spec|ui_spec\.md)-Raw'
 
           fail=0
 


### PR DESCRIPTION
Fix regex to ASCII-only and avoid PowerShell replacement expansion. No meaning change.