### PR TITLE
PROTO: fix Text Integrity Guard (stable PR checks)

### DIFF
--- a/.github/workflows/text_integrity_guard.yml
+++ b/.github/workflows/text_integrity_guard.yml
@@ -3,7 +3,6 @@ name: Text Integrity Guard
 on:
   pull_request:
   workflow_dispatch:
-  push:
 
 permissions:
   contents: read
@@ -17,85 +16,56 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Compute base/head
+      - name: Compute base/head (PR only)
         id: revs
         shell: bash
         run: |
           set -euo pipefail
-
-          # Default
-          HEAD="${GITHUB_SHA}"
-          BASE=""
-
-          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
-            BASE="${{ github.event.pull_request.base.sha }}"
-          elif [ "${GITHUB_EVENT_NAME}" = "push" ]; then
-            # push event has "before"
-            BASE="${{ github.event.before }}"
-            # In some cases (first push/new branch), BASE can be 0000...; fallback to HEAD^
-            if [ -z "$BASE" ] || echo "$BASE" | grep -qE '^0+$'; then
-              BASE="$(git rev-parse "${HEAD}^" 2>/dev/null || true)"
-            fi
-          fi
-
-          if [ -z "$BASE" ]; then
-            echo "BASE is empty (cannot diff). Treat as OK and exit."
-            echo "base=" >> "$GITHUB_OUTPUT"
-            echo "head=$HEAD" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
+          BASE="${{ github.event.pull_request.base.sha }}"
+          HEAD="${{ github.event.pull_request.head.sha }}"
           echo "base=$BASE" >> "$GITHUB_OUTPUT"
           echo "head=$HEAD" >> "$GITHUB_OUTPUT"
           echo "BASE=$BASE"
           echo "HEAD=$HEAD"
 
       - name: Detect changed files
-        id: changed
         shell: bash
         run: |
           set -euo pipefail
           BASE="${{ steps.revs.outputs.base }}"
           HEAD="${{ steps.revs.outputs.head }}"
-
-          if [ -z "$BASE" ]; then
-            echo "No base -> no changed files"
-            : > changed_files.txt
-            exit 0
-          fi
-
           git diff --name-only "$BASE...$HEAD" > changed_files.txt
           echo "Changed files:"
           cat changed_files.txt || true
 
-      - name: Validate encoding / EOL / newline and tripwire on large diffs
+      - name: Validate encoding / EOL / newline + tripwire (sensitive)
         shell: bash
         run: |
           set -euo pipefail
           BASE="${{ steps.revs.outputs.base }}"
           HEAD="${{ steps.revs.outputs.head }}"
-
-          # Files that are extremely sensitive to accidental rewrites
-          SENSITIVE_REGEX='(^|/)(master_spec|ui_spec\.md)$'
-
           fail=0
 
           while IFS= read -r f; do
             [ -z "$f" ] && continue
             [ ! -f "$f" ] && continue
 
-            # Only check text-like files (md + sensitive)
-            if [[ "$f" == *.md ]] || [[ "$f" =~ $SENSITIVE_REGEX ]]; then
-              # 1) CR (\r) must not exist
+            bn="$(basename "$f")"
+            is_sensitive=0
+            if [ "$bn" = "master_spec" ] || [ "$bn" = "ui_spec.md" ]; then
+              is_sensitive=1
+            fi
+
+            # Check: markdown + sensitive
+            if [[ "$f" == *.md ]] || [ "$is_sensitive" -eq 1 ]; then
+              # 1) CR(\r) must not exist
               if python3 - <<'PY' "$f"
 import sys
 p=sys.argv[1]
 b=open(p,'rb').read()
 sys.exit(1 if b.find(b'\r')!=-1 else 0)
 PY
-              then
-                :
-              else
+              then :; else
                 echo "NG: CRLF/CR detected in $f"
                 fail=1
               fi
@@ -117,16 +87,14 @@ if len(b)>0 and b[-1:]!=b'\n':
 PY
             fi
 
-            # 4) Tripwire: if sensitive file changed, block huge diff (accidental rewrite)
-            if [[ "$f" =~ $SENSITIVE_REGEX ]] && [ -n "$BASE" ]; then
+            # 4) Tripwire for sensitive: block huge diff
+            if [ "$is_sensitive" -eq 1 ]; then
               numstat=$(git diff --numstat "$BASE...$HEAD" -- "$f" | awk '{print $1" "$2}')
               ins=$(echo "$numstat" | awk '{print $1}')
               del=$(echo "$numstat" | awk '{print $2}')
               ins=${ins:-0}; del=${del:-0}
               total=$((ins+del))
               echo "SENSITIVE_DIFF $f: +$ins -$del (total=$total)"
-
-              # threshold: stops mojibake/full-rewrite accidents
               if [ "$total" -gt 200 ]; then
                 echo "NG: large diff detected on sensitive file ($f). total=$total > 200"
                 fail=1
@@ -139,5 +107,4 @@ PY
             echo "Text Integrity Guard: FAILED"
             exit 1
           fi
-
           echo "Text Integrity Guard: OK"


### PR DESCRIPTION
Fix: ensure Text Integrity Guard runs on pull_request and appears in PR checks. Sensitive detection is filename-based (JP folder OK).