### PR TITLE
docs: add START_HERE entrypoint to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+﻿MEP entrypoint: START_HERE.md
+
 
 BAT report canary
 
@@ -8,3 +10,4 @@ Auto Gate Runner 20260101-041151
 test: auto pr gate PAT 20260101-063145
 
 test: B-required-checks 20260101-063431
+


### PR DESCRIPTION
Add a single-line entrypoint link so the MEP INDEX flow is discoverable from the repository front door.