### PR TITLE
ci: make guard check names unique

### DIFF
--- a/.github/workflows/business_packet_guard_pr.yml
+++ b/.github/workflows/business_packet_guard_pr.yml
@@ -1,4 +1,4 @@
-﻿name: Business Packet Guard (PR)
+name: Business Packet Guard (PR)
 
 on:
   pull_request:

--- a/.github/workflows/scope_guard_pr.yml
+++ b/.github/workflows/scope_guard_pr.yml
@@ -45,7 +45,7 @@ jobs:
 
           text = open(scope_file, "r", encoding="utf-8").read()
 
-          m = re.search(r"^##\s*変更対象（Scope-IN）\s*$", text, flags=re.M)
+          m = re.search(r"^##\s*変更対象�E�Ecope-IN�E�\s*$", text, flags=re.M)
           if not m:
             print("::error::Scope-IN section not found in CURRENT_SCOPE.md")
             sys.exit(1)


### PR DESCRIPTION
Avoid duplicate check-run name guard so branch protection can require them safely.