### PR TITLE
docs(MEP): revert chat packet schedule test

### DIFF
--- a/docs/MEP/GLOSSARY.md
+++ b/docs/MEP/GLOSSARY.md
@@ -5,4 +5,3 @@
 - TIG: Text Integrity Guard
 - INDEX方式: 入口だけ貼り、必要箇所だけ要求
 
-TEST: chat_packet schedule


### PR DESCRIPTION
Revert temporary test line used to validate chat-packet schedule automation.