### PR TITLE
docs(MEP): revert chat packet schedule test v2

### DIFF
--- a/docs/MEP/GLOSSARY.md
+++ b/docs/MEP/GLOSSARY.md
@@ -6,4 +6,3 @@
 - INDEX方式: 入口だけ貼り、必要箇所だけ要求
 
 
-TEST: chat_packet schedule v2


### PR DESCRIPTION
Revert temporary test line used to validate chat-packet schedule automation.