### PR TITLE
ci: auto-run chat packet update after docs/MEP PR merge

### DIFF
--- a/.github/workflows/chat_packet_update_schedule.yml
+++ b/.github/workflows/chat_packet_update_schedule.yml
@@ -6,6 +6,12 @@ on:
     - cron: "10 18 * * *"
   workflow_dispatch:
 
+  # docs/MEP の入力PRが main にマージされたら自動で追随更新（上位互換A）
+  pull_request:
+    types: [closed]
+    paths:
+      - "docs/MEP/**"
+
 permissions:
   contents: write
   pull-requests: write
@@ -16,6 +22,14 @@ concurrency:
 
 jobs:
   update-chat-packet:
+    # PRがclosedでmergedのときだけ動かす。auto/chat-packet-update-* のmergeは無限ループ防止で除外。
+    if: >
+      github.event_name != 'pull_request' ||
+      (
+        github.event.action == 'closed' &&
+        github.event.pull_request.merged == true &&
+        !startsWith(github.event.pull_request.head.ref, 'auto/chat-packet-update-')
+      )
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Auto-run chat_packet_update_schedule on merged docs/MEP PRs; skip auto/chat-packet-update merges to avoid loops.