### PR TITLE
chore(ci): disable Status Context Bridge on PRs

### DIFF
--- a/.github/workflows/status_context_bridge_pr.yml
+++ b/.github/workflows/status_context_bridge_pr.yml
@@ -1,9 +1,7 @@
 ﻿name: Status Context Bridge (PR)
 
 on:
-  pull_request:
   workflow_dispatch:
-
 permissions:
   contents: read
   actions: read
@@ -95,3 +93,4 @@ jobs:
 
               core.info(`status context '${name}' => ${state} (${desc})`);
             }
+


### PR DESCRIPTION
Rulesets now enforce required check-runs; Status Context Bridge is no longer needed on pull_request. Disable to prevent pending/blocking states.