### PR TITLE
chore(ci): add workflow_dispatch to MEP Gate

### DIFF
--- a/.github/workflows/mep_gate_pr.yml
+++ b/.github/workflows/mep_gate_pr.yml
@@ -2,7 +2,7 @@
 
 on:
   pull_request:
-
+  workflow_dispatch:
 permissions:
   contents: read
   pull-requests: read
@@ -70,3 +70,4 @@ PY
           fi
 
           echo "MEP Gate PASSED"
+


### PR DESCRIPTION
Allow manual runs to seed/verify MEP Gate before switching required checks to required1.