### PR TITLE
fix(scope): export base/head env for Scope-IN Suggest

### DIFF
--- a/.github/workflows/scope_in_suggest_pr.yml
+++ b/.github/workflows/scope_in_suggest_pr.yml
@@ -45,6 +45,11 @@ jobs:
           base="${{ github.event.pull_request.base.sha }}"
           head="${{ github.event.pull_request.head.sha }}"
 
+          export BASE_SHA="$base"
+          export HEAD_SHA="$head"
+          export PR_NUMBER="$pr"
+          export REPO_FULL="$repo"
+
           # Fast-path allowlist (same as Scope Guard Phase1 docs safe-path)
           is_docs_only=1
           while IFS= read -r f; do
@@ -185,5 +190,6 @@ jobs:
           PY
 
           gh pr comment "$pr" --repo "$repo" --body $'### [SCOPE_SUGGEST] Out-of-scope detected\nA suggestion PR was created:\n- '"$url"$'\n\nOut-of-scope files:\n'"$(cat /tmp/out_list.txt)"$'\n'
+
 
 


### PR DESCRIPTION
Fix: ensure BASE_SHA/HEAD_SHA are exported before python, and python reads only exported env vars. Enables fully automatic suggestion PR creation.