### PR TITLE
docs(MEP): INDEX add RUNBOOK link

### DIFF
--- a/docs/MEP/INDEX.md
+++ b/docs/MEP/INDEX.md
@@ -17,3 +17,6 @@
 - [GLOSSARY](./GLOSSARY.md)
 - [GOLDEN_PATH](./GOLDEN_PATH.md)
 
+
+## RUNBOOK（復旧カード）
+- RUNBOOK.md（異常時は診断ではなく次の一手だけを返す）


### PR DESCRIPTION
Adds a direct link entry for RUNBOOK.md to eliminate navigation ambiguity.