### PR TITLE
docs(MEP): add HANDOFF_ID + overview to HANDOFF_100

### DIFF
--- a/docs/MEP/HANDOFF_100.md
+++ b/docs/MEP/HANDOFF_100.md
@@ -1,6 +1,9 @@
 
 
 <!-- HANDOFF_CURRENT_BEGIN -->
+HANDOFF_ID: HOF:d589a187abc4
+CONTINUE_TARGET: (AUTO) 旧チャットの続きは「open PR / 直近の失敗チェック / PLAYBOOK次の一手」で確定する。
+NOTE: IDだけ貼る場合は、この3行（HANDOFF_ID/CONTINUE_TARGET/概要）を一緒に貼ると前提が即時共有できる。
 # HANDOFF_100（引継ぎ100点・新チャット1通目に貼る1枚）
 
 ## CURRENT（貼るのはここだけ）
@@ -15,7 +18,63 @@
 
 ---
 
-### 現在地（STATE_SUMMARY）
+### HANDOFF_OVERVIEW（概要：貼った瞬間に前提が分かる）
+（このブロックは要点。詳細は下の各SUMMARY／束を参照。）
+
+■ 現在地（STATE_SUMMARY 抜粋）
+# STATE_SUMMARY（現在地サマリ） v1.0
+本書は `STATE_CURRENT / INDEX / RUNBOOK / PLAYBOOK` をもとに、現在地を 1枚に圧縮した生成物である。
+本書は時刻・ランID等を含めず、入力が変わらない限り差分が出ないことを前提とする。
+生成: docs/MEP/build_state_summary.py
+---
+## 目的（STATE_CURRENTから要約）
+本書は「いま何が成立しているか／次に何をするか」を1枚で固定する。
+UI/APIは実行器であり、唯一の正は GitHub（main / PR / Checks / docs）に置く。
+---
+## 参照導線（固定）
+- CHAT_PACKET: docs/MEP/CHAT_PACKET.md（新チャット開始入力）
+- 現在地: docs/MEP/STATE_CURRENT.md（唯一の現在地）
+- 次の指示: docs/MEP/PLAYBOOK.md
+- 復旧: docs/MEP/RUNBOOK.md
+
+■ 次の一手（PLAYBOOK_SUMMARY 抜粋）
+# PLAYBOOK_SUMMARY（次の指示サマリ） v1.0
+本書は docs/MEP/PLAYBOOK.md をもとに、カード一覧を 1枚に圧縮した生成物である。
+生成: docs/MEP/build_playbook_summary.py
+---
+## カード一覧
+- CARD-00: 新チャット開始（最短の開始入力）
+- CARD-01: docs/MEP を更新する（最小PRで進める）
+- CARD-02: no-checks（表示待ち）に遭遇した
+- CARD-03: Chat Packet Guard NG（CHAT_PACKET outdated）
+- CARD-04: Scope不足（Scope Guard / Scope-IN Suggest）
+- CARD-05: Head branch is out of date（behind/out-of-date）
+- CARD-06: DIRTY（自動停止すべき状態）
+
+■ 異常時（RUNBOOK_SUMMARY 抜粋）
+# RUNBOOK_SUMMARY（復旧サマリ） v1.0
+本書は docs/MEP/RUNBOOK.md をもとに、カード一覧を 1枚に圧縮した生成物である。
+生成: docs/MEP/build_runbook_summary.py
+---
+## カード一覧
+- CARD-01: no-checks（Checksがまだ出ない／表示されない）
+- CARD-02: Chat Packet Guard NG（CHAT_PACKET outdated）
+- CARD-03: Scope不足（Scope Guard / Scope-IN Suggest）
+- CARD-04: Head branch is out of date（behind/out-of-date）
+- CARD-05: DIRTY（自動で安全に解決できない）
+
+■ 追加束（必要な場合のみ）
+- docs/MEP/REQUEST_BUNDLE_SYSTEM.md
+- docs/MEP/REQUEST_BUNDLE_BUSINESS.md
+
+■ 参照（唯一の正）
+- docs/MEP/UPGRADE_GATE.md
+- docs/MEP/AI_OUTPUT_CONTRACT_POWERSHELL.md
+- docs/MEP/STATE_CURRENT.md / PLAYBOOK.md / RUNBOOK.md / INDEX.md
+
+---
+
+### 現在地（STATE_SUMMARY全文）
 # STATE_SUMMARY（現在地サマリ） v1.0
 
 本書は `STATE_CURRENT / INDEX / RUNBOOK / PLAYBOOK` をもとに、現在地を 1枚に圧縮した生成物である。
@@ -82,7 +141,7 @@ UI/APIは実行器であり、唯一の正は GitHub（main / PR / Checks / docs
 
 ---
 
-### 次の一手（PLAYBOOK_SUMMARY）
+### 次の一手（PLAYBOOK_SUMMARY全文）
 # PLAYBOOK_SUMMARY（次の指示サマリ） v1.0
 
 本書は docs/MEP/PLAYBOOK.md をもとに、カード一覧を 1枚に圧縮した生成物である。
@@ -101,7 +160,7 @@ UI/APIは実行器であり、唯一の正は GitHub（main / PR / Checks / docs
 
 ---
 
-### 異常時（RUNBOOK_SUMMARY）
+### 異常時（RUNBOOK_SUMMARY全文）
 # RUNBOOK_SUMMARY（復旧サマリ） v1.0
 
 本書は docs/MEP/RUNBOOK.md をもとに、カード一覧を 1枚に圧縮した生成物である。
@@ -115,20 +174,139 @@ UI/APIは実行器であり、唯一の正は GitHub（main / PR / Checks / docs
 - CARD-03: Scope不足（Scope Guard / Scope-IN Suggest）
 - CARD-04: Head branch is out of date（behind/out-of-date）
 - CARD-05: DIRTY（自動で安全に解決できない）
-
----
-
-### 追加束（必要な場合のみ）
-- docs/MEP/REQUEST_BUNDLE_SYSTEM.md
-- docs/MEP/REQUEST_BUNDLE_BUSINESS.md
-
-### 参照（唯一の正）
-- docs/MEP/UPGRADE_GATE.md
-- docs/MEP/AI_OUTPUT_CONTRACT_POWERSHELL.md
-- docs/MEP/STATE_CURRENT.md / PLAYBOOK.md / RUNBOOK.md / INDEX.md
 <!-- HANDOFF_CURRENT_END -->
 
 <!-- HANDOFF_ARCHIVE_BEGIN -->
+### ARCHIVE_ENTRY sha256:ffa84cd46a2da8a92172b5cff66c42e3816943b9b8caa7ffa321207687fb3491
+
+（過去のCURRENTスナップショット。通常は貼らない。）
+
+> # HANDOFF_100（引継ぎ100点・新チャット1通目に貼る1枚）
+> 
+> ## CURRENT（貼るのはここだけ）
+> 
+> 新チャット1通目は **この CURRENT ブロックだけ**を貼る。
+> 追加が必要と言われた場合のみ `REQUEST_BUNDLE_SYSTEM` または `REQUEST_BUNDLE_BUSINESS` を貼る。
+> 
+> ### ルール（最優先）
+> - 開始直後に UPGRADE_GATE を必ず適用（矛盾検出 → 観測 → 次の一手カード確定 → 1PR着手）
+> - 追加情報が必要な場合のみ REQUEST 形式（最大3件）で要求
+> - AI出力は PowerShell単一コピペ一本道（ID手入力禁止、ghで自動解決）
+> 
+> ---
+> 
+> ### 現在地（STATE_SUMMARY）
+> # STATE_SUMMARY（現在地サマリ） v1.0
+> 
+> 本書は `STATE_CURRENT / INDEX / RUNBOOK / PLAYBOOK` をもとに、現在地を 1枚に圧縮した生成物である。
+> 本書は時刻・ランID等を含めず、入力が変わらない限り差分が出ないことを前提とする。
+> 生成: docs/MEP/build_state_summary.py
+> 
+> ---
+> 
+> ## 目的（STATE_CURRENTから要約）
+> 本書は「いま何が成立しているか／次に何をするか」を1枚で固定する。
+> UI/APIは実行器であり、唯一の正は GitHub（main / PR / Checks / docs）に置く。
+> 
+> ---
+> 
+> ## 参照導線（固定）
+> - CHAT_PACKET: docs/MEP/CHAT_PACKET.md（新チャット開始入力）
+> - 現在地: docs/MEP/STATE_CURRENT.md（唯一の現在地）
+> - 次の指示: docs/MEP/PLAYBOOK.md
+> - 復旧: docs/MEP/RUNBOOK.md
+> - 出力契約: docs/MEP/AI_OUTPUT_CONTRACT_POWERSHELL.md（PowerShell単一コピペ一本道）
+> 
+> ---
+> 
+> ## STATE_CURRENT の主要見出し
+> - STATE_CURRENT（現在地） v1.2
+> - 目的
+> - 1) docs/MEP：CHAT_PACKET 自動追随 = 成立
+> - 2) 重要ルール（固定）
+> - 3) 次の改良 Top3（一本道）
+> 
+> ---
+> 
+> ## PLAYBOOK カード一覧
+> - CARD-00: 新チャット開始（最短の開始入力）
+> - CARD-01: docs/MEP を更新する（最小PRで進める）
+> - CARD-02: no-checks（表示待ち）に遭遇した
+> - CARD-03: Chat Packet Guard NG（CHAT_PACKET outdated）
+> - CARD-04: Scope不足（Scope Guard / Scope-IN Suggest）
+> - CARD-05: Head branch is out of date（behind/out-of-date）
+> - CARD-06: DIRTY（自動停止すべき状態）
+> 
+> ---
+> 
+> ## RUNBOOK カード一覧
+> - CARD-01: no-checks（Checksがまだ出ない／表示されない）
+> - CARD-02: Chat Packet Guard NG（CHAT_PACKET outdated）
+> - CARD-03: Scope不足（Scope Guard / Scope-IN Suggest）
+> - CARD-04: Head branch is out of date（behind/out-of-date）
+> - CARD-05: DIRTY（自動で安全に解決できない）
+> 
+> ---
+> 
+> ## INDEX の主要見出し
+> - 参照順（固定）
+> - Links
+> - RUNBOOK（復旧カード）
+> - PLAYBOOK（次の指示）
+> - STATE_SUMMARY（現在地サマリ）
+> - PLAYBOOK_SUMMARY（次の指示サマリ）
+> - RUNBOOK_SUMMARY（復旧サマリ）
+> - UPGRADE_GATE（開始ゲート）
+> - HANDOFF_100（引継ぎ100点）
+> - REQUEST_BUNDLE（追加要求ファイル束）
+> 
+> ---
+> 
+> ### 次の一手（PLAYBOOK_SUMMARY）
+> # PLAYBOOK_SUMMARY（次の指示サマリ） v1.0
+> 
+> 本書は docs/MEP/PLAYBOOK.md をもとに、カード一覧を 1枚に圧縮した生成物である。
+> 生成: docs/MEP/build_playbook_summary.py
+> 
+> ---
+> 
+> ## カード一覧
+> - CARD-00: 新チャット開始（最短の開始入力）
+> - CARD-01: docs/MEP を更新する（最小PRで進める）
+> - CARD-02: no-checks（表示待ち）に遭遇した
+> - CARD-03: Chat Packet Guard NG（CHAT_PACKET outdated）
+> - CARD-04: Scope不足（Scope Guard / Scope-IN Suggest）
+> - CARD-05: Head branch is out of date（behind/out-of-date）
+> - CARD-06: DIRTY（自動停止すべき状態）
+> 
+> ---
+> 
+> ### 異常時（RUNBOOK_SUMMARY）
+> # RUNBOOK_SUMMARY（復旧サマリ） v1.0
+> 
+> 本書は docs/MEP/RUNBOOK.md をもとに、カード一覧を 1枚に圧縮した生成物である。
+> 生成: docs/MEP/build_runbook_summary.py
+> 
+> ---
+> 
+> ## カード一覧
+> - CARD-01: no-checks（Checksがまだ出ない／表示されない）
+> - CARD-02: Chat Packet Guard NG（CHAT_PACKET outdated）
+> - CARD-03: Scope不足（Scope Guard / Scope-IN Suggest）
+> - CARD-04: Head branch is out of date（behind/out-of-date）
+> - CARD-05: DIRTY（自動で安全に解決できない）
+> 
+> ---
+> 
+> ### 追加束（必要な場合のみ）
+> - docs/MEP/REQUEST_BUNDLE_SYSTEM.md
+> - docs/MEP/REQUEST_BUNDLE_BUSINESS.md
+> 
+> ### 参照（唯一の正）
+> - docs/MEP/UPGRADE_GATE.md
+> - docs/MEP/AI_OUTPUT_CONTRACT_POWERSHELL.md
+> - docs/MEP/STATE_CURRENT.md / PLAYBOOK.md / RUNBOOK.md / INDEX.md
+
 ### ARCHIVE_ENTRY sha256:ffa84cd46a2da8a92172b5cff66c42e3816943b9b8caa7ffa321207687fb3491
 
 （過去のCURRENTスナップショット。通常は貼らない。）

--- a/docs/MEP/build_handoff_100.py
+++ b/docs/MEP/build_handoff_100.py
@@ -29,8 +29,14 @@ def read_text(p: Path) -> str:
     return p.read_text(encoding="utf-8", errors="replace").replace("\r\n", "\n")
 
 
-def sha256(s: str) -> str:
+def sha256_hex(s: str) -> str:
     return hashlib.sha256(s.encode("utf-8")).hexdigest()
+
+
+def hof_id_from_current_body(current_body: str) -> str:
+    # Stable ID: hash of CURRENT body (excluding ID line)
+    h = sha256_hex(current_body)
+    return "HOF:" + h[:12]
 
 
 def extract_block(text: str, begin: str, end: str) -> str | None:
@@ -45,16 +51,33 @@ def set_block(text: str, begin: str, end: str, body: str) -> str:
     repl = begin + "\n" + body.rstrip("\n") + "\n" + end
     if re.search(pat, text, flags=re.DOTALL):
         return re.sub(pat, repl, text, flags=re.DOTALL)
-    # If missing, append
     if not text.endswith("\n"):
         text += "\n"
     return text + "\n" + repl + "\n"
 
 
-def render_current() -> str:
+def compact_lines(md: str, max_lines: int = 18) -> str:
+    # Compact preview for overview (deterministic)
+    out = []
+    for ln in md.splitlines():
+        ln2 = ln.rstrip()
+        if not ln2:
+            continue
+        out.append(ln2)
+        if len(out) >= max_lines:
+            break
+    return "\n".join(out)
+
+
+def render_current_body_without_meta() -> str:
     state = read_text(STATE_SUMMARY).strip()
     pb = read_text(PLAYBOOK_SUMMARY).strip()
     rb = read_text(RUNBOOK_SUMMARY).strip()
+
+    # Overview is compact, the rest can stay detailed enough to be self-sufficient.
+    ov_state = compact_lines(state, 14) if state else "- （未生成）STATE_SUMMARY.md を確認"
+    ov_pb = compact_lines(pb, 12) if pb else "- （未生成）PLAYBOOK_SUMMARY.md を確認"
+    ov_rb = compact_lines(rb, 12) if rb else "- （未生成）RUNBOOK_SUMMARY.md を確認"
 
     lines: list[str] = []
     lines.append("# HANDOFF_100（引継ぎ100点・新チャット1通目に貼る1枚）")
@@ -71,42 +94,65 @@ def render_current() -> str:
     lines.append("")
     lines.append("---")
     lines.append("")
-    lines.append("### 現在地（STATE_SUMMARY）")
-    lines.append(state if state else "- （未生成）STATE_SUMMARY.md を確認")
+    lines.append("### HANDOFF_OVERVIEW（概要：貼った瞬間に前提が分かる）")
+    lines.append("（このブロックは要点。詳細は下の各SUMMARY／束を参照。）")
     lines.append("")
-    lines.append("---")
+    lines.append("■ 現在地（STATE_SUMMARY 抜粋）")
+    lines.append(ov_state)
     lines.append("")
-    lines.append("### 次の一手（PLAYBOOK_SUMMARY）")
-    lines.append(pb if pb else "- （未生成）PLAYBOOK_SUMMARY.md を確認")
+    lines.append("■ 次の一手（PLAYBOOK_SUMMARY 抜粋）")
+    lines.append(ov_pb)
     lines.append("")
-    lines.append("---")
+    lines.append("■ 異常時（RUNBOOK_SUMMARY 抜粋）")
+    lines.append(ov_rb)
     lines.append("")
-    lines.append("### 異常時（RUNBOOK_SUMMARY）")
-    lines.append(rb if rb else "- （未生成）RUNBOOK_SUMMARY.md を確認")
-    lines.append("")
-    lines.append("---")
-    lines.append("")
-    lines.append("### 追加束（必要な場合のみ）")
+    lines.append("■ 追加束（必要な場合のみ）")
     lines.append("- docs/MEP/REQUEST_BUNDLE_SYSTEM.md")
     lines.append("- docs/MEP/REQUEST_BUNDLE_BUSINESS.md")
     lines.append("")
-    lines.append("### 参照（唯一の正）")
+    lines.append("■ 参照（唯一の正）")
     lines.append("- docs/MEP/UPGRADE_GATE.md")
     lines.append("- docs/MEP/AI_OUTPUT_CONTRACT_POWERSHELL.md")
     lines.append("- docs/MEP/STATE_CURRENT.md / PLAYBOOK.md / RUNBOOK.md / INDEX.md")
     lines.append("")
+    lines.append("---")
+    lines.append("")
+    lines.append("### 現在地（STATE_SUMMARY全文）")
+    lines.append(state if state else "- （未生成）STATE_SUMMARY.md を確認")
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+    lines.append("### 次の一手（PLAYBOOK_SUMMARY全文）")
+    lines.append(pb if pb else "- （未生成）PLAYBOOK_SUMMARY.md を確認")
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+    lines.append("### 異常時（RUNBOOK_SUMMARY全文）")
+    lines.append(rb if rb else "- （未生成）RUNBOOK_SUMMARY.md を確認")
+    lines.append("")
     return "\n".join(lines) + "\n"
 
 
+def render_current_with_id() -> str:
+    # Build body first, then compute ID, then prepend stable meta lines
+    body = render_current_body_without_meta()
+    hid = hof_id_from_current_body(body)
+
+    meta = []
+    meta.append(f"HANDOFF_ID: {hid}")
+    meta.append("CONTINUE_TARGET: (AUTO) 旧チャットの続きは「open PR / 直近の失敗チェック / PLAYBOOK次の一手」で確定する。")
+    meta.append("NOTE: IDだけ貼る場合は、この3行（HANDOFF_ID/CONTINUE_TARGET/概要）を一緒に貼ると前提が即時共有できる。")
+    meta.append("")
+    return "\n".join(meta) + body
+
+
 def render_archive_entry(prev_current: str) -> str:
-    # Archive entry is a compact snapshot of previous CURRENT with hash
-    h = sha256(prev_current)
+    h = sha256_hex(prev_current)
     lines: list[str] = []
     lines.append(f"### ARCHIVE_ENTRY sha256:{h}")
     lines.append("")
     lines.append("（過去のCURRENTスナップショット。通常は貼らない。）")
     lines.append("")
-    # store as quoted block to avoid fence accidents
     for ln in prev_current.strip().splitlines():
         lines.append("> " + ln)
     lines.append("")
@@ -114,7 +160,6 @@ def render_archive_entry(prev_current: str) -> str:
 
 
 def trim_archive(archive_body: str) -> str:
-    # keep only last MAX_ARCHIVE_ENTRIES entries (by appearance)
     parts = re.split(r"(?m)^### ARCHIVE_ENTRY sha256:", archive_body)
     if len(parts) <= 1:
         return archive_body.strip() + "\n" if archive_body.strip() else ""
@@ -129,7 +174,7 @@ def trim_archive(archive_body: str) -> str:
 
 def main() -> None:
     existing = read_text(OUT)
-    new_current = render_current()
+    new_current = render_current_with_id()
 
     # ensure markers exist
     if CURRENT_BEGIN not in existing or CURRENT_END not in existing or ARCHIVE_BEGIN not in existing or ARCHIVE_END not in existing:
@@ -144,7 +189,7 @@ def main() -> None:
     archive_body = extract_block(existing, ARCHIVE_BEGIN, ARCHIVE_END) or ""
 
     # If current changed, append previous snapshot to archive
-    if prev_current.strip() and sha256(prev_current) != sha256(new_current):
+    if prev_current.strip() and sha256_hex(prev_current) != sha256_hex(new_current):
         entry = render_archive_entry(prev_current)
         archive_body = entry + "\n\n" + archive_body
 


### PR DESCRIPTION
Adds a stable HANDOFF_ID (sha256-derived) and a compact overview header at the top of HANDOFF_100 CURRENT so pasting the ID/overview is enough to understand what is inherited and what to do next.