### PR TITLE
docs(MEP): add RUNBOOK (recreate)

### DIFF
--- a/docs/MEP/CHAT_PACKET.md
+++ b/docs/MEP/CHAT_PACKET.md
@@ -132,6 +132,16 @@ checks:
 ## REQUEST_BUNDLE（追加要求ファイル束）
 - REQUEST_BUNDLE_SYSTEM.md（SYSTEM側の要求ファイル束）
 - REQUEST_BUNDLE_BUSINESS.md（BUSINESS側の要求ファイル束）
+
+## IDEA_VAULT（アイデア避難所）
+- IDEA_VAULT.md（アイデア散逸防止。ID化は採用候補のみ）
+
+## IDEA_INDEX（統合用一覧）
+- IDEA_INDEX.md（ACTIVEから生成。番号で選ぶ）
+- IDEA_VAULT.md（本体。ACTIVE/ARCHIVE）
+
+## IDEA_RECEIPTS（実装レシート）
+- IDEA_RECEIPTS.md（RESULT: implemented が付いたら削除可能）
 ```
 
 ---

--- a/docs/MEP/HANDOFF_100.md
+++ b/docs/MEP/HANDOFF_100.md
@@ -1,7 +1,7 @@
 
 
 <!-- HANDOFF_CURRENT_BEGIN -->
-HANDOFF_ID: HOF:e8af8c9e3b3d
+HANDOFF_ID: HOF:3af5d115aa04
 HANDOFF_TRIGGER: ユーザーが『引継ぎ』と言ったら、AIは次の1行だけを返す（説明なし）： .\tools\mep_handoff.ps1
 CONTINUE_TARGET: (AUTO) 旧チャットの続きは「open PR / 直近の失敗チェック / PLAYBOOK次の一手」で確定する。
 # HANDOFF_100（引継ぎ100点・新チャット1通目に貼る1枚）
@@ -57,11 +57,7 @@ UI/APIは実行器であり、唯一の正は GitHub（main / PR / Checks / docs
 生成: docs/MEP/build_runbook_summary.py
 ---
 ## カード一覧
-- CARD-01: no-checks（Checksがまだ出ない／表示されない）
-- CARD-02: Chat Packet Guard NG（CHAT_PACKET outdated）
-- CARD-03: Scope不足（Scope Guard / Scope-IN Suggest）
-- CARD-04: Head branch is out of date（behind/out-of-date）
-- CARD-05: DIRTY（自動で安全に解決できない）
+- （未取得）RUNBOOK.md を確認
 
 ■ アイデア一覧（番号で統合）
 （ACTIVEに候補なし）
@@ -125,11 +121,7 @@ UI/APIは実行器であり、唯一の正は GitHub（main / PR / Checks / docs
 ---
 
 ## RUNBOOK カード一覧
-- CARD-01: no-checks（Checksがまだ出ない／表示されない）
-- CARD-02: Chat Packet Guard NG（CHAT_PACKET outdated）
-- CARD-03: Scope不足（Scope Guard / Scope-IN Suggest）
-- CARD-04: Head branch is out of date（behind/out-of-date）
-- CARD-05: DIRTY（自動で安全に解決できない）
+- （未取得）RUNBOOK.md を確認
 
 ---
 
@@ -178,14 +170,197 @@ UI/APIは実行器であり、唯一の正は GitHub（main / PR / Checks / docs
 ---
 
 ## カード一覧
-- CARD-01: no-checks（Checksがまだ出ない／表示されない）
-- CARD-02: Chat Packet Guard NG（CHAT_PACKET outdated）
-- CARD-03: Scope不足（Scope Guard / Scope-IN Suggest）
-- CARD-04: Head branch is out of date（behind/out-of-date）
-- CARD-05: DIRTY（自動で安全に解決できない）
+- （未取得）RUNBOOK.md を確認
 <!-- HANDOFF_CURRENT_END -->
 
 <!-- HANDOFF_ARCHIVE_BEGIN -->
+### ARCHIVE_ENTRY sha256:804fae40a3bea54ac0312f668080a7a9c2a74ebc0f5492b45850d9eb18cd8fd2
+
+（過去のCURRENTスナップショット。通常は貼らない。）
+
+> HANDOFF_ID: HOF:e8af8c9e3b3d
+> HANDOFF_TRIGGER: ユーザーが『引継ぎ』と言ったら、AIは次の1行だけを返す（説明なし）： .\tools\mep_handoff.ps1
+> CONTINUE_TARGET: (AUTO) 旧チャットの続きは「open PR / 直近の失敗チェック / PLAYBOOK次の一手」で確定する。
+> # HANDOFF_100（引継ぎ100点・新チャット1通目に貼る1枚）
+> 
+> ## CURRENT（貼るのはここだけ）
+> 
+> 新チャット1通目は **この CURRENT ブロックだけ**を貼る。
+> 追加が必要と言われた場合のみ `REQUEST_BUNDLE_SYSTEM` または `REQUEST_BUNDLE_BUSINESS` を貼る。
+> 
+> ### ルール（最優先）
+> - 開始直後に UPGRADE_GATE を必ず適用（矛盾検出 → 観測 → 次の一手カード確定 → 1PR着手）
+> - 追加情報が必要な場合のみ REQUEST 形式（最大3件）で要求
+> - AI出力は PowerShell単一コピペ一本道（ID手入力禁止、ghで自動解決）
+> 
+> ---
+> 
+> ### HANDOFF_OVERVIEW（概要：貼った瞬間に前提が分かる）
+> （このブロックは要点。詳細は下の各SUMMARY／束を参照。）
+> 
+> ■ 現在地（STATE_SUMMARY 抜粋）
+> # STATE_SUMMARY（現在地サマリ） v1.0
+> 本書は `STATE_CURRENT / INDEX / RUNBOOK / PLAYBOOK` をもとに、現在地を 1枚に圧縮した生成物である。
+> 本書は時刻・ランID等を含めず、入力が変わらない限り差分が出ないことを前提とする。
+> 生成: docs/MEP/build_state_summary.py
+> ---
+> ## 目的（STATE_CURRENTから要約）
+> 本書は「いま何が成立しているか／次に何をするか」を1枚で固定する。
+> UI/APIは実行器であり、唯一の正は GitHub（main / PR / Checks / docs）に置く。
+> ---
+> ## 参照導線（固定）
+> - CHAT_PACKET: docs/MEP/CHAT_PACKET.md（新チャット開始入力）
+> - 現在地: docs/MEP/STATE_CURRENT.md（唯一の現在地）
+> - 次の指示: docs/MEP/PLAYBOOK.md
+> - 復旧: docs/MEP/RUNBOOK.md
+> 
+> ■ 次の一手（PLAYBOOK_SUMMARY 抜粋）
+> # PLAYBOOK_SUMMARY（次の指示サマリ） v1.0
+> 本書は docs/MEP/PLAYBOOK.md をもとに、カード一覧を 1枚に圧縮した生成物である。
+> 生成: docs/MEP/build_playbook_summary.py
+> ---
+> ## カード一覧
+> - CARD-00: 新チャット開始（最短の開始入力）
+> - CARD-01: docs/MEP を更新する（最小PRで進める）
+> - CARD-02: no-checks（表示待ち）に遭遇した
+> - CARD-03: Chat Packet Guard NG（CHAT_PACKET outdated）
+> - CARD-04: Scope不足（Scope Guard / Scope-IN Suggest）
+> - CARD-05: Head branch is out of date（behind/out-of-date）
+> - CARD-06: DIRTY（自動停止すべき状態）
+> 
+> ■ 異常時（RUNBOOK_SUMMARY 抜粋）
+> # RUNBOOK_SUMMARY（復旧サマリ） v1.0
+> 本書は docs/MEP/RUNBOOK.md をもとに、カード一覧を 1枚に圧縮した生成物である。
+> 生成: docs/MEP/build_runbook_summary.py
+> ---
+> ## カード一覧
+> - CARD-01: no-checks（Checksがまだ出ない／表示されない）
+> - CARD-02: Chat Packet Guard NG（CHAT_PACKET outdated）
+> - CARD-03: Scope不足（Scope Guard / Scope-IN Suggest）
+> - CARD-04: Head branch is out of date（behind/out-of-date）
+> - CARD-05: DIRTY（自動で安全に解決できない）
+> 
+> ■ アイデア一覧（番号で統合）
+> （ACTIVEに候補なし）
+> 
+> ■ 統合の指示例
+> - 新チャットで：『アイデア統合 1 3』→ PowerShellで： .\tools\mep_idea_pick.ps1 1 3 → 貼り付け → 『統合して進めて』
+> 
+> ■ 追加束（必要な場合のみ）
+> - docs/MEP/REQUEST_BUNDLE_SYSTEM.md
+> - docs/MEP/REQUEST_BUNDLE_BUSINESS.md
+> 
+> ■ 参照（唯一の正）
+> - docs/MEP/UPGRADE_GATE.md
+> - docs/MEP/AI_OUTPUT_CONTRACT_POWERSHELL.md
+> - docs/MEP/STATE_CURRENT.md / PLAYBOOK.md / RUNBOOK.md / INDEX.md
+> 
+> ---
+> 
+> ### 現在地（STATE_SUMMARY全文）
+> # STATE_SUMMARY（現在地サマリ） v1.0
+> 
+> 本書は `STATE_CURRENT / INDEX / RUNBOOK / PLAYBOOK` をもとに、現在地を 1枚に圧縮した生成物である。
+> 本書は時刻・ランID等を含めず、入力が変わらない限り差分が出ないことを前提とする。
+> 生成: docs/MEP/build_state_summary.py
+> 
+> ---
+> 
+> ## 目的（STATE_CURRENTから要約）
+> 本書は「いま何が成立しているか／次に何をするか」を1枚で固定する。
+> UI/APIは実行器であり、唯一の正は GitHub（main / PR / Checks / docs）に置く。
+> 
+> ---
+> 
+> ## 参照導線（固定）
+> - CHAT_PACKET: docs/MEP/CHAT_PACKET.md（新チャット開始入力）
+> - 現在地: docs/MEP/STATE_CURRENT.md（唯一の現在地）
+> - 次の指示: docs/MEP/PLAYBOOK.md
+> - 復旧: docs/MEP/RUNBOOK.md
+> - 出力契約: docs/MEP/AI_OUTPUT_CONTRACT_POWERSHELL.md（PowerShell単一コピペ一本道）
+> 
+> ---
+> 
+> ## STATE_CURRENT の主要見出し
+> - STATE_CURRENT（現在地） v1.2
+> - 目的
+> - 1) docs/MEP：CHAT_PACKET 自動追随 = 成立
+> - 2) 重要ルール（固定）
+> - 3) 次の改良 Top3（一本道）
+> 
+> ---
+> 
+> ## PLAYBOOK カード一覧
+> - CARD-00: 新チャット開始（最短の開始入力）
+> - CARD-01: docs/MEP を更新する（最小PRで進める）
+> - CARD-02: no-checks（表示待ち）に遭遇した
+> - CARD-03: Chat Packet Guard NG（CHAT_PACKET outdated）
+> - CARD-04: Scope不足（Scope Guard / Scope-IN Suggest）
+> - CARD-05: Head branch is out of date（behind/out-of-date）
+> - CARD-06: DIRTY（自動停止すべき状態）
+> 
+> ---
+> 
+> ## RUNBOOK カード一覧
+> - CARD-01: no-checks（Checksがまだ出ない／表示されない）
+> - CARD-02: Chat Packet Guard NG（CHAT_PACKET outdated）
+> - CARD-03: Scope不足（Scope Guard / Scope-IN Suggest）
+> - CARD-04: Head branch is out of date（behind/out-of-date）
+> - CARD-05: DIRTY（自動で安全に解決できない）
+> 
+> ---
+> 
+> ## INDEX の主要見出し
+> - 参照順（固定）
+> - Links
+> - RUNBOOK（復旧カード）
+> - PLAYBOOK（次の指示）
+> - STATE_SUMMARY（現在地サマリ）
+> - PLAYBOOK_SUMMARY（次の指示サマリ）
+> - RUNBOOK_SUMMARY（復旧サマリ）
+> - UPGRADE_GATE（開始ゲート）
+> - HANDOFF_100（引継ぎ100点）
+> - REQUEST_BUNDLE（追加要求ファイル束）
+> - IDEA_VAULT（アイデア避難所）
+> - IDEA_INDEX（統合用一覧）
+> - IDEA_RECEIPTS（実装レシート）
+> 
+> ---
+> 
+> ### 次の一手（PLAYBOOK_SUMMARY全文）
+> # PLAYBOOK_SUMMARY（次の指示サマリ） v1.0
+> 
+> 本書は docs/MEP/PLAYBOOK.md をもとに、カード一覧を 1枚に圧縮した生成物である。
+> 生成: docs/MEP/build_playbook_summary.py
+> 
+> ---
+> 
+> ## カード一覧
+> - CARD-00: 新チャット開始（最短の開始入力）
+> - CARD-01: docs/MEP を更新する（最小PRで進める）
+> - CARD-02: no-checks（表示待ち）に遭遇した
+> - CARD-03: Chat Packet Guard NG（CHAT_PACKET outdated）
+> - CARD-04: Scope不足（Scope Guard / Scope-IN Suggest）
+> - CARD-05: Head branch is out of date（behind/out-of-date）
+> - CARD-06: DIRTY（自動停止すべき状態）
+> 
+> ---
+> 
+> ### 異常時（RUNBOOK_SUMMARY全文）
+> # RUNBOOK_SUMMARY（復旧サマリ） v1.0
+> 
+> 本書は docs/MEP/RUNBOOK.md をもとに、カード一覧を 1枚に圧縮した生成物である。
+> 生成: docs/MEP/build_runbook_summary.py
+> 
+> ---
+> 
+> ## カード一覧
+> - CARD-01: no-checks（Checksがまだ出ない／表示されない）
+> - CARD-02: Chat Packet Guard NG（CHAT_PACKET outdated）
+> - CARD-03: Scope不足（Scope Guard / Scope-IN Suggest）
+> - CARD-04: Head branch is out of date（behind/out-of-date）
+> - CARD-05: DIRTY（自動で安全に解決できない）
+
 ### ARCHIVE_ENTRY sha256:6334bc9efaefc4131cec9767f7504e7559c45fee0788f4524539344056d954da
 
 （過去のCURRENTスナップショット。通常は貼らない。）
@@ -1820,134 +1995,4 @@ UI/APIは実行器であり、唯一の正は GitHub（main / PR / Checks / docs
 > - CARD-03: Scope不足（Scope Guard / Scope-IN Suggest）
 > - CARD-04: Head branch is out of date（behind/out-of-date）
 > - CARD-05: DIRTY（自動で安全に解決できない）
-
-### ARCHIVE_ENTRY sha256:ffa84cd46a2da8a92172b5cff66c42e3816943b9b8caa7ffa321207687fb3491
-
-（過去のCURRENTスナップショット。通常は貼らない。）
-
-> # HANDOFF_100（引継ぎ100点・新チャット1通目に貼る1枚）
-> 
-> ## CURRENT（貼るのはここだけ）
-> 
-> 新チャット1通目は **この CURRENT ブロックだけ**を貼る。
-> 追加が必要と言われた場合のみ `REQUEST_BUNDLE_SYSTEM` または `REQUEST_BUNDLE_BUSINESS` を貼る。
-> 
-> ### ルール（最優先）
-> - 開始直後に UPGRADE_GATE を必ず適用（矛盾検出 → 観測 → 次の一手カード確定 → 1PR着手）
-> - 追加情報が必要な場合のみ REQUEST 形式（最大3件）で要求
-> - AI出力は PowerShell単一コピペ一本道（ID手入力禁止、ghで自動解決）
-> 
-> ---
-> 
-> ### 現在地（STATE_SUMMARY）
-> # STATE_SUMMARY（現在地サマリ） v1.0
-> 
-> 本書は `STATE_CURRENT / INDEX / RUNBOOK / PLAYBOOK` をもとに、現在地を 1枚に圧縮した生成物である。
-> 本書は時刻・ランID等を含めず、入力が変わらない限り差分が出ないことを前提とする。
-> 生成: docs/MEP/build_state_summary.py
-> 
-> ---
-> 
-> ## 目的（STATE_CURRENTから要約）
-> 本書は「いま何が成立しているか／次に何をするか」を1枚で固定する。
-> UI/APIは実行器であり、唯一の正は GitHub（main / PR / Checks / docs）に置く。
-> 
-> ---
-> 
-> ## 参照導線（固定）
-> - CHAT_PACKET: docs/MEP/CHAT_PACKET.md（新チャット開始入力）
-> - 現在地: docs/MEP/STATE_CURRENT.md（唯一の現在地）
-> - 次の指示: docs/MEP/PLAYBOOK.md
-> - 復旧: docs/MEP/RUNBOOK.md
-> - 出力契約: docs/MEP/AI_OUTPUT_CONTRACT_POWERSHELL.md（PowerShell単一コピペ一本道）
-> 
-> ---
-> 
-> ## STATE_CURRENT の主要見出し
-> - STATE_CURRENT（現在地） v1.2
-> - 目的
-> - 1) docs/MEP：CHAT_PACKET 自動追随 = 成立
-> - 2) 重要ルール（固定）
-> - 3) 次の改良 Top3（一本道）
-> 
-> ---
-> 
-> ## PLAYBOOK カード一覧
-> - CARD-00: 新チャット開始（最短の開始入力）
-> - CARD-01: docs/MEP を更新する（最小PRで進める）
-> - CARD-02: no-checks（表示待ち）に遭遇した
-> - CARD-03: Chat Packet Guard NG（CHAT_PACKET outdated）
-> - CARD-04: Scope不足（Scope Guard / Scope-IN Suggest）
-> - CARD-05: Head branch is out of date（behind/out-of-date）
-> - CARD-06: DIRTY（自動停止すべき状態）
-> 
-> ---
-> 
-> ## RUNBOOK カード一覧
-> - CARD-01: no-checks（Checksがまだ出ない／表示されない）
-> - CARD-02: Chat Packet Guard NG（CHAT_PACKET outdated）
-> - CARD-03: Scope不足（Scope Guard / Scope-IN Suggest）
-> - CARD-04: Head branch is out of date（behind/out-of-date）
-> - CARD-05: DIRTY（自動で安全に解決できない）
-> 
-> ---
-> 
-> ## INDEX の主要見出し
-> - 参照順（固定）
-> - Links
-> - RUNBOOK（復旧カード）
-> - PLAYBOOK（次の指示）
-> - STATE_SUMMARY（現在地サマリ）
-> - PLAYBOOK_SUMMARY（次の指示サマリ）
-> - RUNBOOK_SUMMARY（復旧サマリ）
-> - UPGRADE_GATE（開始ゲート）
-> - HANDOFF_100（引継ぎ100点）
-> - REQUEST_BUNDLE（追加要求ファイル束）
-> 
-> ---
-> 
-> ### 次の一手（PLAYBOOK_SUMMARY）
-> # PLAYBOOK_SUMMARY（次の指示サマリ） v1.0
-> 
-> 本書は docs/MEP/PLAYBOOK.md をもとに、カード一覧を 1枚に圧縮した生成物である。
-> 生成: docs/MEP/build_playbook_summary.py
-> 
-> ---
-> 
-> ## カード一覧
-> - CARD-00: 新チャット開始（最短の開始入力）
-> - CARD-01: docs/MEP を更新する（最小PRで進める）
-> - CARD-02: no-checks（表示待ち）に遭遇した
-> - CARD-03: Chat Packet Guard NG（CHAT_PACKET outdated）
-> - CARD-04: Scope不足（Scope Guard / Scope-IN Suggest）
-> - CARD-05: Head branch is out of date（behind/out-of-date）
-> - CARD-06: DIRTY（自動停止すべき状態）
-> 
-> ---
-> 
-> ### 異常時（RUNBOOK_SUMMARY）
-> # RUNBOOK_SUMMARY（復旧サマリ） v1.0
-> 
-> 本書は docs/MEP/RUNBOOK.md をもとに、カード一覧を 1枚に圧縮した生成物である。
-> 生成: docs/MEP/build_runbook_summary.py
-> 
-> ---
-> 
-> ## カード一覧
-> - CARD-01: no-checks（Checksがまだ出ない／表示されない）
-> - CARD-02: Chat Packet Guard NG（CHAT_PACKET outdated）
-> - CARD-03: Scope不足（Scope Guard / Scope-IN Suggest）
-> - CARD-04: Head branch is out of date（behind/out-of-date）
-> - CARD-05: DIRTY（自動で安全に解決できない）
-> 
-> ---
-> 
-> ### 追加束（必要な場合のみ）
-> - docs/MEP/REQUEST_BUNDLE_SYSTEM.md
-> - docs/MEP/REQUEST_BUNDLE_BUSINESS.md
-> 
-> ### 参照（唯一の正）
-> - docs/MEP/UPGRADE_GATE.md
-> - docs/MEP/AI_OUTPUT_CONTRACT_POWERSHELL.md
-> - docs/MEP/STATE_CURRENT.md / PLAYBOOK.md / RUNBOOK.md / INDEX.md
 <!-- HANDOFF_ARCHIVE_END -->

--- a/docs/MEP/RUNBOOK.md
+++ b/docs/MEP/RUNBOOK.md
@@ -1,67 +1,102 @@
-﻿# RUNBOOK（復旧カード集）
+﻿# RUNBOOK（復旧カード）
 
-本書は「異常が起きたとき、診断ではなく次の一手だけを返す」ための復旧カード集である。
-手順は PowerShell 単一コピペ一本道を原則とし、IDは gh で自動解決する（手入力禁止）。
-唯一の正：main / PR / Checks / docs（GitHub上の状態）
-
----
-
-## CARD-01: no-checks（Checksがまだ出ない／表示されない）
-
-症状：
-- gh pr checks が「no checks reported」または空
-- ただし直後に表示されることがある（生成待ち）
-
-次の一手（待機→再観測）：
-- 一定時間（例：30〜90秒）待機して再度 gh pr checks を実行
-- それでも出ない場合は A運用（Gate Runner Manual）へ遷移
-
-停止条件（人間判断）：
-- 一定時間待機してもChecksが出ない状態が継続
+本書は「異常時の復旧」をカードとして固定する。
+本書は説明を行わない。評価を行わない。
+目的は、観測 → 一次対応 → 停止条件 → 次の遷移 を迷いなく実行すること。
 
 ---
 
-## CARD-02: Chat Packet Guard NG（CHAT_PACKET outdated）
+## CARD: no-checks（Checksがまだ出ない／表示されない）
 
-症状：
-- Chat Packet Guard が NG（例：CHAT_PACKET.md is outdated）
+### 観測
+- PR の状態とChecks表示
+  - `gh pr view <PR> --json number,state,url,headRefName,baseRefName,mergeable --jq '.'`
+  - `gh pr checks <PR>`
+- GitHub 側の遅延か、ワークフロー未発火かを切り分ける
 
-次の一手：
-- docs/MEP/build_chat_packet.py を実行して CHAT_PACKET.md を更新
-- 更新差分を同一PRに含めて再push（または自動更新PRに任せる）
+### 一次対応
+- しばらく待って再観測（短時間で出ることがある）
+- `gh pr checks <PR>` が永続的に空なら、RUNBOOK: Guard / Scope / token 起因を疑う
+
+### 停止条件（DIRTYへ遷移）
+- 何度観測してもChecksが出ない／「No checks」のまま変化しない
+
+### 次の遷移
+- `CARD: Guard NG` または `CARD: Scope不足` を適用（観測結果により決定）
+- それでも不明なら `CARD: DIRTY`
 
 ---
 
-## CARD-03: Scope不足（Scope Guard / Scope-IN Suggest）
+## CARD: behind / out-of-date（Head branch is out of date）
 
-症状：
+### 観測
+- PR 画面で “Head branch is out of date” 表示
+- `gh pr view <PR> --json mergeable,baseRefOid,headRefOid --jq '.'`
+
+### 一次対応
+- 原則：main を取り込んで更新（rebase/merge は運用規約に従う）
+- 自動で安全に解決できない場合は DIRTY に落とす
+
+### 停止条件（DIRTYへ遷移）
+- 競合が発生する／解決に人間判断が必要
+
+### 次の遷移
+- 解消できたら PLAYBOOK の該当カードへ復帰
+- 解消できないなら `CARD: DIRTY`
+
+---
+
+## CARD: DIRTY（自動で安全に解決できない）
+
+### 観測
+- `git status --porcelain` が空でない
+- 差分が「意図した範囲」外へ漏れている
+- どのカードにも機械的に当てはまらず、人間判断が必要
+
+### 一次対応
+- 自動実行を停止する（これ以上進めない）
+- 停止理由を分類し、人間入力に変換する（最大3点）
+
+### 停止条件（固定）
+- 以後の自動PR作成は行わない
+
+### 次の遷移
+- PLAYBOOK へ戻す前に、人間が「採るべき方針」を確定させる
+
+---
+
+## CARD: Scope不足（Scope Guard / Scope-IN Suggest）
+
+### 観測
 - Scope Guard が NG
-- Scope-IN Suggest が提案を出す
+- 変更対象が Scope-IN に含まれていない
 
-次の一手：
-- 変更対象が本当に必要かを確認
-- 必要なら CURRENT_SCOPE の Scope-IN を最小追加してPRで通す
-- 不要なら変更をScope内に戻す
+### 一次対応
+- CURRENT_SCOPE に必要最小限の Scope-IN を追加する（1PR）
+- 余計なパスを増やさない
 
----
+### 停止条件（DIRTYへ遷移）
+- どのパスを許可すべきか、人間判断が必要
 
-## CARD-04: Head branch is out of date（behind/out-of-date）
-
-症状：
-- gh pr merge が "Head branch is out of date" を返す
-
-次の一手：
-- PRブランチを main に追従（merge/rebaseのいずれか）して再push
-- その後 auto-merge を再設定
+### 次の遷移
+- Scope PR が通ったら、元の目的PRへ復帰
 
 ---
 
-## CARD-05: DIRTY（自動で安全に解決できない）
+## CARD: Guard NG（Chat Packet Guard / Docs Index Guard 等）
 
-定義：
-- merge conflict / push不可 / 自動修復失敗 など、汚染リスクが上がるため自動停止すべき状態
+### 観測
+- Guard のチェック名とログで NG 理由を確定
+- 典型：生成物が outdated / 参照不整合 / 期待ファイル不足
 
-次の一手：
-- 停止理由（分類）を確認
-- 人間判断入力に変換（何を採用/破棄するかを明示）
-- その判断を反映した最小差分PRで再実行
+### 一次対応
+- main 最新から「生成物を再生成して整合」させる（差分最小）
+- 必要なら `docs/MEP/build_*` を実行して追随させる
+
+### 停止条件（DIRTYへ遷移）
+- 追随しても原因が解消しない
+- 参照の正が不明で人間判断が必要
+
+### 次の遷移
+- 解消できたら PLAYBOOK へ復帰
+- 解消できないなら DIRTY

--- a/docs/MEP/RUNBOOK_SUMMARY.md
+++ b/docs/MEP/RUNBOOK_SUMMARY.md
@@ -6,9 +6,5 @@
 ---
 
 ## カード一覧
-- CARD-01: no-checks（Checksがまだ出ない／表示されない）
-- CARD-02: Chat Packet Guard NG（CHAT_PACKET outdated）
-- CARD-03: Scope不足（Scope Guard / Scope-IN Suggest）
-- CARD-04: Head branch is out of date（behind/out-of-date）
-- CARD-05: DIRTY（自動で安全に解決できない）
+- （未取得）RUNBOOK.md を確認
 

--- a/docs/MEP/STATE_SUMMARY.md
+++ b/docs/MEP/STATE_SUMMARY.md
@@ -42,11 +42,7 @@ UI/APIは実行器であり、唯一の正は GitHub（main / PR / Checks / docs
 ---
 
 ## RUNBOOK カード一覧
-- CARD-01: no-checks（Checksがまだ出ない／表示されない）
-- CARD-02: Chat Packet Guard NG（CHAT_PACKET outdated）
-- CARD-03: Scope不足（Scope Guard / Scope-IN Suggest）
-- CARD-04: Head branch is out of date（behind/out-of-date）
-- CARD-05: DIRTY（自動で安全に解決できない）
+- （未取得）RUNBOOK.md を確認
 
 ---
 


### PR DESCRIPTION
Manual-as-Code: recreate RUNBOOK PR (previous PR was closed / head branch deleted)

- Adds: docs/MEP/RUNBOOK.md (minimum cards)
- Regenerates summaries if generators exist