### PR TITLE
tools/docs(MEP): make mep_idea_receipt non-interactive (+Help/+IdeaId)

### DIFF
--- a/docs/MEP/PLAYBOOK.md
+++ b/docs/MEP/PLAYBOOK.md
@@ -89,3 +89,17 @@
 - docs/MEP/IDEA_VAULT.md（避難所）
 - docs/MEP/IDEA_INDEX.md（候補一覧）
 - docs/MEP/IDEA_RECEIPTS.md（実装レシート）
+
+## CARD: IDEA → Receipt → PR（mep_idea_receipt）
+
+目的：
+- 採用したIDEAを「実装レシート（IDEA_RECEIPTS）」として固定し、必要ならPRとして提出する。
+
+実行（非対話／例）：
+- powershell: .\tools\mep_idea_receipt.ps1 -IdeaId abcd1234efgh -Ref "PR#999" -Desc "Implemented the idea"
+- usage:     .\tools\mep_idea_receipt.ps1 -Help
+
+参照：
+- docs/MEP/IDEA_VAULT.md（避難所）
+- docs/MEP/IDEA_INDEX.md（候補一覧）
+- docs/MEP/IDEA_RECEIPTS.md（実装レシート）


### PR DESCRIPTION
目的：
- tools/mep_idea_receipt.ps1 を「新チャットで迷わず実行できる」形にする（非対話）。
- docs/MEP/PLAYBOOK のカードを非対話コマンドに更新。

変更：
- tools/mep_idea_receipt.ps1: -Help / -IdeaId を追加し、行生成を非対話化
- docs/MEP/PLAYBOOK.md: 実行例を -IdeaId/-Ref/-Desc 付きに更新