### PR TITLE
docs(MEP): apply LEASE + CONTINUE_TARGET at start (v1.1)

### DIFF
--- a/docs/MEP/HANDOFF_100.md
+++ b/docs/MEP/HANDOFF_100.md
@@ -1955,3 +1955,12 @@ UI/APIは実行器であり、唯一の正は GitHub（main / PR / Checks / docs
 > - CARD-04: Head branch is out of date（behind/out-of-date）
 > - CARD-05: DIRTY（自動で安全に解決できない）
 <!-- HANDOFF_ARCHIVE_END -->
+
+---
+
+## Lease / Continue Target（導入） v1.1
+
+- LEASE: docs/MEP/LEASE.md
+- CONTINUE_TARGET: docs/MEP/CONTINUE_TARGET.md
+
+運用は「開始直後に UPGRADE_GATE → CONTINUE_TARGET確定 → 1PR」の1本道に固定する。

--- a/docs/MEP/PLAYBOOK.md
+++ b/docs/MEP/PLAYBOOK.md
@@ -103,3 +103,13 @@
 - docs/MEP/IDEA_VAULT.md（避難所）
 - docs/MEP/IDEA_INDEX.md（候補一覧）
 - docs/MEP/IDEA_RECEIPTS.md（実装レシート）
+
+---
+
+## CARD-00 追記（Lease / Continue Target） v1.1
+
+新チャット開始時の最初の作業は、必ず以下の順で固定する：
+- LEASE 適用（CURRENT）
+- UPGRADE_GATE 適用（矛盾検出 → 観測）
+- CONTINUE_TARGET により “次の一手カード” を 1つに確定
+- そのカードに従い 1PR を着手

--- a/docs/MEP/UPGRADE_GATE.md
+++ b/docs/MEP/UPGRADE_GATE.md
@@ -32,3 +32,19 @@
 - 新チャット開始で、STATE_SUMMARY から開始できる
 - 必要に応じて REQUEST（最大3件）で追加情報を取得できる
 - 取得後、観測→次の一手→1PR、の一本道が成立する
+
+---
+
+## Lease / Continue Target（開始直後の固定手順） v1.1
+
+開始直後、AIは必ず以下を実行する。
+
+1) LEASE を適用する（CURRENT に含まれる：HANDOFF_ID / HANDOFF_OVERVIEW / CONTINUE_TARGET）
+2) UPGRADE_GATE を適用する（矛盾検出 → 観測 → 次の一手カード確定）
+3) CONTINUE_TARGET を決定する
+   - AUTO: open PR / failing checks / RUNBOOK異常 → 1つに確定
+   - FIXED: CURRENT 指定の CARD-ID を優先（ただし DIRTY は例外なく停止）
+4) 出力は PowerShell 単一コピペ一本道（ID手入力禁止、ghで自動解決）
+5) 1サイクルは「観測 → 1PR」まで（複数PR同時進行は禁止）
+
+本手順に違反した場合は LEASE_BREAK として DIRTY 扱いで停止する。


### PR DESCRIPTION
Append-only wiring: UPGRADE_GATE / PLAYBOOK(CARD-00) / HANDOFF_100 to require Lease + Continue Target at start.