### PR TITLE
docs(MEP): make IDEA_RECEIPTS example non-executable

### DIFF
--- a/docs/MEP/IDEA_RECEIPTS.md
+++ b/docs/MEP/IDEA_RECEIPTS.md
@@ -7,7 +7,7 @@
 運用（固定）：
 - 実装が完了したら、次の形式で1行追記する（編集はPR経由）。
 - 例：
-  - IDEA:abcd1234efgh  RESULT: implemented  REF: PR#999  DESC: 今回このアイデアが実装されました
+- EXAMPLE:abcd1234efgh  RESULT: implemented  REF: PR#999  DESC: 今回このアイデアが実装されました
 
 フォーマット（機械判定）：
 - 行に `IDEA:xxxxxxxxxxxx`（12桁） と `RESULT: implemented` が同時に含まれていれば「実装済み」と判定する。
@@ -19,3 +19,4 @@
 （空）
 IDEA:1c4d4e1a7f30  RESULT: implemented  REF: CLEANUP  DESC: cleanup: mistaken capture (command text), discard
 IDEA:abcd1234efgh  RESULT: implemented  REF: PR#999  DESC: Implemented the idea (test receipt PR)
+


### PR DESCRIPTION
目的：
- IDEA_RECEIPTS のサンプル行が機械判定の対象にならないようにする（台帳品質の維持）。

変更：
- サンプルの先頭を 'EXAMPLE:' に変更（実レシート行は 'IDEA:' のまま）