### PR TITLE
fix(text): stabilize UTF-8/LF via gitattributes+editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-root = true
+﻿root = true
 
 [*]
 charset = utf-8
@@ -8,3 +8,21 @@ trim_trailing_whitespace = true
 
 [*.md]
 trim_trailing_whitespace = false
+
+# --- MEP text stability (UTF-8/LF) ---
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = true
+
+[*.yml]
+trim_trailing_whitespace = true
+
+[*.yaml]
+trim_trailing_whitespace = true
+

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-* text=auto eol=lf
+﻿* text=auto eol=lf
 
 *.md  text eol=lf
 *.yml text eol=lf
@@ -13,3 +13,16 @@
 *.gif  binary
 *.pdf  binary
 *.zip  binary
+
+# --- MEP text stability (UTF-8/LF) ---
+* text=auto eol=lf
+
+# Markdown/spec files must be treated as text with LF
+*.md text eol=lf
+master_spec text eol=lf
+ui_spec.md text eol=lf
+
+# YAML workflows also LF (avoid CRLF diffs)
+*.yml text eol=lf
+*.yaml text eol=lf
+


### PR DESCRIPTION
Add minimal UTF-8/LF stabilization via .gitattributes + .editorconfig.
Purpose: prevent CRLF/encoding drift and reduce mojibake/format-diff incidents.
Scope: only .gitattributes and .editorconfig.
