### PR TITLE
docs(MEP): regenerate chat packet/docs index (fix guard)

### DIFF
--- a/docs/MEP/CHAT_PACKET.md
+++ b/docs/MEP/CHAT_PACKET.md
@@ -215,7 +215,7 @@ AIは本書に従ってのみ情報要求を行う。
 
 ## STATE_CURRENT.md（現在地）  (docs/MEP/STATE_CURRENT.md)
 ```
-﻿# STATE_CURRENT (MEP)
+# STATE_CURRENT (MEP)
 
 ## CURRENT_SCOPE (canonical)
 - platform/MEP/03_BUSINESS/よりそい堂/**
@@ -231,6 +231,7 @@ AIは本書に従ってのみ情報要求を行う。
 ## How to start a new conversation
 Tell the assistant:
 - "Read docs/MEP/START_HERE.md and proceed."
+- (If memory=0 / new chat) paste CHAT_PACKET_MIN first (tools/mep_chat_packet_min.ps1 output).
 ```
 
 ---


### PR DESCRIPTION
目的：Chat Packet Guard NG を解消するため、生成物（CHAT_PACKET/Docs Index等）をmain最新から再生成して整合させる。

- regen: chat packet + docs index related outputs (tool-driven)
- rule: 1 theme = 1 PR; canonical is main after merge