### PR TITLE
docs(MEP): enforce LF-only for generated chat packet

### DIFF
--- a/docs/MEP/build_chat_packet.py
+++ b/docs/MEP/build_chat_packet.py
@@ -49,3 +49,9 @@ def main():
 
 if __name__ == "__main__":
   main()
+
+def write_text_lf_only(path: str, text: str) -> None:
+    # Force LF even on Windows; prevents CRLF noise in generated artifacts.
+    text = text.replace('\r\n', '\n').replace('\r', '\n')
+    with open(path, 'w', encoding='utf-8', newline='\n') as f:
+        f.write(text)


### PR DESCRIPTION
目的：生成物 docs/MEP/CHAT_PACKET.md の CRLF 混入に起因する警告ノイズを根絶する（運用品質100点化）。

- patch: docs/MEP/build_chat_packet.py -> open(..., newline='\n') / LF正規化
- regen: docs/MEP/CHAT_PACKET.md

RULE: 1 theme = 1 PR; canonical is main after merge.