### PR TITLE
docs(MEP): fix ops rules (LF attrs + gh --json quoting + snippets)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -25,4 +25,6 @@ ui_spec.md text eol=lf
 # YAML workflows also LF (avoid CRLF diffs)
 *.yml text eol=lf
 *.yaml text eol=lf
+docs/MEP/CHAT_PACKET.md text eol=lf
+docs/MEP/IDEA_INDEX.md text eol=lf
 

--- a/docs/MEP/OPS_SNIPPETS_PS.md
+++ b/docs/MEP/OPS_SNIPPETS_PS.md
@@ -1,0 +1,27 @@
+﻿# OPS_SNIPPETS_PS（PowerShell運用スニペット｜固定）
+
+本書は「1ブロック運用」で発生しがちな **ノイズ/事故** を根絶するための定型スニペット集である。
+
+## 1) Python runner 検出（elseif禁止）
+
+~~~powershell
+$runner = $null
+if (Get-Command python -ErrorAction SilentlyContinue) { $runner = "python" }
+if (-not $runner) { if (Get-Command py -ErrorAction SilentlyContinue) { $runner = "py" } }
+if (-not $runner) { throw "Python not found (python or py required)." }
+~~~
+
+## 2) gh --json の注意（カンマは必ずクォート）
+
+PowerShell は `state,mergeable,mergedAt` を配列として分解する。
+必ず文字列で渡す：
+
+~~~powershell
+gh pr view $prNumber --json "state,mergeable,mergedAt" --jq ".state"
+~~~
+
+## 3) 表示（Write-Host -f 禁止／Format推奨）
+
+~~~powershell
+Write-Host ([string]::Format("PR: #{0} {1}", $prNumber, $prUrl))
+~~~


### PR DESCRIPTION
目的：私の提示ブロックが壊れる原因を根絶する（規約修正）。

- 禁止：外側コードブロック内に ` 行を含めない（コードブロック崩壊）
- 修正：gh --json は必ず --json a,b,c とクォート（PowerShellカンマ分解の事故を根絶）
- 安定：docs/MEP 生成物に eol=lf を明示し、CRLF警告ノイズを抑制
- 追加：docs/MEP/OPS_SNIPPETS_PS.md（~~~ フェンスで安全に記述）

RULE: 1 theme = 1 PR; canonical is main after merge.