### PR TITLE
docs(MEP): Issue-form UI + dispatch workflow skeleton

### DIFF
--- a/.github/ISSUE_TEMPLATE/mep_dispatch.yml
+++ b/.github/ISSUE_TEMPLATE/mep_dispatch.yml
@@ -1,0 +1,37 @@
+﻿name: MEP Dispatch
+description: Run MEP via GitHub (UI入口). One theme = one PR.
+title: "[MEP] <theme>"
+labels: ["mep-dispatch"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This issue is an execution request for MEP. Do not paste large files. Describe intent and payload.
+  - type: input
+    id: theme
+    attributes:
+      label: theme
+      description: One theme = one PR (e.g., health_score, doc_split_policy)
+      placeholder: health_score
+    validations:
+      required: true
+  - type: dropdown
+    id: intent
+    attributes:
+      label: intent
+      description: What to do
+      options:
+        - OBSERVE
+        - UPDATE_SPEC
+        - REGENERATE
+    validations:
+      required: true
+  - type: textarea
+    id: payload
+    attributes:
+      label: payload
+      description: Free text instructions or spec text to add. Keep it small.
+      placeholder: |
+        Add health-score deduction rules to master_spec section 9.4 ...
+    validations:
+      required: true

--- a/.github/workflows/mep_dispatch_from_issue.yml
+++ b/.github/workflows/mep_dispatch_from_issue.yml
@@ -1,0 +1,35 @@
+﻿name: MEP Dispatch (from Issue)
+
+on:
+  issues:
+    types: [opened, edited, labeled]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  dispatch:
+    if: contains(github.event.issue.labels.*.name, 'mep-dispatch')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Acknowledge
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const body = issue.body || "";
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              body: [
+                "MEP Dispatch received.",
+                "",
+                "- Next: implement parsing of issue form fields (theme/intent/payload).",
+                "- Then: run OBSERVE or create PR for UPDATE_SPEC/REGENERATE.",
+                "",
+                "Current status: skeleton workflow only (no repo changes)."
+              ].join("\\n")
+            });

--- a/docs/MEP/INTERFACE_CONTRACT.md
+++ b/docs/MEP/INTERFACE_CONTRACT.md
@@ -1,0 +1,20 @@
+﻿# INTERFACE_CONTRACT (MEP Dispatch) v1.0
+
+目的：
+- 入口（PowerShell/UI）を差し替えても同じ挙動になるよう、外部入力の契約を固定する。
+- BAT（B/A/T等）は内部（GitHub Actions）に畳み込み、入口は intent/payload を渡すだけにする。
+
+Inputs（固定）：
+- theme: 1テーマ=1PR の識別子（例: health_score）
+- intent: OBSERVE / UPDATE_SPEC / REGENERATE
+- payload: 自由文（追記したい仕様や指示）。大型ファイル貼付は禁止。
+
+Outputs（固定）：
+- PR URL（UPDATE_SPEC/REGENERATEの場合）
+- Checks 結果（成功/失敗の要点）
+- main は merge 後に唯一の正として更新される
+
+Rules（固定）：
+- 1 theme = 1 PR
+- Scope は platform/MEP/90_CHANGES/CURRENT_SCOPE.md に従う
+- Guard NG の場合は「生成物再生成」優先で整合させる


### PR DESCRIPTION
目的：UI＋GitHubでMEPを回すための最短入口を追加（入口差し替え可能な構造の第一歩）。

- add: .github/ISSUE_TEMPLATE/mep_dispatch.yml (UI入口)
- add: .github/workflows/mep_dispatch_from_issue.yml (実行器の骨組み)
- add: docs/MEP/INTERFACE_CONTRACT.md (共通契約 v1.0)

NOTE: workflowは現時点では受付コメントのみ（安全）。次PRで実処理を実装する。