### PR TITLE
biz(master_spec): Order_YYYY の主要項目へ alertLabels を反映（最小差分）

### DIFF
--- a/platform/MEP/03_BUSINESS/よりそい堂/master_spec
+++ b/platform/MEP/03_BUSINESS/よりそい堂/master_spec
@@ -304,7 +304,7 @@ UP_ID / CU_ID / 物件番号 / 物件名 / 郵便番号 / 住所 / 建物種別 
 主キー：Order_ID
 主要項目：
 Order_ID / UP_ID / CU_ID / 媒体コード / 顧客名 / 電話 / 郵便番号 / 住所 / addressFull / addressCityTown /
-希望日1 / 希望日2 / 見積金額 / 備考（raw全文） / summary / STATUS /
+希望日1 / 希望日2 / 見積金額 / 備考（raw全文） / summary / STATUS / alertLabels /
 CreatedAt / UpdatedAt / LastSyncedAt / HistoryNotes
 業務ルール：
 ・HistoryNotes は自由記述で、内部の Order_ID と相互参照できる


### PR DESCRIPTION
Theme: alertLabels 列の整合（Order_YYYY）

- 3.3.0.1 alertLabels 定義は既に存在するため、Order_YYYY の主要項目（列ブロック）へ alertLabels を反映するだけの最小修正。
- STATUS の直後に alertLabels を追加し、実装の置き場を“列定義としても”確定させる。
- 意味は変更しない（列の見える化のみ）。