### PR TITLE
biz(master_spec): 3.7.2 の 禁止事項（補助｜固定）見出し重複を整理（意味不変）

### DIFF
--- a/platform/MEP/03_BUSINESS/よりそい堂/master_spec
+++ b/platform/MEP/03_BUSINESS/よりそい堂/master_spec
@@ -571,7 +571,6 @@ rootCause（固定キー）：
 禁止事項（補助｜固定）：
 - UIや人が、未定義語を rootCauseValues に入れない（固定集合外はNG）。
 - 起点が曖昧なのに “推測” で rootCause を埋めない（曖昧さは REVIEW のまま保持）。
-禁止事項（補助｜固定）：
 - UIや人が、signals の内容判定（鮮明/不鮮明等）で reviewType を決めない（将来テーマ）。
 - REVIEW を RESOLVED/CANCELLED にする場合は ResolutionMetadata（3.7.4）に従う。
 


### PR DESCRIPTION
Theme: 3.7.2 表記整合（整理のみ）
- 3.7.2 内で「禁止事項（補助｜固定）」見出しが重複していたため、見出し重複のみを解消（本文は削除しない）。
- schema-level の「禁止事項（固定）（payloadVersion…）」は変更しない。