### PR TITLE
biz(master_spec): REVIEW schema に rootCauseKind/rootCauseValues（任意）を追記（3.7.2・整合のみ）

### DIFF
--- a/platform/MEP/03_BUSINESS/よりそい堂/master_spec
+++ b/platform/MEP/03_BUSINESS/よりそい堂/master_spec
@@ -516,6 +516,8 @@ REVIEW（Category=REVIEW）：
 - reviewType     : HEALTH_CHECK / INCONSISTENCY / MISSING_INFO / APPROVAL（必須）
 - requestSummary : 依頼の短文（必須）
 - memo           : 補足（任意）
+- rootCauseKind    : ALERT_LABEL / SIGNAL / PHOTO_FLAG（任意：空を許容）
+- rootCauseValues  : 文字列配列（任意：空を許容。複数可）
 3.7.2.1 REVIEW.reviewType（列挙と起点｜固定）
 
 目的：


### PR DESCRIPTION
Theme: REVIEW schema 整合（明文化のみ）
- 3.7.2 の REVIEW schema 本体に rootCauseKind/rootCauseValues（任意）を追記し、3.7.2.2（定義）と整合させる。
- 既存定義の schema 反映のみ（意味追加なし）。