### PR TITLE
docs(STATE_CURRENT): CURRENT_SCOPE の文字化けを修正（唯一の正へ復元）

### DIFF
--- a/docs/MEP/STATE_CURRENT.md
+++ b/docs/MEP/STATE_CURRENT.md
@@ -5,7 +5,7 @@
 - STABLE/GENERATED は原則触らない（目的明示の専用PRのみ）
 
 ## CURRENT_SCOPE (canonical)
-- platform/MEP/03_BUSINESS/繧医ｊ縺昴＞蝣・**
+- platform/MEP/03_BUSINESS/よりそい堂/**
 
 ## Guards / Safety
 - Text Integrity Guard (PR): enabled


### PR DESCRIPTION
Theme: 起動情報の整合
- docs/MEP/STATE_CURRENT.md の CURRENT_SCOPE (canonical) に文字化けが混入していたため、正しい scope 行へ復元。
- 変更は1行のみ（意味不変／唯一の正の復元）。