### PR TITLE
ui(ui_spec): Phase-1 flow markers（PARTS/EXPENSE）を追加（Go/No-Go用・意味不変）

### DIFF
--- a/platform/MEP/03_BUSINESS/よりそい堂/ui_spec.md
+++ b/platform/MEP/03_BUSINESS/よりそい堂/ui_spec.md
@@ -224,3 +224,7 @@ UIの禁止事項（固定）：
 - UI は RequestStatus を確定しない（OPEN/RESOLVED/CANCELLED の判断は業務ロジック）。
 - UI は “勝手に解決扱い（RESOLVED/CANCELLED）” にしない。
 - 未確定（判定不能）の場合は、一覧導線を出して “監督判断” に寄せる。
+
+<!-- PHASE1_MARKERS (do not change meaning; for Go/No-Go checks only) -->
+<!-- PARTS_FLOW_PHASE1 -->
+<!-- EXPENSE_FLOW_PHASE1 -->


### PR DESCRIPTION
Theme: Phase-1 Go/No-Go の整合
- BUSINESS_IMPL_GO_NOGO が参照する ui_spec.md の marker（<!-- PARTS_FLOW_PHASE1 --> / <!-- EXPENSE_FLOW_PHASE1 -->）が欠けていたため追加。
- マーカー追加のみ（ui_spec の意味／導線定義は変更しない）。