### PR TITLE
biz(phase1): PARTS/EXPENSE 派生定義を business_spec/business_master/ui_master に反映（意味不変）

### DIFF
--- a/platform/MEP/03_BUSINESS/よりそい堂/business_master.md
+++ b/platform/MEP/03_BUSINESS/よりそい堂/business_master.md
@@ -186,6 +186,26 @@ ROLE: BUSINESS_MASTER (data dictionary / IDs / fields / constraints)
 - 不備（写真不足/LOCATION不整合/価格未確定 等）は管理警告対象
 
 <!-- PARTS_FIELDS_PHASE1 -->
+
+<!-- PHASE1_PARTS_FIELDS_BLOCK (derived; do not edit meaning) -->
+### Phase-1: Parts_Master（部材台帳）— 最小フィールド（派生）
+参照（唯一の正）：master_spec 3.4 / 3.4.1 / 6 / 7 / 9
+
+主キー：PART_ID
+
+主要項目（業務的意味を持つ列）：
+- PART_ID / AA番号 / PA/MA番号 / PART_TYPE（BP/BM）
+- Order_ID / OD_ID
+- 品番 / 数量 / メーカー
+- PRICE / STATUS
+- CREATED_AT / DELIVERED_AT / USED_DATE
+- MEMO / LOCATION
+
+必須（最小）：
+- STATUS=STOCK の場合：LOCATION 必須
+- PART_TYPE=BP の場合：納品時に PRICE 確定（未確定は警告）
+- PART_TYPE=BM の場合：PRICE=0（固定）
+<!-- END PHASE1_PARTS_FIELDS_BLOCK -->
 ## PARTS（部材）— BUSINESS_MASTER（辞書）
 
 本節は PARTS（部材）に関する辞書（field/enum/補助辞書）を定義する。
@@ -269,6 +289,21 @@ ROLE: BUSINESS_MASTER (data dictionary / IDs / fields / constraints)
 - BP/BM 区分変更は危険修正（申請/FIX）として扱う
 
 <!-- EXPENSE_FIELDS_PHASE1 -->
+
+<!-- PHASE1_EXPENSE_FIELDS_BLOCK (derived; do not edit meaning) -->
+### Phase-1: Expense_Master（経費台帳）— 最小フィールド（派生）
+参照（唯一の正）：master_spec 3.6 / 3.6.1 / 9
+
+主キー：EXP_ID
+
+主要項目（業務的意味を持つ列）：
+- EXP_ID / Order_ID / PART_ID / CU_ID / UP_ID
+- PRICE / USED_DATE / CreatedAt
+
+最小ルール（固定）：
+- 完了同期で BP の PRICE を根拠に確定（推測代入禁止）
+- BM は経費対象外（PRICE=0）
+<!-- END PHASE1_EXPENSE_FIELDS_BLOCK -->
 ## EXPENSE（経費）— BUSINESS_MASTER（辞書）
 
 ### Fields（Phase-1）

--- a/platform/MEP/03_BUSINESS/よりそい堂/business_spec.md
+++ b/platform/MEP/03_BUSINESS/よりそい堂/business_spec.md
@@ -141,6 +141,30 @@ ROLE: BUSINESS_SPEC (workflow / rules / decisions / exceptions)
 - 完了同期の代替として、別経路で台帳を確定させてはならない
 
 <!-- PARTS_SPEC_PHASE1 -->
+
+<!-- PHASE1_PARTS_SPEC_BLOCK (derived; do not edit meaning) -->
+### Phase-1: PARTS（部材）— 業務最小定義（派生）
+参照（唯一の正）：
+- master_spec: 3.4 Parts_Master / 3.4.1 Parts STATUS / 6 部材体系 / 7 UF06/UF07 / 9 完了同期
+
+最小目的：
+- 部材（BP/BM）の発注→納品→使用→在庫の追跡を、Order_ID と PART_ID で破綻なく再現する。
+
+業務状態（固定）：
+- STOCK / ORDERED / DELIVERED / USED / STOCK_ORDERED
+
+最小トリガー（固定）：
+- UF06（発注確定）: ORDERED または STOCK_ORDERED（Order_ID有無で判定）
+- UF06（納品確定）: DELIVERED（DELIVERED_AT 記録）
+- UF07（価格入力）: PRICE 確定（状態は原則維持）
+- 完了同期（現場完了起点）: DELIVERED の対象を USED へ（使用確定）
+- 未使用部材コメント抽出: STOCK 戻し（LOCATION 整合必須）
+
+不変条件（固定）：
+- BP は納品時に PRICE を確定（未確定は警告対象）
+- BM は PRICE=0（経費対象外）
+- LOCATION は STATUS=STOCK の部材で必須
+<!-- END PHASE1_PARTS_SPEC_BLOCK -->
 ## PARTS（部材）— BUSINESS_SPEC（Phase-1）
 
 ### 目的
@@ -207,6 +231,26 @@ ROLE: BUSINESS_SPEC (workflow / rules / decisions / exceptions)
 - LOCATION 欠落の放置（警告として扱い、管理で回収）
 
 <!-- EXPENSE_SPEC_PHASE1 -->
+
+<!-- PHASE1_EXPENSE_SPEC_BLOCK (derived; do not edit meaning) -->
+### Phase-1: EXPENSE（経費）— 業務最小定義（派生）
+参照（唯一の正）：
+- master_spec: 3.6 Expense_Master / 3.6.1 Expense確定 / 9 完了同期 / 8.4.1 警告
+
+最小目的：
+- USED（使用確定）になった BP の PRICE を根拠に、確定経費として一意に記録する。
+
+確定トリガー（固定）：
+- 完了同期（現場完了起点）でのみ確定（作成/追記）
+
+対象範囲（固定）：
+- BP（メーカー手配品）: PRICE確定が前提（未確定は警告）
+- BM: PRICE=0（経費対象外／経費に入れない）
+
+不変条件（固定）：
+- 推測代入は禁止（PRICEは確定値のみ）
+- 既存Expenseの削除は禁止（履歴保全）
+<!-- END PHASE1_EXPENSE_SPEC_BLOCK -->
 ## EXPENSE（経費）— BUSINESS_SPEC（Phase-1）
 
 ### 目的

--- a/platform/MEP/03_BUSINESS/よりそい堂/ui_master.md
+++ b/platform/MEP/03_BUSINESS/よりそい堂/ui_master.md
@@ -191,6 +191,18 @@ ROLE: UI_MASTER (screen/components/field mappings)
 - 添付不足（写真不足など）は “警告” として扱い、送信は止めない（管理警告で吸収）
 
 <!-- PARTS_UI_MASTER_PHASE1 -->
+
+<!-- PHASE1_PARTS_UI_MASTER_BLOCK (derived; do not edit meaning) -->
+### Phase-1: PARTS UI（表示/導線）— 最小（派生）
+参照（唯一の正）：
+- master_spec: 7 UF06/UF07 / 3.4 / 3.4.1 / 9
+- ui_spec: ALERT_LABELS / REQUEST_LIST_FLOW（表示のみ）
+
+UI責務（固定）：
+- 入力補助・表示・導線のみ（確定は業務ロジック／判断権の原則）
+- Parts の一覧表示（PART_ID / PART_TYPE / AA/PA/MA / STATUS / PRICE / LOCATION）
+- 未確定（PRICE未入力、未納品、LOCATION欠落等）は警告ラベル/導線で可視化（確定はしない）
+<!-- END PHASE1_PARTS_UI_MASTER_BLOCK -->
 ## PARTS（部材）— UI_MASTER（Phase-1）
 
 本節は PARTS（部材：発注/納品/価格入力）に関する UI 辞書（画面/表示/入力の最小定義）を追加する。
@@ -281,6 +293,18 @@ ROLE: UI_MASTER (screen/components/field mappings)
 - UI は STATUS を任意に編集しない（表示のみ、または非表示でも可）
 
 <!-- EXPENSE_UI_MASTER_PHASE1 -->
+
+<!-- PHASE1_EXPENSE_UI_MASTER_BLOCK (derived; do not edit meaning) -->
+### Phase-1: EXPENSE UI（表示/導線）— 最小（派生）
+参照（唯一の正）：
+- master_spec: 3.6 / 3.6.1 / 9 / 8.4.1
+- ui_spec: OV01 表示（参照のみ）
+
+UI責務（固定）：
+- 経費（Expense_Master）の表示（EXP_ID / Order_ID / PART_ID / PRICE / USED_DATE）
+- 推測計算や確定操作はしない（確定は完了同期）
+- PRICE未確定などは警告ラベルで可視化（確定はしない）
+<!-- END PHASE1_EXPENSE_UI_MASTER_BLOCK -->
 ## EXPENSE（経費）— UI_MASTER（Phase-1）
 
 ### Screens（最小）


### PR DESCRIPTION
Theme: Phase-1（PARTS/EXPENSE）派生ドキュメント整備
- master_spec を唯一の正として、Phase-1 の最小定義を派生文書へ反映（参照・再現のため）。
- business_spec.md: PARTS/EXPENSE の業務最小定義（状態/トリガー/不変条件）を追記（意味追加なし）
- business_master.md: Parts_Master / Expense_Master の最小フィールドを追記（意味追加なし）
- ui_master.md: UIの表示/導線（確定しない）を最小で追記（意味追加なし）