### PR TITLE
docs(MEP): fix IDEA_INDEX mojibake

### DIFF
--- a/docs/MEP/IDEA_INDEX.md
+++ b/docs/MEP/IDEA_INDEX.md
@@ -5,6 +5,4 @@
 生成: docs/MEP/build_idea_index.py
 
 ---
-
 1. One-paste capture wrapper idea; implemented as scripts + merged PR  [IDEA:e61113b095cb]
-


### PR DESCRIPTION
Regenerate docs/MEP/IDEA_INDEX.md from IDEA_VAULT (ACTIVE) with UTF-8 (no BOM) + LF.
This fixes mojibake in the IDEA_INDEX header while keeping content minimal.