### PR TITLE
docs(MEP): add UTF-8 BOM to STATE_CURRENT to avoid mojibake in PS5.1

### DIFF
--- a/docs/MEP/STATE_CURRENT.md
+++ b/docs/MEP/STATE_CURRENT.md
@@ -1,4 +1,4 @@
-# STATE_CURRENT (MEP)
+﻿# STATE_CURRENT (MEP)
 
 ## Doc status registry（重複防止）
 - docs/MEP/DOC_REGISTRY.md を最初に確認する (ACTIVE/STABLE/GENERATED)


### PR DESCRIPTION
PowerShell 5.1 Get-Content (default encoding) may display UTF-8 (no BOM) Japanese as mojibake.
Add UTF-8 BOM to docs/MEP/STATE_CURRENT.md so default Get-Content shows readable Japanese.

Scope: docs/MEP only. No content changes other than BOM.