### PR TITLE
docs(MEP): sync CHAT_PACKET.md with generator

### DIFF
--- a/docs/MEP/CHAT_PACKET.md
+++ b/docs/MEP/CHAT_PACKET.md
@@ -218,11 +218,7 @@ AIは本書に従ってのみ情報要求を行う。
 
 ## STATE_CURRENT.md（現在地）  (docs/MEP/STATE_CURRENT.md)
 ```
-﻿# STATE_CURRENT (MEP)
-
-## Doc status registry（重複防止）
-- docs/MEP/DOC_REGISTRY.md を最初に確認する (ACTIVE/STABLE/GENERATED)
-- STABLE/GENERATED は原則触らない（目的明示の専用PRのみ）
+# STATE_CURRENT (MEP)
 
 ## Doc status registry（重複防止）
 - docs/MEP/DOC_REGISTRY.md を最初に確認する (ACTIVE/STABLE/GENERATED)
@@ -232,6 +228,7 @@ AIは本書に従ってのみ情報要求を行う。
 - platform/MEP/03_BUSINESS/よりそい堂/**
 
 ## Guards / Safety
+- Required checks は「PRで必ず表示されるチェック名」のみに限定する（schedule/dispatch専用チェック名を入れると永久BLOCKEDになり得る）。
 - Text Integrity Guard (PR): enabled
 - Halfwidth Kana Guard: enabled
 - UTF-8/LF stabilization: enabled (.gitattributes/.editorconfig)


### PR DESCRIPTION
Chat Packet Guard の前提（generator 出力と一致）を満たすため、
docs/MEP/build_chat_packet.py の出力をそのまま反映。

Scope:
- docs/MEP/CHAT_PACKET.md のみ