### PR TITLE
docs(MEP): add pwsh guard to prevent PS5.1 crashes

### DIFF
--- a/docs/MEP/PROCESS.md
+++ b/docs/MEP/PROCESS.md
@@ -26,3 +26,7 @@
 git checkout main
 git pull --ff-only
 scope-guard enforcement test 20260103-002424
+
+## PowerShell 実行環境（必須）
+- MEP 操作は **pwsh（PowerShell 7）** を使用する（Windows PowerShell 5.1 は禁止）。
+- 5.1 で起動してしまった場合は tools/mep_pwsh_guard.ps1 の方式で pwsh に転送して実行する。

--- a/tools/mep_pwsh_guard.ps1
+++ b/tools/mep_pwsh_guard.ps1
@@ -1,0 +1,25 @@
+# MEP_PWSH_GUARD
+# Purpose: prevent running MEP operations under Windows PowerShell 5.1 (Desktop) which causes encoding/stderr/CLI edge issues.
+# Behavior:
+# - If already pwsh (Core) => no-op
+# - If Desktop => re-exec current script in pwsh and exit with same code
+param(
+  [Parameter(ValueFromRemainingArguments=$true)]
+  [string[]] $ArgsForward
+)
+
+$ErrorActionPreference = "Stop"
+
+if ($PSVersionTable.PSEdition -eq "Core") { return }
+
+$pwshExe = Join-Path $env:ProgramFiles "PowerShell\7\pwsh.exe"
+if (-not (Test-Path $pwshExe)) {
+  throw "MEP_PWSH_GUARD: pwsh not found at: $pwshExe"
+}
+
+if (-not $PSCommandPath) {
+  throw "MEP_PWSH_GUARD: PSCommandPath is empty (cannot re-exec). Run from a script file."
+}
+
+& $pwshExe -NoLogo -NoProfile -ExecutionPolicy Bypass -File $PSCommandPath @ArgsForward
+exit $LASTEXITCODE


### PR DESCRIPTION
目的:
- MEP 作業を Windows PowerShell 5.1 で踏んだ際のクラッシュ/文字コード/CLI地雷を入口で遮断する。

変更:
- tools/mep_pwsh_guard.ps1 を追加（5.1 → pwsh 再実行）
- docs/MEP/PROCESS.md に pwsh 必須を明記