### PR TITLE
business(work): normalize Phase-1 WORK section

### DIFF
--- a/platform/MEP/03_BUSINESS/よりそい堂/business_spec.md
+++ b/platform/MEP/03_BUSINESS/よりそい堂/business_spec.md
@@ -120,25 +120,25 @@ ROLE: BUSINESS_SPEC (workflow / rules / decisions / exceptions)
 - 施工の途中経過は、運用上のメモとして残してよいが、台帳確定のトリガーではない。
 
 ### 最小データ（業務要件）
-- workDoneAt（完了日時）
-- workDoneComment（完了コメント全文：未使用部材記載を含み得る）
-- photosBefore / photosAfter / photosParts / photosExtra（任意：不足は管理警告）
-- videoInspection（任意）
-- workSummary（任意：要約の作り込みで業務判断を置換しない）
+- `workDoneAt`（完了日時）
+- `workDoneComment`（完了コメント全文：未使用部材記載を含み得る）
+- `photosBefore` / `photosAfter` / `photosParts` / `photosExtra`（任意：不足は管理警告）
+- `videoInspection`（任意）
+- `workSummary`（任意：要約の作り込みで業務判断を置換しない）
 
 ### 完了コメント規約（抽出）
 - 未使用部材は、以下の書式で列挙できること（master_spec 9.3 準拠）：
-  例）未使用：BP-YYYYMM-AAxx-PAyy, BM-YYYYMM-AAxx-MAyy
-- 抽出結果は在庫戻し（STATUS=STOCK）へ利用される（LOCATION 整合が必須）
+  - 例）未使用：BP-YYYYMM-AAxx-PAyy, BM-YYYYMM-AAxx-MAyy
+- 抽出結果は在庫戻し（STATUS=STOCK）へ利用される（LOCATION 整合が必須）。
 
 ### 完了時に起きる業務（概要）
-- Order の完了日時・状態更新・最終同期日時の更新
-- DELIVERED 部材の USED 化、EX/Expense の確定、未使用部材の STOCK 戻し
-- 不備（価格未入力/写真不足/LOCATION不整合 等）は管理警告対象
+- Order の完了日時・状態更新・最終同期日時の更新。
+- DELIVERED 部材の USED 化、EX/Expense の確定、未使用部材の STOCK 戻し。
+- 不備（価格未入力 / 写真不足 / LOCATION 不整合 等）は管理警告対象。
 
 ### 禁止事項
-- 人/AI/UI が Order の STATUS/orderStatus を任意に確定/変更してはならない
-- 完了同期の代替として、別経路で台帳を確定させてはならない
+- 人 / AI / UI が Order の STATUS / orderStatus を任意に確定・変更してはならない。
+- 完了同期の代替として、別経路で台帳を確定させてはならない。
 
 <!-- PARTS_SPEC_PHASE1 -->
 


### PR DESCRIPTION
目的: WORK（施工）章の「意味追加なし」正規化（箇条書き/表記揺れの整形のみ）。
範囲: platform/MEP/03_BUSINESS/よりそい堂/business_spec.md の WORK 章のみ。
注意: 派生ブロック（PARTS）以降は変更しない。