### PR TITLE
docs(MEP): require post-merge minimal notes in STATE_CURRENT

### DIFF
--- a/START_HERE.md
+++ b/START_HERE.md
@@ -16,6 +16,9 @@
 - 最短は docs/MEP/CHAT_PACKET.md を貼る（1枚で開始できる）。
 - CHAT_PACKET が無い場合は、本書（START_HERE）を貼って開始する。
 
+- PRをMERGEしたら、STATE_CURRENT.mdへ最小追記（1〜3行）を行い、「何が正式採用になったか」を固定する。
+- 対象は「運用ルール／ゲート／境界」および「BUSINESSの契約（同期・冪等・回収など）」で、整形や生成物更新だけは原則スキップする。
+
 ---
 
 ## 参照順（固定）
@@ -50,4 +53,5 @@
 - docs/MEP/GOLDEN_PATH.md
 
 - [OPS: Scope-IN Suggest 運用（Out-of-scope 自動提案PR）](docs/MEP/OPS_SCOPE_SUGGEST.md)
+
 

--- a/docs/MEP/CHAT_PACKET.md
+++ b/docs/MEP/CHAT_PACKET.md
@@ -27,6 +27,9 @@
 - 最短は docs/MEP/CHAT_PACKET.md を貼る（1枚で開始できる）。
 - CHAT_PACKET が無い場合は、本書（START_HERE）を貼って開始する。
 
+- PRをMERGEしたら、STATE_CURRENT.mdへ最小追記（1〜3行）を行い、「何が正式採用になったか」を固定する。
+- 対象は「運用ルール／ゲート／境界」および「BUSINESSの契約（同期・冪等・回収など）」で、整形や生成物更新だけは原則スキップする。
+
 ---
 
 ## 参照順（固定）
@@ -250,7 +253,7 @@ AIはまず以下を提示し、採用/不採用の判断材料を揃える：
 
 ## STATE_CURRENT.md（現在地）  (docs/MEP/STATE_CURRENT.md)
 ```
-# STATE_CURRENT (MEP)
+﻿# STATE_CURRENT (MEP)
 
 ## Doc status registry（重複防止）
 - docs/MEP/DOC_REGISTRY.md を最初に確認する (ACTIVE/STABLE/GENERATED)
@@ -267,6 +270,8 @@ AIはまず以下を提示し、採用/不採用の判断材料を揃える：
 
 ## Current objective
 - Build and refine Yorisoidou BUSINESS master_spec and UI spec under the above scope.
+- 2026-01-05: (PR #479) Decision-first（採用/不採用→採用後のみ実装）を正式採用
+- 2026-01-05: (PR #483) Phase-2 Integration Contract（Todoist×ClickUp×Ledger）を business_spec に追加
 
 ## How to start a new conversation
 Tell the assistant:
@@ -327,7 +332,7 @@ MEP運用で迷い・暴走・汚染が起きる箇所を、構造（パス境�
 
 ## PROCESS.md（実行テンプレ）  (docs/MEP/PROCESS.md)
 ```
-# PROCESS（手続き） v1.1
+﻿# PROCESS（手続き） v1.1
 
 ## 目的
 本書は、GitHub上で「迷わず同じ結果になる」最小手順をテンプレとして固定する。
@@ -335,8 +340,11 @@ MEP運用で迷い・暴走・汚染が起きる箇所を、構造（パス境�
 
 ---
 
-## 基本原則（必須）
 
+## Post-merge（必須）
+- MERGE後、docs/MEP/STATE_CURRENT.md に `YYYY-MM-DD: (PR #NNN) 要点` を 1〜3行だけ追記する（肥大化禁止）。
+- 追記対象：運用ルール・ゲート・境界、または BUSINESS の契約/責務分界/同期/冪等/競合回収。
+- 禁止：長文化、全文貼替、整形だけコミット、DOC_REGISTRYで GENERATED とされる生成物を手で直すこと。
 ## docs/MEP 生成物同期（必須）
 - docs/MEP/** を変更したPRは、先に **Chat Packet Update (Dispatch)** を実行して docs/MEP/CHAT_PACKET.md を最新化する。
 - Chat Packet Guard は Required check のため、**outdated のままではマージ不可**（＝このルールを守れば詰まらない）。

--- a/docs/MEP/PROCESS.md
+++ b/docs/MEP/PROCESS.md
@@ -1,4 +1,4 @@
-# PROCESS（手続き） v1.1
+﻿# PROCESS（手続き） v1.1
 
 ## 目的
 本書は、GitHub上で「迷わず同じ結果になる」最小手順をテンプレとして固定する。
@@ -6,8 +6,11 @@
 
 ---
 
-## 基本原則（必須）
 
+## Post-merge（必須）
+- MERGE後、docs/MEP/STATE_CURRENT.md に `YYYY-MM-DD: (PR #NNN) 要点` を 1〜3行だけ追記する（肥大化禁止）。
+- 追記対象：運用ルール・ゲート・境界、または BUSINESS の契約/責務分界/同期/冪等/競合回収。
+- 禁止：長文化、全文貼替、整形だけコミット、DOC_REGISTRYで GENERATED とされる生成物を手で直すこと。
 ## docs/MEP 生成物同期（必須）
 - docs/MEP/** を変更したPRは、先に **Chat Packet Update (Dispatch)** を実行して docs/MEP/CHAT_PACKET.md を最新化する。
 - Chat Packet Guard は Required check のため、**outdated のままではマージ不可**（＝このルールを守れば詰まらない）。
@@ -41,3 +44,4 @@ scope-guard enforcement test 20260103-002424
 ~~~powershell
 .\tools\mep_autopilot.ps1 -MaxRounds 120 -SleepSeconds 5 -StagnationRounds 12
 ~~~
+

--- a/docs/MEP/STATE_CURRENT.md
+++ b/docs/MEP/STATE_CURRENT.md
@@ -1,4 +1,4 @@
-# STATE_CURRENT (MEP)
+﻿# STATE_CURRENT (MEP)
 
 ## Doc status registry（重複防止）
 - docs/MEP/DOC_REGISTRY.md を最初に確認する (ACTIVE/STABLE/GENERATED)
@@ -15,8 +15,11 @@
 
 ## Current objective
 - Build and refine Yorisoidou BUSINESS master_spec and UI spec under the above scope.
+- 2026-01-05: (PR #479) Decision-first（採用/不採用→採用後のみ実装）を正式採用
+- 2026-01-05: (PR #483) Phase-2 Integration Contract（Todoist×ClickUp×Ledger）を business_spec に追加
 
 ## How to start a new conversation
 Tell the assistant:
 - "Read docs/MEP/START_HERE.md and proceed."
 - (If memory=0 / new chat) paste CHAT_PACKET_MIN first (tools/mep_chat_packet_min.ps1 output).
+


### PR DESCRIPTION
Adds a mandatory post-merge housekeeping rule:
- After merging impactful PRs, append 1–3 lines to docs/MEP/STATE_CURRENT.md to lock in what was formally adopted.
- Applies to: operational rules/gates/boundaries and BUSINESS contracts (sync/idempotency/recovery).
- Avoids: long updates, full rewrites, formatting-only commits, and manual edits to GENERATED docs.

Also records recent adoption notes for PR #479 and PR #483 (minimal, non-expanding).