### PR TITLE
docs(MEP): document non-GitHub work normalization (reflected in CHAT_PACKET)

### DIFF
--- a/docs/MEP/CHAT_PACKET.md
+++ b/docs/MEP/CHAT_PACKET.md
@@ -373,6 +373,28 @@ MEP運用で迷い・暴走・汚染が起きる箇所を、構造（パス境�
 
 
 ## Post-merge（必須）
+
+## 外部変更の正規化（GitHub経由しない作業を main に固定）
+
+目的：
+- GAS / スプレッドシート / 外部運用など「GitHub外で進んだ作業」を、引っ越し・再現性・唯一の正のために main へ正規化して固定する。
+
+原則（固定）：
+- 外部で進めた作業は、そのままでは GitHub に残らないため、結果（現在地）だけを docs/MEP に追記して PR→MERGE する。
+- 追記は「確定した値のみ」。推測・埋め・未確定URLの混入は禁止（汚染防止）。
+- 追記先は原則 docs/MEP/STATE_CURRENT.md の「## Current objective」に 1〜3 行（肥大化禁止）。
+
+手順（最小・毎回同じ）：
+1) docs/MEP/STATE_CURRENT.md に以下を最小追記（例）：
+   - 外部システムの到達点（例：GAS Write Endpoint が B16-1 まで）
+   - 台帳の識別子（例：Spreadsheet ID、対象シート名）
+   - 次テーマ（NEXT）を 1 行
+2) docs/MEP/build_chat_packet.py を実行し docs/MEP/CHAT_PACKET.md を再生成（Guard対策）。
+3) 変更は docs/MEP のみに限定した PR を作成し、Required checks を通して MERGE。
+4) MERGE 後は mep_autopilot.ps1 で open PR=0 を収束させる。
+
+Done 判定：
+- main に「外部の現在地」が固定され、CHAT_PACKET から参照できる（＝引っ越し後も同じ手順で続行できる）。
 - MERGE後、docs/MEP/STATE_CURRENT.md に `YYYY-MM-DD: (PR #NNN) 要点` を 1〜3行だけ追記する（肥大化禁止）。
 - 追記対象：運用ルール・ゲート・境界、または BUSINESS の契約/責務分界/同期/冪等/競合回収。
 - 禁止：長文化、全文貼替、整形だけコミット、DOC_REGISTRYで GENERATED とされる生成物を手で直すこと。

--- a/docs/MEP/PROCESS.md
+++ b/docs/MEP/PROCESS.md
@@ -8,6 +8,28 @@
 
 
 ## Post-merge（必須）
+
+## 外部変更の正規化（GitHub経由しない作業を main に固定）
+
+目的：
+- GAS / スプレッドシート / 外部運用など「GitHub外で進んだ作業」を、引っ越し・再現性・唯一の正のために main へ正規化して固定する。
+
+原則（固定）：
+- 外部で進めた作業は、そのままでは GitHub に残らないため、結果（現在地）だけを docs/MEP に追記して PR→MERGE する。
+- 追記は「確定した値のみ」。推測・埋め・未確定URLの混入は禁止（汚染防止）。
+- 追記先は原則 docs/MEP/STATE_CURRENT.md の「## Current objective」に 1〜3 行（肥大化禁止）。
+
+手順（最小・毎回同じ）：
+1) docs/MEP/STATE_CURRENT.md に以下を最小追記（例）：
+   - 外部システムの到達点（例：GAS Write Endpoint が B16-1 まで）
+   - 台帳の識別子（例：Spreadsheet ID、対象シート名）
+   - 次テーマ（NEXT）を 1 行
+2) docs/MEP/build_chat_packet.py を実行し docs/MEP/CHAT_PACKET.md を再生成（Guard対策）。
+3) 変更は docs/MEP のみに限定した PR を作成し、Required checks を通して MERGE。
+4) MERGE 後は mep_autopilot.ps1 で open PR=0 を収束させる。
+
+Done 判定：
+- main に「外部の現在地」が固定され、CHAT_PACKET から参照できる（＝引っ越し後も同じ手順で続行できる）。
 - MERGE後、docs/MEP/STATE_CURRENT.md に `YYYY-MM-DD: (PR #NNN) 要点` を 1〜3行だけ追記する（肥大化禁止）。
 - 追記対象：運用ルール・ゲート・境界、または BUSINESS の契約/責務分界/同期/冪等/競合回収。
 - 禁止：長文化、全文貼替、整形だけコミット、DOC_REGISTRYで GENERATED とされる生成物を手で直すこと。
@@ -56,4 +78,5 @@ scope-guard enforcement test 20260103-002424
   - `--json ...` の出力を `ConvertFrom-Json` で処理する（`-q` 依存を避ける）。
 - 誤って main に戻ってしまった場合でも、人間判断なしで復旧できるようにする:
   - 「作業ブランチ候補を自動検出 → checkout → push → PR作成/再利用 → auto-merge → main同期」を 1ブロックで実行する。
+
 


### PR DESCRIPTION
Add a documented method for when work happens outside GitHub (e.g., GAS/Sheets):
- Normalize current state into docs/MEP/STATE_CURRENT.md via PR→MERGE (confirmed-only, minimal lines)
- Regenerate docs/MEP/CHAT_PACKET.md to satisfy guards
This makes “non-GitHub work” compatible with the usual MEP flow and handoff.