### PR TITLE
docs(MEP): add CHAT_PACKET_BUNDLE (self-contained start/current)

### DIFF
--- a/docs/MEP/CHAT_PACKET_BUNDLE.md
+++ b/docs/MEP/CHAT_PACKET_BUNDLE.md
@@ -758,5 +758,11 @@ scope-guard enforcement test 20260103-002424
 ```
 
 ---
+---
+
+<!-- CHAT_PACKET_BUNDLE_POINTER -->
+## CHAT_PACKET_BUNDLE（追加）
+- 自己完結版: docs/MEP/CHAT_PACKET_BUNDLE.md（START_HERE / AI_BOOT / STATE_CURRENT を同梱）
+- 新チャットで参照できない環境でも、貼るだけで入口と現在地が確定する。
 ~~~
 


### PR DESCRIPTION
ADD ONLY.
- Add docs/MEP/CHAT_PACKET_BUNDLE.md that inlines START_HERE.md / AI_BOOT.md / STATE_CURRENT.md for paste-only environments.
- Append a short pointer section to docs/MEP/CHAT_PACKET.md (idempotent marker).
