### PR TITLE
Fix: unify channel key to KURAMA

### DIFF
--- a/seed/payment_channel.csv
+++ b/seed/payment_channel.csv
@@ -5,3 +5,4 @@ MITSUMOA,ミツモア,2,TRUE,媒体カテゴリに従う
 KURASHI,くらしのマーケット,3,TRUE,媒体カテゴリに従う
 MEDIA_OTHER,その他媒体,4,TRUE,媒体カテゴリに従う
 
+


### PR DESCRIPTION
Unify payment channel key for くらしのマーケット: KURASHI -> KURAMA in seed/payment_channel.csv and business/business_spec.md.