### PR TITLE
UF06: add GAS entrypoints + minimal UI templates (Phase-1, new files only)

### DIFF
--- a/gas/uf06/README_UF06.md
+++ b/gas/uf06/README_UF06.md
@@ -1,0 +1,10 @@
+# UF06 Implementation (Phase-1)
+
+このディレクトリは UF06（発注/納品）実装の入口（GAS）を提供する。
+- UI 受信 → 正規化 → Orchestrator（別層）へ委譲
+- FIXATE（採用済み）に従い、タスク名投影と辞書検索の最小関数を含む。
+
+Files:
+- uf06_app.gs : UI入口 + normalize
+- parts_dict.gs : Parts_Dict 正規化/検索（設計→実装の入口）
+- task_title_projector.gs : タスク名投影（AA<=5 else x/y、自由文スロット保持）

--- a/gas/uf06/parts_dict.gs
+++ b/gas/uf06/parts_dict.gs
@@ -1,0 +1,50 @@
+/**
+ * Parts_Dict（設計→実装の入口）
+ * - 採用(adopted=true)のみ確定扱い
+ * - AI提案はここでは扱わない（提案は別層）
+ */
+function PartsDict_normalizeRecord(rec) {
+  rec = rec || {};
+  var legacy = String(rec.legacyStatus || '').toUpperCase();
+  if (legacy !== 'CURRENT' && legacy !== 'OLD' && legacy !== 'UNKNOWN') legacy = 'UNKNOWN';
+
+  var mark = String(rec.discontinuedMark || '');
+  if (mark !== '◇' && mark !== '◆') mark = '';
+
+  var tags = rec.tags;
+  if (!Array.isArray(tags)) tags = [];
+  tags = tags.map(function(t){ return String(t||'').trim(); }).filter(function(t){ return !!t; });
+
+  return {
+    dictId: String(rec.dictId || '').trim(),
+    maker: String(rec.maker || '').trim(),
+    modelNumber: String(rec.modelNumber || '').trim(),
+    tags: tags,
+    legacyStatus: legacy,
+    legacyModelNumber: String(rec.legacyModelNumber || '').trim(),
+    replacementModelNumber: String(rec.replacementModelNumber || '').trim(),
+    discontinuedMark: mark,
+    adopted: !!rec.adopted,
+    adoptedAt: String(rec.adoptedAt || '').trim(),
+    adoptedBy: String(rec.adoptedBy || '').trim(),
+    note: String(rec.note || '').trim()
+  };
+}
+
+/**
+ * 検索（設計レベル）
+ * - modelNumber 部分一致
+ * - tags は maker 同格で検索対象
+ */
+function PartsDict_search(records, query) {
+  records = Array.isArray(records) ? records : [];
+  query = String(query || '').trim();
+  if (!query) return [];
+
+  var terms = query.split(/\s+/).filter(function(x){ return !!x; });
+  return records.filter(function(r){
+    r = PartsDict_normalizeRecord(r);
+    var hay = [r.maker, r.modelNumber, r.legacyModelNumber, r.replacementModelNumber].join(' ') + ' ' + (r.tags||[]).join(' ');
+    return terms.every(function(t){ return hay.indexOf(t) >= 0; });
+  });
+}

--- a/gas/uf06/task_title_projector.gs
+++ b/gas/uf06/task_title_projector.gs
@@ -1,0 +1,33 @@
+/**
+ * タスク名投影（FIXATE）
+ * - AA最大5、6以上は x/y 表示
+ * - 自由文スロット（末尾 '_ '）は非干渉：残し、ここへ追記しない
+ * - 欠番/キャンセルはタスク名へ反映しない（台帳のみ）
+ */
+function TaskTitle_project(currentTitle, aaList, deliveredCount, totalCount) {
+  currentTitle = String(currentTitle || '');
+  aaList = Array.isArray(aaList) ? aaList : [];
+
+  // free slot "_ " の保持（無ければ末尾に追加してもよい：既存契約に従う）
+  var freeSlot = '_ ';
+  var idx = currentTitle.lastIndexOf(freeSlot);
+  var base = (idx >= 0) ? currentTitle.substring(0, idx).trimRight() : currentTitle.trimRight();
+
+  var head = '';
+  var uniq = {};
+  var aas = aaList.map(function(a){ return String(a||'').trim(); }).filter(function(a){ return !!a; })
+    .filter(function(a){ if (uniq[a]) return false; uniq[a]=true; return true; });
+
+  if (aas.length > 0 && aas.length <= 5) {
+    head = aas.join(' ');
+  } else {
+    var x = Number(deliveredCount || 0);
+    var y = Number(totalCount || 0);
+    head = '納品 ' + x + '/' + y;
+  }
+
+  var nextBase = head;
+  // 既存 base に顧客名等が入っている場合、head と衝突しない範囲で残す（破壊しない）
+  // ここでは最小安全として「head だけ」を出す。追加情報は別層で合成する。
+  return (nextBase + ' ' + freeSlot);
+}

--- a/gas/uf06/uf06_app.gs
+++ b/gas/uf06/uf06_app.gs
@@ -1,0 +1,78 @@
+/**
+ * UF06 実装（発注/納品）— Phase-1
+ * - 既存の業務ロジック（台帳確定/採番/冪等/回収）へ接続するための「入口」を提供する。
+ * - ここでは UI 受信と正規化のみを定義し、確定判断は Orchestrator（別層）へ委譲する。
+ *
+ * FIXATE（採用済み）に従う：
+ * - 発注UI: 左=顧客、右=部品、複数行、一括登録
+ * - 納品UI: 発注日時順、チェックで一括納品
+ * - タスク名: AA最大5、超過は x/y、自由文スロットは非干渉
+ */
+
+/** UF06-ORDER: 発注（入力を受け取り、正規化して返す） */
+function UF06_ORDER_normalize(payload) {
+  payload = payload || {};
+  var rows = Array.isArray(payload.rows) ? payload.rows : [];
+  // 1行 = { customer: {...}, parts: [{...},{...} ...] } を想定（UIは自由に複数行）
+  var out = rows.map(function(r){
+    var c = r && r.customer ? r.customer : {};
+    var parts = Array.isArray(r && r.parts) ? r.parts : [];
+    return {
+      customer: {
+        // UI検索結果から持つ：name + cityTown + customerId（末尾）
+        name: String(c.name || '').trim(),
+        cityTown: String(c.cityTown || '').trim(),
+        customerId: String(c.customerId || '').trim(),
+        // section filter (1-5) を保持（絞り込み条件の監査用）
+        section: String(c.section || '').trim()
+      },
+      parts: parts.map(function(p){
+        p = p || {};
+        return {
+          mode: (String(p.mode || 'NEW').toUpperCase() === 'STOCK') ? 'STOCK' : 'NEW', // NEW or STOCK
+          maker: String(p.maker || '').trim(),
+          modelNumber: String(p.modelNumber || '').trim(),
+          quantity: (p.quantity == null || p.quantity === '') ? 1 : Number(p.quantity),
+          aa: String(p.aa || '').trim(), // STOCK選択時に AA+品番 を渡せる
+          note: String(p.note || '').trim()
+        };
+      })
+    };
+  });
+
+  return { ok:true, kind:'UF06_ORDER_NORMALIZED', rows: out };
+}
+
+/** UF06-DELIVER: 納品（対象PART候補のチェック結果を受け取り、正規化して返す） */
+function UF06_DELIVER_normalize(payload) {
+  payload = payload || {};
+  var items = Array.isArray(payload.items) ? payload.items : [];
+  // 1item = { partKey, modelNumber, deliveredAt, checked } を想定（partKeyは実装層で PART_ID 等へ解決）
+  var out = items.map(function(x){
+    x = x || {};
+    return {
+      partKey: String(x.partKey || '').trim(),
+      modelNumber: String(x.modelNumber || '').trim(),
+      checked: !!x.checked,
+      deliveredAt: String(x.deliveredAt || '').trim(), // UI側で日時確定（空は拒否扱いはOrchestrator）
+      note: String(x.note || '').trim()
+    };
+  });
+
+  return { ok:true, kind:'UF06_DELIVER_NORMALIZED', items: out };
+}
+
+/** HtmlService: 発注フォーム（最低限の雛形） */
+function UF06_UI_order() {
+  return HtmlService.createTemplateFromFile('ui/uf06_order').evaluate().setTitle('UF06 発注');
+}
+
+/** HtmlService: 納品フォーム（最低限の雛形） */
+function UF06_UI_deliver() {
+  return HtmlService.createTemplateFromFile('ui/uf06_deliver').evaluate().setTitle('UF06 納品');
+}
+
+/** HtmlService include helper */
+function include(filename) {
+  return HtmlService.createHtmlOutputFromFile(filename).getContent();
+}

--- a/gas/ui/uf06_deliver.html
+++ b/gas/ui/uf06_deliver.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>UF06 納品</title>
+    <style>
+      body { font-family: system-ui, -apple-system, Segoe UI, sans-serif; margin: 16px; }
+      label { display:block; font-size: 12px; margin-top: 8px; }
+      input, textarea { width: 100%; padding: 8px; box-sizing: border-box; }
+      button { padding: 10px 14px; }
+      .muted { color:#666; font-size: 12px; }
+    </style>
+  </head>
+  <body>
+    <h1>UF06 納品（雛形）</h1>
+    <p class="muted">この画面は雛形。実運用の「発注日時順一覧」「チェック一括」は次のPRで拡張。</p>
+
+    <label>partKey（実装層で PART_ID 等へ解決）</label><input id="partKey">
+    <label>品番</label><input id="modelNumber">
+    <label>納品日時（文字列で可）</label><input id="deliveredAt">
+    <label>チェック</label><input id="checked" type="checkbox">
+    <label>メモ</label><textarea id="note"></textarea>
+
+    <button onclick="submitOne()">送信（1件）</button>
+    <pre id="out"></pre>
+
+    <script>
+      function payload() {
+        return {
+          items: [{
+            partKey: document.getElementById('partKey').value,
+            modelNumber: document.getElementById('modelNumber').value,
+            deliveredAt: document.getElementById('deliveredAt').value,
+            checked: document.getElementById('checked').checked,
+            note: document.getElementById('note').value
+          }]
+        };
+      }
+      function submitOne() {
+        google.script.run
+          .withSuccessHandler(function(res){ document.getElementById('out').textContent = JSON.stringify(res, null, 2); })
+          .withFailureHandler(function(err){ document.getElementById('out').textContent = String(err); })
+          .UF06_DELIVER_normalize(payload());
+      }
+    </script>
+  </body>
+</html>

--- a/gas/ui/uf06_order.html
+++ b/gas/ui/uf06_order.html
@@ -1,0 +1,84 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>UF06 発注</title>
+    <style>
+      body { font-family: system-ui, -apple-system, Segoe UI, sans-serif; margin: 16px; }
+      .row { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; padding: 12px 0; border-bottom: 1px solid #ddd; }
+      .box { border-left: 2px solid #222; padding-left: 12px; }
+      label { display:block; font-size: 12px; margin-top: 8px; }
+      input, textarea, select { width: 100%; padding: 8px; box-sizing: border-box; }
+      .muted { color:#666; font-size: 12px; }
+      button { padding: 10px 14px; }
+    </style>
+  </head>
+  <body>
+    <h1>UF06 発注（雛形）</h1>
+    <p class="muted">この画面は雛形。実運用の検索UI/行自動追加/辞書サジェストは次のPRで拡張。</p>
+
+    <div class="row">
+      <div class="box">
+        <h3>顧客（左）</h3>
+        <label>顧客名</label><input id="c_name">
+        <label>市区町村</label><input id="c_city">
+        <label>顧客ID（末尾）</label><input id="c_id">
+        <label>セクション（①〜⑤）</label>
+        <select id="c_section">
+          <option value="">未指定</option>
+          <option value="1">①受注</option>
+          <option value="2">②見積→連絡待ち</option>
+          <option value="3">③発注済→納品待ち</option>
+          <option value="4">④納品待→日時調整待ち</option>
+          <option value="5">⑤日時確定→作業待ち</option>
+        </select>
+      </div>
+      <div class="box">
+        <h3>部品（右：1個）</h3>
+        <label>モード</label>
+        <select id="p_mode">
+          <option value="NEW">新規発注</option>
+          <option value="STOCK">在庫</option>
+        </select>
+        <label>メーカー</label><input id="p_maker">
+        <label>品番</label><input id="p_model">
+        <label>数量</label><input id="p_qty" type="number" value="1">
+        <label>AA（在庫時）</label><input id="p_aa">
+        <label>メモ</label><textarea id="p_note"></textarea>
+      </div>
+    </div>
+
+    <button onclick="submitOne()">送信（1行）</button>
+    <pre id="out"></pre>
+
+    <script>
+      function payload() {
+        return {
+          rows: [{
+            customer: {
+              name: document.getElementById('c_name').value,
+              cityTown: document.getElementById('c_city').value,
+              customerId: document.getElementById('c_id').value,
+              section: document.getElementById('c_section').value
+            },
+            parts: [{
+              mode: document.getElementById('p_mode').value,
+              maker: document.getElementById('p_maker').value,
+              modelNumber: document.getElementById('p_model').value,
+              quantity: document.getElementById('p_qty').value,
+              aa: document.getElementById('p_aa').value,
+              note: document.getElementById('p_note').value
+            }]
+          }]
+        };
+      }
+      function submitOne() {
+        google.script.run
+          .withSuccessHandler(function(res){ document.getElementById('out').textContent = JSON.stringify(res, null, 2); })
+          .withFailureHandler(function(err){ document.getElementById('out').textContent = String(err); })
+          .UF06_ORDER_normalize(payload());
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
What:
- Add new GAS modules under gas/uf06:
  - UF06 normalize entrypoints (ORDER / DELIVER)
  - Parts_Dict normalize/search helpers (design → implementation entry)
  - Task title projector (AA<=5 else x/y; preserves '_ ' free slot)
- Add minimal HtmlService templates under gas/ui (skeleton only)
- New files only (no edits to existing files)

Spec refs:
- platform/MEP/03_BUSINESS/よりそい堂/ui_spec.md (UF06 UI spec markers)
- platform/MEP/03_BUSINESS/よりそい堂/business_master.md (Parts_Dict design markers)

Safety:
- No conflict markers (<<<<<<< / >>>>>>>)
- No overwrite of existing files