### PR TITLE
UF06: wire UI to UF06_QUEUE (submitToQueue wrappers, Phase-1)

### DIFF
--- a/gas/uf06/uf06_app.gs
+++ b/gas/uf06/uf06_app.gs
@@ -76,3 +76,19 @@ function UF06_UI_deliver() {
 function include(filename) {
   return HtmlService.createHtmlOutputFromFile(filename).getContent();
 }
+
+/* UF06_UI_TO_QUEUE_BEGIN */
+/**
+ * UI → Queue 連携（Phase-1）
+ * - UI は normalize ではなく submitToQueue を呼ぶ（受付キューへ登録）。
+ * - 確定（Parts_Master等への反映）は Orchestrator が実行する。
+ */
+function UF06_ORDER_submitToQueue(payload) {
+  var normalized = UF06_ORDER_normalize(payload);
+  return UF06_QUEUE_submit_ORDER(normalized);
+}
+function UF06_DELIVER_submitToQueue(payload) {
+  var normalized = UF06_DELIVER_normalize(payload);
+  return UF06_QUEUE_submit_DELIVER(normalized);
+}
+/* UF06_UI_TO_QUEUE_END */

--- a/gas/ui/uf06_deliver.html
+++ b/gas/ui/uf06_deliver.html
@@ -41,7 +41,7 @@
         google.script.run
           .withSuccessHandler(function(res){ document.getElementById('out').textContent = JSON.stringify(res, null, 2); })
           .withFailureHandler(function(err){ document.getElementById('out').textContent = String(err); })
-          .UF06_DELIVER_normalize(payload());
+          .UF06_DELIVER_submitToQueue(payload());
       }
     </script>
   </body>

--- a/gas/ui/uf06_order.html
+++ b/gas/ui/uf06_order.html
@@ -77,7 +77,7 @@
         google.script.run
           .withSuccessHandler(function(res){ document.getElementById('out').textContent = JSON.stringify(res, null, 2); })
           .withFailureHandler(function(err){ document.getElementById('out').textContent = String(err); })
-          .UF06_ORDER_normalize(payload());
+          .UF06_ORDER_submitToQueue(payload());
       }
     </script>
   </body>


### PR DESCRIPTION
What:
- Add server wrappers in gas/uf06/uf06_app.gs:
  - UF06_ORDER_submitToQueue(payload) -> normalize -> UF06_QUEUE_submit_ORDER
  - UF06_DELIVER_submitToQueue(payload) -> normalize -> UF06_QUEUE_submit_DELIVER
- Update UI templates to call submitToQueue (queue ingestion) instead of normalize-only

Safety:
- Minimal edits (no conflict markers)
- Queue remains the only ledger touchpoint; no Parts_Master direct write