### PR TITLE
FIXATE: Implement acceptance-tests gate + single artifact format

### DIFF
--- a/.github/workflows/acceptance_tests.yml
+++ b/.github/workflows/acceptance_tests.yml
@@ -1,0 +1,16 @@
+name: acceptance-tests
+
+on:
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+jobs:
+  acceptance:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Acceptance Tests
+        shell: pwsh
+        run: |
+          pwsh -NoProfile -File tools/acceptance_tests.ps1 -ArtifactPath mep/MEP_ARTIFACT.md

--- a/mep/ACCEPTANCE_TESTS_SPEC.md
+++ b/mep/ACCEPTANCE_TESTS_SPEC.md
@@ -1,0 +1,59 @@
+ArtifactKind: SPEC_UPDATE
+StatusTag: Adopted
+Scope:
+  - ACCEPTANCE_TESTS
+Evidence:
+  - BUNDLE_VERSION: v0.0.0+20260110_030257+main_31f4b1a
+Changes:
+  - Defines machine-enforced acceptance tests at the ingestion boundary.
+  - FAIL-fast, reason-coded, and "NG = discard (no PR)" contract.
+Unfinalized:
+  - None
+Risks:
+  - If the artifact file drifts from the Single Artifact format, the gate will block merges.
+Next:
+  - Keep expanding checks only via Adopted changes (PR->main->Bundled).
+
+# ACCEPTANCE_TESTS / SPEC (Adopted)
+
+## Purpose
+Prevent contamination by enforcing that "truth" is only Git evidence (PR -> main -> Bundled). UI is thinking-only.
+
+## Input
+A single text artifact that conforms to SINGLE ARTIFACT FORMAT (v1).
+
+## Output
+PASS or FAIL with a stable reason code (ATxxxx). FAIL means discard (do not create PR / do not merge).
+
+## Check Order (fail-fast)
+A. Format integrity
+- Required headers exist; no duplicates.
+- StatusTag exists and is one of:
+  Draft | Adopted | PR Open | Merged to main | Bundled | Completed Gate | DIRTY
+- Evidence includes BUNDLE_VERSION.
+
+B. Boundary audit (reserved)
+- If BEGIN/END boundaries are used in the artifact, both must exist and must not be duplicated.
+
+C. Draft contamination block
+- If StatusTag is Draft:
+  - Unfinalized must exist and must not be "None".
+  - Must not contain definitive claims such as "確定", "採用済み", "反映済み".
+
+D. Evidence convergence
+- Must not claim any non-bundle source of truth.
+- StatusTag Bundled requires BUNDLE_VERSION (already required).
+
+E. DIRTY stop
+- StatusTag DIRTY always FAIL.
+- Conflict markers (<<<<<<< or >>>>>>>) always FAIL.
+
+## Reason Codes (examples)
+AT1001 Missing required header
+AT1002 Duplicate header
+AT1003 Missing/invalid StatusTag
+AT1101 Missing BUNDLE_VERSION
+AT1201 Boundary BEGIN/END missing or duplicated
+AT1301 Draft contains definitive claim or missing Unfinalized
+AT1401 Non-bundle source of truth referenced
+AT1501 DIRTY or conflict markers detected

--- a/mep/MEP_ARTIFACT.md
+++ b/mep/MEP_ARTIFACT.md
@@ -1,0 +1,16 @@
+ArtifactKind: MEP_DECISION
+StatusTag: Adopted
+Scope:
+  - ACCEPTANCE_TESTS
+  - SINGLE_ARTIFACT_FORMAT
+Evidence:
+  - BUNDLE_VERSION: v0.0.0+20260110_030257+main_31f4b1a
+Changes:
+  - Implemented Acceptance Tests gate (local + CI).
+  - Fixed the Single Artifact format as the only accepted artifact.
+Unfinalized:
+  - None
+Risks:
+  - None
+Next:
+  - Implement boundary-audit expansion rules if/when diff-based artifacts are introduced.

--- a/mep/SINGLE_ARTIFACT_FORMAT.md
+++ b/mep/SINGLE_ARTIFACT_FORMAT.md
@@ -1,0 +1,40 @@
+ArtifactKind: SPEC_UPDATE
+StatusTag: Adopted
+Scope:
+  - SINGLE_ARTIFACT_FORMAT
+Evidence:
+  - BUNDLE_VERSION: v0.0.0+20260110_030257+main_31f4b1a
+Changes:
+  - Fixes the Single Artifact v1 headers and constraints as the only accepted artifact format.
+Unfinalized:
+  - None
+Risks:
+  - Any alternative artifact formats must be rejected by acceptance gate by design.
+Next:
+  - If new fields are needed, evolve v1 via PR->main->Bundled and update acceptance gate in lockstep.
+
+# SINGLE ARTIFACT FORMAT (v1) — Adopted
+
+## Required headers (order fixed, no duplicates)
+- ArtifactKind:
+- StatusTag:
+- Scope:
+- Evidence:
+- Changes:
+- Unfinalized:
+- Risks:
+- Next:
+
+## StatusTag allowed values
+Draft | Adopted | PR Open | Merged to main | Bundled | Completed Gate | DIRTY
+
+## Draft constraints
+- Must have Unfinalized that is not "None".
+- Must not contain definitive claims (確定 / 採用済み / 反映済み).
+
+## Evidence constraints
+- Must include: BUNDLE_VERSION: <value>
+- Optional: PR: <number> / commit: <sha>
+
+## DIRTY constraints
+- DIRTY is a hard stop: never accepted.

--- a/tools/acceptance_tests.ps1
+++ b/tools/acceptance_tests.ps1
@@ -1,0 +1,81 @@
+param(
+  [Parameter(Mandatory=$false)][string]$ArtifactPath = "mep/MEP_ARTIFACT.md"
+)
+
+$ErrorActionPreference = 'Stop'
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+
+function Fail([string]$code, [string]$msg) {
+  Write-Host ("{0}: {1}" -f $code, $msg)
+  exit 2
+}
+
+function Read-Text([string]$p) {
+  if (-not (Test-Path $p)) { Fail "AT1000" ("Artifact file not found: {0}" -f $p) }
+  return Get-Content -Raw -Encoding UTF8 $p
+}
+
+$txt = Read-Text $ArtifactPath
+
+# E: DIRTY stop + conflict markers
+if ($txt -match '<<<<<<<|>>>>>>>') { Fail "AT1501" "Conflict markers detected." }
+
+# Parse required headers (top-level keys)
+$required = @("ArtifactKind","StatusTag","Scope","Evidence","Changes","Unfinalized","Risks","Next")
+
+$matches = [regex]::Matches(
+  $txt,
+  '^(ArtifactKind|StatusTag|Scope|Evidence|Changes|Unfinalized|Risks|Next):\s*(.*)$',
+  [Text.RegularExpressions.RegexOptions]::Multiline
+)
+
+$map = @{}
+foreach ($m in $matches) {
+  $k = $m.Groups[1].Value
+  if ($map.ContainsKey($k)) { Fail "AT1002" ("Duplicate header: {0}" -f $k) }
+  $map[$k] = $m.Groups[2].Value.Trim()
+}
+
+foreach ($k in $required) {
+  if (-not $map.ContainsKey($k)) { Fail "AT1001" ("Missing required header: {0}" -f $k) }
+}
+
+$StatusTag = $map["StatusTag"]
+$allowed = @("Draft","Adopted","PR Open","Merged to main","Bundled","Completed Gate","DIRTY")
+if ($allowed -notcontains $StatusTag) { Fail "AT1003" ("Invalid StatusTag: {0}" -f $StatusTag) }
+if ($StatusTag -eq "DIRTY") { Fail "AT1501" "StatusTag DIRTY is a hard stop." }
+
+# Evidence: scan Evidence section lines until next top-level header
+$lines = $txt -split "`r?`n"
+$idx = -1
+for ($i=0; $i -lt $lines.Length; $i++) { if ($lines[$i] -match '^Evidence:\s*$') { $idx = $i; break } }
+if ($idx -lt 0) { Fail "AT1101" "Evidence section not found." }
+
+$bvFound = $false
+for ($j=$idx+1; $j -lt $lines.Length; $j++) {
+  if ($lines[$j] -match '^(ArtifactKind|StatusTag|Scope|Evidence|Changes|Unfinalized|Risks|Next):\s*') { break }
+  if ($lines[$j] -match 'BUNDLE_VERSION:\s*v\d+\.\d+\.\d+\+\d{8}_\d{6}\+main_[0-9a-f]{7,40}') { $bvFound = $true; break }
+}
+if (-not $bvFound) { Fail "AT1101" "Missing BUNDLE_VERSION in Evidence." }
+
+# C: Draft contamination block
+if ($StatusTag -eq "Draft") {
+  $unfHeader = $map["Unfinalized"]
+  if ($unfHeader -eq "None") { Fail "AT1301" "Draft requires Unfinalized != None." }
+  if ($txt -match '確定|採用済み|反映済み') { Fail "AT1301" "Draft contains definitive claims." }
+}
+
+# D: Evidence convergence guard (simple)
+if ($txt -match 'source of truth|唯一の正' -and $txt -notmatch 'BUNDLE') {
+  Fail "AT1401" "Non-bundle source-of-truth referenced."
+}
+
+# B: Boundary audit (reserved) — enforce BEGIN/END pairing if used
+$beginCount = ([regex]::Matches($txt, '^\s*BEGIN\b', [Text.RegularExpressions.RegexOptions]::Multiline)).Count
+$endCount   = ([regex]::Matches($txt, '^\s*END\b',   [Text.RegularExpressions.RegexOptions]::Multiline)).Count
+if (($beginCount -gt 0) -or ($endCount -gt 0)) {
+  if ($beginCount -ne 1 -or $endCount -ne 1) { Fail "AT1201" "BEGIN/END boundary missing or duplicated." }
+}
+
+Write-Host "PASS"
+exit 0


### PR DESCRIPTION
Implements ingestion-boundary contamination prevention via:
- Adopted ACCEPTANCE_TESTS / SPEC
- Adopted SINGLE ARTIFACT FORMAT (v1)
- Canonical artifact: mep/MEP_ARTIFACT.md
- Local + CI acceptance gate (tools/acceptance_tests.ps1, .github/workflows/acceptance_tests.yml)

Contract:
- FAIL-fast with stable AT codes
- NG = discard (no merge); DIRTY is hard stop