### PR TITLE
chore(mep): sync Evidence BUNDLE_VERSION (v0.0.0+20260110_040155+main_f01f16b)

### DIFF
--- a/mep/ACCEPTANCE_TESTS_SPEC.md
+++ b/mep/ACCEPTANCE_TESTS_SPEC.md
@@ -3,7 +3,7 @@ StatusTag: Adopted
 Scope:
   - ACCEPTANCE_TESTS
 Evidence:
-  - BUNDLE_VERSION: v0.0.0+20260110_030257+main_31f4b1a
+  - BUNDLE_VERSION: v0.0.0+20260110_040155+main_f01f16b
 Changes:
   - Defines machine-enforced acceptance tests at the ingestion boundary.
   - FAIL-fast, reason-coded, and "NG = discard (no PR)" contract.

--- a/mep/SINGLE_ARTIFACT_FORMAT.md
+++ b/mep/SINGLE_ARTIFACT_FORMAT.md
@@ -3,7 +3,7 @@ StatusTag: Adopted
 Scope:
   - SINGLE_ARTIFACT_FORMAT
 Evidence:
-  - BUNDLE_VERSION: v0.0.0+20260110_030257+main_31f4b1a
+  - BUNDLE_VERSION: v0.0.0+20260110_040155+main_f01f16b
 Changes:
   - Fixes the Single Artifact v1 headers and constraints as the only accepted artifact format.
 Unfinalized:


### PR DESCRIPTION
Purpose
- Align Evidence headers in mep/*.md with Bundled BUNDLE_VERSION (single source of truth).

Change
- Update Evidence: BUNDLE_VERSION in:
  - mep/SINGLE_ARTIFACT_FORMAT.md
  - mep/ACCEPTANCE_TESTS_SPEC.md

Verification
- Local: tools/acceptance_tests.ps1 -ArtifactPath mep/MEP_ARTIFACT.md => PASS

Notes
- No PR/merge claims included; only Bundled-derived BUNDLE_VERSION sync.