### PR TITLE
UX屋上: mep_auto_pr_gate_dispatch に workflow_dispatch を追加（422解消）

### DIFF
--- a/.github/workflows/mep_auto_pr_gate_dispatch.yml
+++ b/.github/workflows/mep_auto_pr_gate_dispatch.yml
@@ -2,6 +2,7 @@ name: MEP Auto PR + Gate (GitHub-only)
 
 on:
   workflow_dispatch:
+  workflow_dispatch:
     inputs:
       artifact_title:
         description: "Artifact title (short)"


### PR DESCRIPTION
main の .github/workflows/mep_auto_pr_gate_dispatch.yml に workflow_dispatch を追加して HTTP 422（dispatch不可）を解消する。