### PR TITLE
UX屋上: workflow_dispatch を確定有効化（HTTP 422 解消）

### DIFF
--- a/.github/workflows/mep_auto_pr_gate_dispatch.yml
+++ b/.github/workflows/mep_auto_pr_gate_dispatch.yml
@@ -2,7 +2,6 @@ name: MEP Auto PR + Gate (GitHub-only)
 
 on:
   workflow_dispatch:
-  workflow_dispatch:
     inputs:
       artifact_title:
         description: "Artifact title (short)"
@@ -63,10 +62,12 @@ jobs:
             echo ""
           } > "$ART_IN"
 
+          # conflict痕跡
           if grep -nE '^(<{7}|={7}|>{7})' "$ART_IN" >/dev/null 2>&1; then
             echo "NG: conflict markers detected" >&2
             exit 2
           fi
+          # 曖昧採用語（最小）
           if grep -nF 'ここまで全部採用' "$ART_IN" >/dev/null 2>&1; then
             echo "NG: ambiguous bulk-adoption phrase detected" >&2
             exit 3
@@ -87,6 +88,7 @@ jobs:
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
 
           git checkout -b "$BRANCH"
+
           mkdir -p .mep/artifacts
           ART_PATH=".mep/artifacts/artifact_${TS}.md"
           cp "${{ steps.preflight.outputs.artifact_in }}" "$ART_PATH"


### PR DESCRIPTION
対象 workflow:
- id: 219927397
- path: .github/workflows/mep_auto_pr_gate_dispatch.yml

目的:
- workflow_dispatch が無く dispatch API が HTTP 422 になる問題を解消
- 入口（workflow_dispatch）から artifact入力→PR作成→Gate→OKなら自動マージまでの最小成立