### PR TITLE
UX屋上: FULLAUTO入口の 'on' をクォートして 422 を回避

### DIFF
--- a/.github/workflows/dispatch_smoke.yml
+++ b/.github/workflows/dispatch_smoke.yml
@@ -1,6 +1,6 @@
 name: UX Rooftop Entry (FULLAUTO)
 
-on:
+'on':
   workflow_dispatch:
     inputs:
       artifact_title:


### PR DESCRIPTION
dispatch_smoke.yml の FULLAUTO 入口で 422 が出るため、'on' をクォートして GitHub 側の解釈崩れを回避する。