### PR TITLE
UX屋上: v2 の 'on' クォートを撤去（workflow_dispatch 422 解消）

### DIFF
--- a/.github/workflows/ux_rooftop_full_auto_dispatch_v2.yml
+++ b/.github/workflows/ux_rooftop_full_auto_dispatch_v2.yml
@@ -1,6 +1,6 @@
 name: UX Rooftop Full Auto Dispatch v2
 
-'on':
+on:
   workflow_dispatch:
     inputs:
       artifact_title:


### PR DESCRIPTION
GitHub Actions はトップレベルキー 'on' を厳密に要求するため、'on': を on: に戻して workflow_dispatch を認識させる。