### PR TITLE
Make auto-merge default for UX Rooftop FULLAUTO entry (merge_if_ok optional)

### DIFF
--- a/.github/workflows/dispatch_smoke.yml
+++ b/.github/workflows/dispatch_smoke.yml
@@ -14,7 +14,7 @@ on:
         required: true
       merge_if_ok:
         description: "Merge automatically if gate OK (true/false)"
-        required: true
+        required: false
         default: "true"
 
 permissions:

--- a/.github/workflows/ux_rooftop_full_auto_dispatch.yml
+++ b/.github/workflows/ux_rooftop_full_auto_dispatch.yml
@@ -14,7 +14,7 @@ on:
         required: true
       merge_if_ok:
         description: "Merge automatically if gate OK (true/false)"
-        required: true
+        required: false
         default: "true"
 
 permissions:

--- a/.github/workflows/ux_rooftop_full_auto_dispatch_v2.yml
+++ b/.github/workflows/ux_rooftop_full_auto_dispatch_v2.yml
@@ -14,7 +14,7 @@ on:
         required: true
       merge_if_ok:
         description: "Merge automatically if gate OK (true/false)"
-        required: true
+        required: false
         default: "true"
 
 permissions:


### PR DESCRIPTION
Purpose:
- Make workflow_dispatch input merge_if_ok optional with default "true".
- This enables FULLAUTO to proceed to auto-merge without requiring the caller to provide merge_if_ok.

Files:
- .github/workflows/dispatch_smoke.yml
- .github/workflows/ux_rooftop_full_auto_dispatch.yml
- .github/workflows/ux_rooftop_full_auto_dispatch_v2.yml