### PR TITLE
Gate3: update BUNDLE_VERSION to match main HEAD

### DIFF
--- a/docs/MEP/MEP_BUNDLE.md
+++ b/docs/MEP/MEP_BUNDLE.md
@@ -1,4 +1,4 @@
-BUNDLE_VERSION = v0.0.0+20260110_040155+main_f01f16b
+BUNDLE_VERSION = v0.0.0+20260112_181011+main_ceaad6b
 # MEP_BUNDLE
 SOURCE_CONTEXT: 本ファイルは「MEPの唯一の正（main反映）」を前提に、次チャット開始時の再現性を最大化するための束ね（生成物）である。手編集は原則禁止。更新はゲートを経た反映（PR→main→Bundled）で行う。
 


### PR DESCRIPTION
Scope: docs/MEP/MEP_BUNDLE.md
Purpose: Align BUNDLE_VERSION evidence with current main HEAD after Gate3 Fix merges.
Note: tools/mep_writeback_bundle.ps1 currently fails to detect BUNDLE_VERSION; this PR updates the line directly.