### PR TITLE
Gate5: Issue-01 vocabulary/evidence rule (RULESET) + STATE_CURRENT downgrade near evidence:TBD

### DIFF
--- a/docs/MEP/RULESET.md
+++ b/docs/MEP/RULESET.md
@@ -57,3 +57,27 @@
 <!-- ONE_BUSINESS_ONE_REPO_END -->
 
 
+
+## Issue-01: STATE_CURRENT 語彙と証跡 整合ルール
+
+### 目的
+STATE_CURRENT.md における「強い事実表現（verified/fixed/resolved/confirmed/established 等）」が、
+FIXATION_PROTOCOL の「証跡必須（PR→main→BUNDLE_VERSION）」と同居したときに、
+証跡なしの断定が「確定扱い」に見える誤読リスクを除去する。
+
+### ルール
+- R1: STATE_CURRENT の語彙は 3区分（FIXED / OBSERVED / PLAN）で運用する。
+  - FIXED（確定語彙）: 確定 / Merged / Bundled / BUNDLE_VERSION など、FIXATION_PROTOCOL の成立条件を満たす事実にのみ使用可。
+  - OBSERVED（検証語彙）: observed / checked / tested 等、観測・実行結果を表す。確定ではない。
+  - PLAN（計画語彙）: TBD / NEXT 等、未実施・未決を表す。
+- R2: verified / fixed / resolved / confirmed / established は FIXED（確定語彙）として扱う。
+  - これらを STATE_CURRENT に置く場合、同一行または直近行に PR#/commit/BUNDLE_VERSION の証跡を併記すること。
+  - 証跡が無い場合、上記語彙は禁止し、OBSERVED へ置換する（非確定を明示すること）。
+- R3: 「evidence:TBD; PR/commit/BUNDLE not recorded here」近傍（±5行）に R2 語彙を混在させない。
+  - 混在が必要な場合は R2 語彙を OBSERVED へ置換し、「not FIXED（非確定）」を明示する。
+
+### 受入条件（機械的チェック観点）
+- STATE_CURRENT.md 内に verified|fixed|resolved|confirmed|established が存在する場合、
+  同一行または直近行に PR # / commit / BUNDLE_VERSION が存在すること。
+- evidence:TBD; PR/commit/BUNDLE not recorded here の近傍（±5行）に R2 語彙が存在しないこと。
+

--- a/docs/MEP/STATE_CURRENT.md
+++ b/docs/MEP/STATE_CURRENT.md
@@ -14,11 +14,11 @@
 - UTF-8/LF stabilization: enabled (.gitattributes/.editorconfig)
 
 ## Current objective
-- 2026-01-06: (OPS) clasp fixed-URL redeploy loop established (RUNBOOK CARD-08: GAS Fixed-URL Redeploy (clasp fast loop)): scriptId=1wpUF60VBRASNKuFOx1hLXK2bGQ74qL7YwU4Eq_wnd9eEAApHp9F4okxc deploymentId=AKfycbxdJqepEVK_q0y3JI_8pdHQJPjDJzzCNNU-jJGy41Vdh-R55gblEcscBxJgKA1ekRdzaw exec=https://script.google.com/macros/s/AKfycbxdJqepEVK_q0y3JI_8pdHQJPjDJzzCNNU-jJGy41Vdh-R55gblEcscBxJgKA1ekRdzaw/exec
+- 2026-01-06: (OPS) clasp observed-URL redeploy loop observed (RUNBOOK CARD-08: GAS observed-URL Redeploy (clasp fast loop)): scriptId=1wpUF60VBRASNKuFOx1hLXK2bGQ74qL7YwU4Eq_wnd9eEAApHp9F4okxc deploymentId=AKfycbxdJqepEVK_q0y3JI_8pdHQJPjDJzzCNNU-jJGy41Vdh-R55gblEcscBxJgKA1ekRdzaw exec=https://script.google.com/macros/s/AKfycbxdJqepEVK_q0y3JI_8pdHQJPjDJzzCNNU-jJGy41Vdh-R55gblEcscBxJgKA1ekRdzaw/exec (not FIXED; evidence not recorded here)
 - 2026-01-06: (OPS) B23: RUNBOOK CARD-07 fixes operational procedure for request.normalize_status_columns (status/requestStatus) using B22 endpoint (evidence: TBD; PR/commit/BUNDLE not recorded here): https://script.google.com/macros/s/AKfycbxdJqepEVK_q0y3JI_8pdHQJPjDJzzCNNU-jJGy41Vdh-R55gblEcscBxJgKA1ekRdzaw/exec
 - 2026-01-06: (NEXT) B24: TBD (define next theme)
 - 2026-01-06: (GAS) WRITE endpoint is B22 (B21 + tool: request.normalize_status_columns for status/requestStatus normalization): https://script.google.com/macros/s/AKfycbxdJqepEVK_q0y3JI_8pdHQJPjDJzzCNNU-jJGy41Vdh-R55gblEcscBxJgKA1ekRdzaw/exec
-- 2026-01-06: (GAS) B22 verified: normalize_status_columns exists and runs (dryRun + write), then request.get returns effectiveStatus on https://script.google.com/macros/s/AKfycbxdJqepEVK_q0y3JI_8pdHQJPjDJzzCNNU-jJGy41Vdh-R55gblEcscBxJgKA1ekRdzaw/exec
+- 2026-01-06: (GAS) B22 observed: normalize_status_columns exists and runs (dryRun + write), then request.get returns effectiveStatus on https://script.google.com/macros/s/AKfycbxdJqepEVK_q0y3JI_8pdHQJPjDJzzCNNU-jJGy41Vdh-R55gblEcscBxJgKA1ekRdzaw/exec (not FIXED; evidence not recorded here)
 - 2026-01-06: (NEXT) B23: TBD (define next theme)
 - 2026-01-06: (PR #576) master_spec: ledger reflection — add event→ledger mapping for delete/FREEZE/FIX
 - 2026-01-06: (GAS) B21 verified: status and requestStatus kept in sync (OPEN/RESOLVED/CANCELLED); list_status works; resolve-after-cancel rejected on https://script.google.com/macros/s/AKfycbw2moBfgg13VaxGPNQDj-2vGzai5GZXHGpZP4bkNib3h12mVsldCCkwAfEvVAgbCs2-3Q/exec
@@ -64,4 +64,6 @@ Tell the assistant:
 - 日時: 20260108_060248
 - 内容: ビジネス仕様（business/*）と seed（seed/*）を唯一の正として運用開始。以後の変更はPRで反映。
 - 承認: 0
+
+
 


### PR DESCRIPTION
Gate 5 / Issue-01

- RULESET.md: append "STATE_CURRENT vocabulary vs evidence" rule (FIXED/OBSERVED/PLAN; strong words require PR/commit/BUNDLE_VERSION).
- STATE_CURRENT.md: in ±5 lines of "evidence:TBD; PR/commit/BUNDLE not recorded here", downgrade strong fact words to OBSERVED + add "not FIXED" disclaimer when evidence is absent.

No other files touched.