### PR TITLE
Gate X: set GH_TOKEN for dispatch_smoke gh steps

### DIFF
--- a/.github/workflows/dispatch_smoke.yml
+++ b/.github/workflows/dispatch_smoke.yml
@@ -53,6 +53,7 @@ jobs:
       - name: Create PR (Gate X)
         shell: bash
         env:
+          GH_TOKEN: ${{ github.token }}
           INPUT_BIZ_KEY: ${{ github.event.inputs.biz_key }}
           INPUT_PR_BODY: ${{ github.event.inputs.pr_body }}
         run: |
@@ -82,6 +83,7 @@ jobs:
         if: ${{ github.event.inputs.merge_if_ok == 'true' }}
         shell: bash
         env:
+          GH_TOKEN: ${{ github.token }}
           INPUT_BIZ_KEY: ${{ github.event.inputs.biz_key }}
         run: |
           set -euo pipefail
@@ -92,4 +94,3 @@ jobs:
             exit 0
           fi
           gh pr merge --auto --squash "${PR_URL}"
-


### PR DESCRIPTION
Gate X:
- Fix smoke run failure: gh CLI needs GH_TOKEN in Actions
- Add env GH_TOKEN: ${{ github.token }} to Create PR / Enable auto-merge steps only