### PR TITLE
Gate X: make smoke run always create PR diff

### DIFF
--- a/.github/workflows/dispatch_smoke.yml
+++ b/.github/workflows/dispatch_smoke.yml
@@ -61,7 +61,9 @@ jobs:
           BIZ="${INPUT_BIZ_KEY:-yorisoidou}"
           BODY="${INPUT_PR_BODY}"
           if [ -z "${BODY}" ]; then BODY="Gate X: FULLAUTO PR"; fi
-
+# Gate X smoke evidence (force diff to allow PR)
+mkdir -p .github
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) run_id=${GITHUB_RUN_ID} biz=${BIZ}" >> .github/gate_x_smoke.log
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 


### PR DESCRIPTION
Gate X:
- Smoke run was success but produced no PR due to "No changes; nothing to PR."
- Add minimal evidence write (.github/gate_x_smoke.log) to force a diff for PR creation
- No design changes beyond enabling PR creation