### PR TITLE
Gate X: restore dispatch_smoke.yml to last known-good (fix 422/workflow file issue)

### DIFF
--- a/.github/workflows/dispatch_smoke.yml
+++ b/.github/workflows/dispatch_smoke.yml
@@ -61,9 +61,7 @@ jobs:
           BIZ="${INPUT_BIZ_KEY:-yorisoidou}"
           BODY="${INPUT_PR_BODY}"
           if [ -z "${BODY}" ]; then BODY="Gate X: FULLAUTO PR"; fi
-# Gate X smoke evidence (force diff to allow PR)
-mkdir -p .github
-printf "%s run_id=%s biz=%s\n" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${GITHUB_RUN_ID}" "${BIZ}" >> .github/gate_x_smoke.log
+
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 


### PR DESCRIPTION
Gate X:
- workflow_dispatch returns HTTP 422 and push runs say "workflow file issue" (workflow invalid/disabled)
- Restore .github/workflows/dispatch_smoke.yml EXACTLY from a known-good commit (taken from a successful workflow_dispatch run headSha)
- No additional edits in this PR (restore-only) to re-enable workflow first