### PR TITLE
Gate5: BUNDLE_VERSION bump to main_3932455

### DIFF
--- a/docs/MEP/MEP_BUNDLE.md
+++ b/docs/MEP/MEP_BUNDLE.md
@@ -1,4 +1,4 @@
-BUNDLE_VERSION=v0.0.0+20260113_225654+main_55f1d3e
+BUNDLE_VERSION = v0.0.0+20260114_004831+main_3932455
 # MEP_BUNDLE
 SOURCE_CONTEXT: 本ファイルは「MEPの唯一の正（main反映）」を前提に、次チャット開始時の再現性を最大化するための束ね（生成物）である。手編集は原則禁止。更新はゲートを経た反映（PR→main→Bundled）で行う。
 


### PR DESCRIPTION
Evidence:
- main HEAD: 3932455
- BUNDLE_VERSION: v0.0.0+20260113_225654+main_55f1d3e -> v0.0.0+20260114_004831+main_3932455

Gate X evidence (runs):
- success run:20962531400
- success run:20962643801
- success run:20962786648
- success run:20961995065

Gate X PRs:
- #794 #795 #796 #797 #798 #799 (all merged)