### PR TITLE
Gate5: BUNDLE_VERSION bump to main_fa31bda

### DIFF
--- a/docs/MEP/MEP_BUNDLE.md
+++ b/docs/MEP/MEP_BUNDLE.md
@@ -1,4 +1,4 @@
-BUNDLE_VERSION = v0.0.0+20260114_004831+main_3932455
+BUNDLE_VERSION = v0.0.0+20260114_005937+main_fa31bda
 # MEP_BUNDLE
 SOURCE_CONTEXT: 本ファイルは「MEPの唯一の正（main反映）」を前提に、次チャット開始時の再現性を最大化するための束ね（生成物）である。手編集は原則禁止。更新はゲートを経た反映（PR→main→Bundled）で行う。
 


### PR DESCRIPTION
Evidence:
- main HEAD: fa31bda
- BUNDLE_VERSION: v0.0.0+20260114_004831+main_3932455 -> v0.0.0+20260114_005937+main_fa31bda

Reason:
- PR#800 bumped BUNDLE_VERSION but Chat Packet Guard required PR#801, so main advanced again.
- This PR re-syncs Bundled to the current main.