### PR TITLE
chore(mep): Gate 9 T4 writeback PR input + required evidence guard

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch.yml
@@ -3,7 +3,11 @@ name: MEP Writeback Bundle (Evidence)
 on:
   workflow_dispatch:
 
-permissions:
+    inputs:
+      pr_number:
+        description: 'PR number to write back (optional; 0 = auto latest merged PR)'
+        required: false
+        default: '0'permissions:
   contents: write
   pull-requests: write
 
@@ -19,4 +23,4 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          pwsh -NoProfile -File tools/mep_writeback_bundle.ps1 -Mode pr
+          pwsh -NoProfile -File tools/mep_writeback_bundle.ps1 -Mode pr -PrNumber ${{ inputs.pr_number }}


### PR DESCRIPTION
Gate 9 (T4) minimal patch.

- Add workflow_dispatch input pr_number (0=auto latest merged PR)
- Pass pr_number to tools/mep_writeback_bundle.ps1
- Enforce required evidence fields (mergeCommit missing => non-zero stop)
- Add audit=OK/NG + code into evidence line

Scope:
- .github/workflows/mep_writeback_bundle_dispatch.yml
- tools/mep_writeback_bundle.ps1