### PR TITLE
fix(mep): repair writeback workflow YAML so workflow_dispatch works (422)

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch.yml
@@ -2,12 +2,12 @@ name: MEP Writeback Bundle (Evidence)
 
 on:
   workflow_dispatch:
-
     inputs:
       pr_number:
         description: 'PR number to write back (optional; 0 = auto latest merged PR)'
         required: false
-        default: '0'permissions:
+        default: '0'
+permissions:
   contents: write
   pull-requests: write
 


### PR DESCRIPTION
Gate 9 (T4) — Fix HTTP 422 when dispatching writeback workflow.

Root cause:
- YAML corruption around `workflow_dispatch` / `permissions` caused GitHub to ignore workflow_dispatch.

Fix:
- Rewrite the header to a well-formed:
  on:
    workflow_dispatch:
      inputs: pr_number ...
  permissions:
    ...
Scope:
- .github/workflows/mep_writeback_bundle_dispatch.yml