### PR TITLE
fix(mep): accept BUNDLE_VERSION ':' or '=' in writeback script

### DIFF
--- a/tools/mep_writeback_bundle.ps1
+++ b/tools/mep_writeback_bundle.ps1
@@ -32,7 +32,7 @@ $repo = (Run "gh repo view" { gh repo view --json nameWithOwner -q .nameWithOwne
 if (-not $repo) { Fail "gh repo view failed to resolve nameWithOwner" }
 
 $bundle = ReadUtf8 $BundlePath
-$mx = [regex]::Match($bundle, 'BUNDLE_VERSION:\s*([^\s]+)')
+$mx = [regex]::Match($bundle, 'BUNDLE_VERSION\s*[:=]\s*([^\s]+)')
 if (-not $mx.Success) { Fail "BUNDLE_VERSION not found in MEP_BUNDLE.md" }
 $bv = $mx.Groups[1].Value.Trim()
 


### PR DESCRIPTION
Gate 9 (T4) — writeback run failed: "BUNDLE_VERSION not found in MEP_BUNDLE.md".

Root cause:
- tools/mep_writeback_bundle.ps1 only matched `BUNDLE_VERSION:` but Bundled uses `BUNDLE_VERSION = ...`.

Fix:
- accept both `:` and `=` in the BUNDLE_VERSION matcher.

Scope:
- tools/mep_writeback_bundle.ps1