### PR TITLE
fix(mep): set git identity in writeback workflow (actions runner)

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch.yml
@@ -18,6 +18,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Configure git identity
+        shell: bash
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
       - name: Writeback evidence -> PR
         shell: pwsh
         env:


### PR DESCRIPTION
Gate 9 (T4) — writeback run failed: git commit "Author identity unknown".

Fix:
- Configure git user.name/user.email in the workflow before running tools/mep_writeback_bundle.ps1.

Scope:
- .github/workflows/mep_writeback_bundle_dispatch.yml