### PR TITLE
fix(mep): use MEP_PR_TOKEN for writeback PR creation (trigger checks)

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch.yml
@@ -26,6 +26,6 @@ jobs:
       - name: Writeback evidence -> PR
         shell: pwsh
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.MEP_PR_TOKEN }}
         run: |
           pwsh -NoProfile -File tools/mep_writeback_bundle.ps1 -Mode pr -PrNumber ${{ inputs.pr_number }}


### PR DESCRIPTION
Gate 9 (T4) — writeback PR had "no checks reported".

Root cause (GitHub behavior):
- PRs created with GITHUB_TOKEN may not trigger pull_request workflows.

Fix:
- Use secrets.MEP_PR_TOKEN as GH_TOKEN in writeback workflow so PRs are created by PAT and checks run.

Scope:
- .github/workflows/mep_writeback_bundle_dispatch.yml