### PR TITLE
fix(writeback): support IDictionary PR objects in evidence formatting

### DIFF
--- a/tools/mep_writeback_bundle.ps1
+++ b/tools/mep_writeback_bundle.ps1
@@ -1,3 +1,56 @@
+function Try-GetDictValue($obj,[string]$key){
+  try{
+    if($null -eq $obj){ return $null }
+    if($obj -is [System.Collections.IDictionary]){
+      if($obj.Contains($key)){ return $obj[$key] }
+      return $null
+    }
+    return $null
+  } catch { return $null }
+}
+function Format-Scalar($v){
+  try {
+    if($null -eq $v){ return "" }
+    if($v -is [string] -or $v -is [int] -or $v -is [long]){ return [string]$v }
+    return [string]$v
+  } catch { return "" }
+}
+function Format-PrNumber($pr){
+  try {
+    if($null -eq $pr){ return "" }
+    if($pr -is [int] -or $pr -is [long] -or $pr -is [string]){ return [string]$pr }
+    $d = Try-GetDictValue $pr "number"
+    if($null -ne $d){ return Format-Scalar $d }
+    if($pr.PSObject.Properties.Match("number").Count -gt 0){ return Format-Scalar $pr.number }
+    return Format-Scalar $pr
+  } catch { return "" }
+}
+function Format-MergedAt($pr){
+  try {
+    if($null -eq $pr){ return "" }
+    $d = Try-GetDictValue $pr "mergedAt"
+    if($null -ne $d){ return Format-Scalar $d }
+    if($pr.PSObject.Properties.Match("mergedAt").Count -gt 0){ return Format-Scalar $pr.mergedAt }
+    return ""
+  } catch { return "" }
+}
+function Format-MergeCommit($pr){
+  try {
+    if($null -eq $pr){ return "" }
+    $mc = $null
+    $d = Try-GetDictValue $pr "mergeCommit"
+    if($null -ne $d){ $mc = $d }
+    elseif($pr.PSObject.Properties.Match("mergeCommit").Count -gt 0){ $mc = $pr.mergeCommit }
+    if($null -eq $mc){ return "" }
+    if($mc -is [System.Collections.IDictionary]){
+      $oid = Try-GetDictValue $mc "oid"
+      if($null -ne $oid){ return Format-Scalar $oid }
+      return Format-Scalar $mc
+    }
+    if($mc.PSObject.Properties.Match("oid").Count -gt 0){ return Format-Scalar $mc.oid }
+    return Format-Scalar $mc
+  } catch { return "" }
+}
 param(
 Run "gh pr view" { gh pr view $targetBranch --repo $repo --json number,url,headRefName,state -q '{number,url,headRefName,state}' }
 function Format-Scalar($v){


### PR DESCRIPTION
Fix evidence writeback formatting for PR objects passed as Hashtable/IDictionary.
Ensures PR number / mergedAt / mergeCommit.oid are scalarized to avoid "PR #@{...}" and empty fields.