### PR TITLE
fix(writeback): restore parseability of mep_writeback_bundle.ps1

### DIFF
--- a/tools/mep_writeback_bundle.ps1
+++ b/tools/mep_writeback_bundle.ps1
@@ -1,3 +1,11 @@
+param(
+  [int]$PrNumber = 0,
+  [ValidateSet("update","pr")]
+  [string]$Mode = "update",
+  [string]$BundlePath = "docs/MEP/MEP_BUNDLE.md",
+  [string]$TargetBranchPrefix = "auto/writeback-bundle"
+)
+
 function Try-GetDictValue($obj,[string]$key){
   try{
     if($null -eq $obj){ return $null }
@@ -9,14 +17,14 @@ function Try-GetDictValue($obj,[string]$key){
   } catch { return $null }
 }
 function Format-Scalar($v){
-  try {
+  try{
     if($null -eq $v){ return "" }
     if($v -is [string] -or $v -is [int] -or $v -is [long]){ return [string]$v }
     return [string]$v
   } catch { return "" }
 }
 function Format-PrNumber($pr){
-  try {
+  try{
     if($null -eq $pr){ return "" }
     if($pr -is [int] -or $pr -is [long] -or $pr -is [string]){ return [string]$pr }
     $d = Try-GetDictValue $pr "number"
@@ -26,7 +34,7 @@ function Format-PrNumber($pr){
   } catch { return "" }
 }
 function Format-MergedAt($pr){
-  try {
+  try{
     if($null -eq $pr){ return "" }
     $d = Try-GetDictValue $pr "mergedAt"
     if($null -ne $d){ return Format-Scalar $d }
@@ -35,7 +43,7 @@ function Format-MergedAt($pr){
   } catch { return "" }
 }
 function Format-MergeCommit($pr){
-  try {
+  try{
     if($null -eq $pr){ return "" }
     $mc = $null
     $d = Try-GetDictValue $pr "mergeCommit"
@@ -51,49 +59,7 @@ function Format-MergeCommit($pr){
     return Format-Scalar $mc
   } catch { return "" }
 }
-param(
-Run "gh pr view" { gh pr view $targetBranch --repo $repo --json number,url,headRefName,state -q '{number,url,headRefName,state}' }
-function Format-Scalar($v){
-  try {
-    if($null -eq $v){ return "" }
-    if($v -is [string] -or $v -is [int] -or $v -is [long]){ return [string]$v }
-    return [string]$v
-  } catch { return "" }
-}
-function Format-PrNumber($pr){
-  try {
-    if($null -eq $pr){ return "" }
-    if($pr -is [int] -or $pr -is [long] -or $pr -is [string]){ return [string]$pr }
-    if($pr.PSObject.Properties.Match("number").Count -gt 0){ return [string]$pr.number }
-    return [string]$pr
-  } catch { return "" }
-}
-function Format-MergedAt($pr){
-  try {
-    if($null -eq $pr){ return "" }
-    if($pr.PSObject.Properties.Match("mergedAt").Count -gt 0){ return Format-Scalar $pr.mergedAt }
-    return ""
-  } catch { return "" }
-}
-function Format-MergeCommit($pr){
-  try {
-    if($null -eq $pr){ return "" }
-    if($pr.PSObject.Properties.Match("mergeCommit").Count -gt 0){
-      $mc = $pr.mergeCommit
-      if($null -eq $mc){ return "" }
-      if($mc.PSObject.Properties.Match("oid").Count -gt 0){ return Format-Scalar $mc.oid }
-      return Format-Scalar $mc
-    }
-    return ""
-  } catch { return "" }
-}
-param(
-  [int]$PrNumber = 0,
-  [ValidateSet("update","pr")]
-  [string]$Mode = "update",
-  [string]$BundlePath = "docs/MEP/MEP_BUNDLE.md",
-  [string]$TargetBranchPrefix = "auto/writeback-bundle"
-)
+
 
 $ErrorActionPreference = 'Stop'
 $ProgressPreference = 'SilentlyContinue'


### PR DESCRIPTION
Sanitize the header of tools/mep_writeback_bundle.ps1:
- Keep exactly one param() block
- Place helper functions outside param()
- Remove accidental injected statements/functions inside param block
This fixes CI ParseError and enables writeback workflow to run again.