### PR TITLE
fix(writeback): treat no-diff as OK (idempotent)

### DIFF
--- a/tools/mep_writeback_bundle.ps1
+++ b/tools/mep_writeback_bundle.ps1
@@ -254,7 +254,12 @@ if ($Mode -eq "update") {
 
 # Mode=pr: commit + PR (bundle only)
 $porc = (Run "git status porcelain" { git status --porcelain }).Trim()
-if (-not $porc) { Fail "No changes to commit (writeback produced no diff)." }
+if (-not $porc) {
+  # BEGIN: NO_DIFF_IS_OK
+  Write-Host "No changes to commit (writeback produced no diff). Treat as OK (idempotent)."
+  return
+  # END: NO_DIFF_IS_OK
+}
 
 Run "git checkout main" { git checkout main }
 Run "git pull main" { git pull --ff-only origin main }


### PR DESCRIPTION
Writeback workflow should be idempotent. When there is no diff to commit, treat it as success instead of failing the run.