### PR TITLE
docs(MEP): add evidence corruption guard (DIRTY on PR #@{ / empty mergedAt/mergeCommit)

### DIFF
--- a/docs/MEP/MEP_BUNDLE.md
+++ b/docs/MEP/MEP_BUNDLE.md
@@ -225,6 +225,17 @@ BUSINESS側を構築すると、例外・分岐・用語・台帳参照が急増
 - 手作業ではなく **スクリプト/CI** が自動で貼り戻す。
 - 証跡が欠けるものは「入った扱い禁止」。
 
+<!-- BEGIN: EVIDENCE_CORRUPTION_GUARD (MEP) -->
+
+### 証跡ログ破損の検知（必須）
+- 証跡ログ（自動貼り戻し）に以下の破損パターンを検出した場合、**DIRTY（停止）**とする（入った扱い禁止）。
+  - `PR #@{` を含む行（PowerShellオブジェクト文字列化）
+  - `mergedAt=` が空
+  - `mergeCommit=` が空
+- 復旧は「壊れ行の除去」＋「正規行（PR番号／mergedAt／mergeCommit／BUNDLE_VERSION／audit）を1本だけ残す」。
+- 同一PRの壊れ行が複数ある場合は、削除後に正規行を1本に収束させる。
+
+<!-- END: EVIDENCE_CORRUPTION_GUARD (MEP) -->
 <!-- END: EVIDENCE_WRITEBACK_SPEC (MEP) -->
 
 <!-- BEGIN: DIFF_POLICY_BOUNDARY_AUDIT (MEP) -->


### PR DESCRIPTION
Add a Bundled rule to detect evidence-log corruption and stop (DIRTY) when:
- PR #@{...} appears (object stringification)
- mergedAt= is empty
- mergeCommit= is empty
Also defines recovery: remove broken lines and keep exactly one normalized evidence line.