### PR TITLE
Fix writeback dispatch YAML: steps under job + correct order (checkout before repair)

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch.yml
@@ -14,11 +14,7 @@ permissions:
 jobs:
   writeback:
     runs-on: ubuntu-latest
-steps:
-      - name: Repair Evidence line (fill mergedAt/mergeCommit)
-        shell: pwsh
-        run: |
-          pwsh -NoProfile -File tools/mep_repair_evidence_line.ps1 -PrNumber ${{ github.event.inputs.pr_number }}
+    steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -33,4 +29,10 @@ steps:
           GH_TOKEN: ${{ secrets.MEP_PR_TOKEN }}
         run: |
           pwsh -NoProfile -File tools/mep_writeback_bundle.ps1 -Mode pr -PrNumber ${{ inputs.pr_number }}
+      - name: Repair Evidence line (fill mergedAt/mergeCommit)
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.MEP_PR_TOKEN }}
+        run: |
+          pwsh -NoProfile -File tools/mep_repair_evidence_line.ps1 -PrNumber ${{ inputs.pr_number }}
 


### PR DESCRIPTION
mep_writeback_bundle_dispatch.yml が壊れており、workflow_dispatch が HTTP 422:
- Unexpected value "steps"（job 配下に無い top-level steps）
- さらに repair step が checkout 前に実行され得る（tools 未存在）

本PRは
- steps を jobs.writeback 配下へ正しく配置
- 実行順序を checkout → git identity → writeback → repair に固定
して dispatch 可能状態へ復旧する。