### PR TITLE
Fix writeback: holistic Evidence Log repair (no empty mergedAt/mergeCommit)

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch.yml
@@ -29,9 +29,10 @@ jobs:
           GH_TOKEN: ${{ secrets.MEP_PR_TOKEN }}
         run: |
           pwsh -NoProfile -File tools/mep_writeback_bundle.ps1 -Mode pr -PrNumber ${{ inputs.pr_number }}
-      - name: Repair Evidence line (fill mergedAt/mergeCommit)
+      - name: Repair Evidence Log (fill/remove empty mergedAt/mergeCommit)
         shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.MEP_PR_TOKEN }}
         run: |
           pwsh -NoProfile -File tools/mep_repair_evidence_log.ps1
+


### PR DESCRIPTION
writeback の repair が「対象PR 1本のみ補修」だったため、Evidence Log 内に残る別PRの空 mergedAt/mergeCommit を解消できず、再DIRTYが発生する。

本PRは:
- tools/mep_repair_evidence_log.ps1 を追加（Evidence Log 内の空 mergedAt/mergeCommit を全件、GitHub API 真値で補修。真値が取れない行は除去）
- mep_writeback_bundle_dispatch.yml の repair step を当該スクリプトへ切替

により、writeback 実行ごとに Evidence Log を DIRTY-free に収束させる。