### PR TITLE
Fix writeback: auto-merge auto repair PRs after writeback

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch.yml
@@ -48,7 +48,11 @@ jobs:
             git add docs/MEP/MEP_BUNDLE.md
             git commit -m "Fix: repair Evidence Log (fill empty mergedAt/mergeCommit)"
             git push -u origin "$BR"
-            gh pr create --title "Fix Evidence Log: fill empty mergedAt/mergeCommit" --body "Automated repair after writeback: fill/remove empty mergedAt/mergeCommit in Evidence Log." --base "main" --head "$BR" || true
+            PRURL=$(gh pr create --title "Fix Evidence Log: fill empty mergedAt/mergeCommit" --body "Automated repair after writeback: fill/remove empty mergedAt/mergeCommit in Evidence Log." --base "${{ github.ref_name }}" --head "$BR" || true)
+            if [ -n "${PRURL:-}" ]; then
+              echo "repair PR=$PRURL"
+              gh pr merge --auto --merge "$PRURL" || true
+            fi
           else
             echo "no diff; skip repair PR"
           fi


### PR DESCRIPTION
AUTO_REPAIR_PR_STEP が作成する auto/repair-evidence-log_* PR について、
作成直後に gh pr merge --auto --merge を best-effort で要求するように修正します。
（手動マージの削減）