### PR TITLE
Fix Evidence Log: fill empty mergedAt/mergeCommit

### DIFF
--- a/docs/MEP/MEP_BUNDLE.md
+++ b/docs/MEP/MEP_BUNDLE.md
@@ -261,7 +261,7 @@ BUSINESS側を構築すると、例外・分岐・用語・台帳参照が急増
 - PR #860 | mergedAt=01/18/2026 05:00:28 | mergeCommit=135c75ca4271237521ec9d760cbbd4bb35892a57 | BUNDLE_VERSION=v0.0.0+20260114_005937+main_fa31bda | audit=OK,WB0000 | acceptance:SUCCESS, Business Packet Guard (PR):SUCCESS, done_check:SUCCESS, enable_auto_merge:SUCCESS, gate:SUCCESS, guard:SUCCESS, self-heal:SUCCESS, semantic-audit-business:SUCCESS, semantic-audit:SUCCESS, suggest:SUCCESS, Text Integrity Guard (PR):SUCCESS | https://github.com/Osuu-ops/yorisoidou-system/pull/860
 - PR #864 | mergedAt=01/19/2026 00:26:26 | mergeCommit=6851620dc593b57ce5e9b5da673ce4a3941fbdc6 | BUNDLE_VERSION=v0.0.0+20260114_005937+main_fa31bda | audit=OK,WB0000 | acceptance:SUCCESS, Business Packet Guard (PR):SUCCESS, done_check:SUCCESS, enable_auto_merge:SUCCESS, gate:SUCCESS, semantic-audit-business:SUCCESS, semantic-audit:SUCCESS, suggest:SUCCESS, Text Integrity Guard (PR):SUCCESS | https://github.com/Osuu-ops/yorisoidou-system/pull/864
 - PR #866 | mergedAt=01/19/2026 00:32:54 | mergeCommit=2a7b196fc7e9d3baf7e48f0c8fb57a44b381b7e9 | BUNDLE_VERSION=v0.0.0+20260114_005937+main_fa31bda | audit=OK,WB0000 | acceptance:SUCCESS, Business Packet Guard (PR):SUCCESS, done_check:SUCCESS, enable_auto_merge:SUCCESS, gate:SUCCESS, guard:SUCCESS, self-heal:SUCCESS, semantic-audit-business:SUCCESS, semantic-audit:SUCCESS, suggest:SUCCESS, Text Integrity Guard (PR):SUCCESS, update-state-summary:SUCCESS | https://github.com/Osuu-ops/yorisoidou-system/pull/866
-- PR #868 | mergedAt= | mergeCommit= | BUNDLE_VERSION=v0.0.0+20260114_005937+main_fa31bda | audit=OK,WB0000 | acceptance:SUCCESS, Business Packet Guard (PR):SUCCESS, done_check:SUCCESS, enable_auto_merge:SUCCESS, gate:SUCCESS, guard:SUCCESS, self-heal:SUCCESS, semantic-audit-business:SUCCESS, semantic-audit:SUCCESS, suggest:SUCCESS, Text Integrity Guard (PR):SUCCESS | https://github.com/Osuu-ops/yorisoidou-system/pull/868
+- PR #868 | mergedAt=01/19/2026 00:36:25 | mergeCommit=2e95f270f68c91c9f1efa953ce4b05335bd9b945 | BUNDLE_VERSION=v0.0.0+20260114_005937+main_fa31bda | audit=OK,WB0000 | acceptance:SUCCESS, Business Packet Guard (PR):SUCCESS, done_check:SUCCESS, enable_auto_merge:SUCCESS, gate:SUCCESS, guard:SUCCESS, self-heal:SUCCESS, semantic-audit-business:SUCCESS, semantic-audit:SUCCESS, suggest:SUCCESS, Text Integrity Guard (PR):SUCCESS | https://github.com/Osuu-ops/yorisoidou-system/pull/868
 ## CARD: DIFF_POLICY / BOUNDARY AUDIT（差分運用・境界監査）  [Draft]
 
 ### 基本
@@ -465,6 +465,7 @@ Bundled 本文に基づき、
 
 以上。
 <!-- END: OFFICIAL_DESCRIPTION (MEP) -->
+
 
 
 


### PR DESCRIPTION
Automated repair after writeback: fill/remove empty mergedAt/mergeCommit in Evidence Log.