### PR TITLE
Gate10: add acceptance tests (BEGIN/END, duplicate BEGIN, conflict ma…

### DIFF
--- a/.github/workflows/mep_acceptance_tests_dispatch.yml
+++ b/.github/workflows/mep_acceptance_tests_dispatch.yml
@@ -1,0 +1,19 @@
+name: mep_acceptance_tests_dispatch
+
+on:
+  workflow_dispatch:
+    inputs:
+      path:
+        description: "Target markdown path"
+        required: true
+        default: "docs/MEP/MEP_BUNDLE.md"
+
+jobs:
+  acceptance:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run acceptance tests (MEP)
+        shell: pwsh
+        run: |
+          ./tools/mep_acceptance_tests.ps1 -Path "${{ github.event.inputs.path }}"

--- a/.github/workflows/mep_acceptance_tests_pr.yml
+++ b/.github/workflows/mep_acceptance_tests_pr.yml
@@ -1,0 +1,19 @@
+name: mep_acceptance_tests_pr
+
+on:
+  pull_request:
+    paths:
+      - "docs/MEP/MEP_BUNDLE.md"
+      - "tools/mep_acceptance_tests.ps1"
+      - ".github/workflows/mep_acceptance_tests_pr.yml"
+      - ".github/workflows/mep_acceptance_tests_dispatch.yml"
+
+jobs:
+  acceptance:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run acceptance tests (MEP)
+        shell: pwsh
+        run: |
+          ./tools/mep_acceptance_tests.ps1 -Path "docs/MEP/MEP_BUNDLE.md"

--- a/tools/mep_acceptance_tests.ps1
+++ b/tools/mep_acceptance_tests.ps1
@@ -1,0 +1,93 @@
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory=$false)]
+  [string]$Path = "docs/MEP/MEP_BUNDLE.md"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function OutNG([int]$code, [string[]]$msgs) {
+  foreach ($m in $msgs) { Write-Host $m }
+  exit $code
+}
+
+if (-not (Test-Path -LiteralPath $Path)) {
+  OutNG 21 @("AT0021 INPUT_NOT_FOUND path=$Path")
+}
+
+$lines = Get-Content -LiteralPath $Path -Encoding UTF8
+
+# (A) Conflict markers are NG
+$conf = @()
+for ($i=0; $i -lt $lines.Count; $i++) {
+  if ($lines[$i] -match '^(<{7}|={7}|>{7})') {
+    $conf += "AT0001 CONFLICT_MARKER line=$($i+1) text=$($lines[$i])"
+  }
+}
+if ($conf.Count -gt 0) { OutNG 1 $conf }
+
+# (B) Parse BEGIN/END
+$reBegin = '^\s*<!--\s*BEGIN:\s*([A-Za-z0-9_./:-]+)\s*-->.*$'
+$reEnd   = '^\s*<!--\s*END:\s*([A-Za-z0-9_./:-]+)\s*-->.*$'
+
+$begin = @{}
+$end   = @{}
+$beginLines = @{}
+$endLines   = @{}
+
+for ($i=0; $i -lt $lines.Count; $i++) {
+  $line = $lines[$i]
+  $m1 = [regex]::Match($line, $reBegin)
+  if ($m1.Success) {
+    $id = $m1.Groups[1].Value
+    if (-not $begin.ContainsKey($id)) { $begin[$id] = 0; $beginLines[$id] = @() }
+    $begin[$id]++
+    $beginLines[$id] += ($i+1)
+    continue
+  }
+  $m2 = [regex]::Match($line, $reEnd)
+  if ($m2.Success) {
+    $id = $m2.Groups[1].Value
+    if (-not $end.ContainsKey($id)) { $end[$id] = 0; $endLines[$id] = @() }
+    $end[$id]++
+    $endLines[$id] += ($i+1)
+    continue
+  }
+}
+
+$ng = New-Object System.Collections.Generic.List[string]
+
+# (C) Duplicate BEGIN is NG
+foreach ($id in $begin.Keys) {
+  if ([int]$begin[$id] -gt 1) {
+    $ng.Add("AT0002 DUPLICATE_BEGIN id=$id lines=$($beginLines[$id] -join ',')") | Out-Null
+  }
+}
+
+# (D) Pair integrity: orphan END / missing END / duplicate END
+$allIds = New-Object System.Collections.Generic.HashSet[string]
+foreach ($k in $begin.Keys) { [void]$allIds.Add($k) }
+foreach ($k in $end.Keys)   { [void]$allIds.Add($k) }
+
+foreach ($id in $allIds) {
+  $bc = if ($begin.ContainsKey($id)) { [int]$begin[$id] } else { 0 }
+  $ec = if ($end.ContainsKey($id))   { [int]$end[$id] } else { 0 }
+
+  if ($bc -eq 0 -and $ec -gt 0) {
+    $ng.Add("AT0003 ORPHAN_END id=$id lines=$($endLines[$id] -join ',')") | Out-Null
+    continue
+  }
+  if ($bc -gt 0 -and $ec -eq 0) {
+    $ng.Add("AT0004 MISSING_END id=$id lines=$($beginLines[$id] -join ',')") | Out-Null
+    continue
+  }
+  if ($ec -gt 1) {
+    $ng.Add("AT0005 DUPLICATE_END id=$id lines=$($endLines[$id] -join ',')") | Out-Null
+  }
+}
+
+if ($ng.Count -gt 0) { OutNG 2 @($ng) }
+
+Write-Host "AT0000 OK path=$Path"
+exit 0


### PR DESCRIPTION
…rkers)

﻿# Purpose
(What is this PR changing? Keep it short.)

# Required checks
- [ ] semantic-audit is GREEN (required)
- [ ] If semantic-audit is SKIP, confirm this PR does not change platform/MEP/01_CORE/**/*.md

# If semantic-audit is NG (paste this as a PR comment)
## Template A (standard)
@copilot
Fix this PR so that the required check "semantic-audit" passes.

Constraints:
- Make minimal diffs only. Do NOT rewrite whole documents.
- Only touch files necessary to fix the audit.
- Primary scope: platform/MEP/01_CORE/**/*.md
- Use the audit log from the "MEP Semantic Audit" comment/summary as the source of truth.
- After making changes, push commits to this PR (or open a sub-PR targeting this branch) until checks pass.

Output:
- Briefly state what you changed and why, linked to the audit failure.

## Template B (tight scope)
@copilot
Only modify the exact lines/files referenced by the semantic-audit failure.
Do not refactor, do not reformat, do not touch unrelated files.
One failing point = one minimal fix.

## Template C (no sub-PR)
@copilot
Do NOT create a separate pull request.
Commit directly to this PR branch only.

# Notes for GPT (this chat)
If Copilot loops or the failure reason is unclear, paste:
- the MEP Semantic Audit comment (audit.log section), or
- a screenshot of the failing check log.
