### PR TITLE
Fix Evidence Log: fill empty mergedAt/mergeCommit

### DIFF
--- a/docs/MEP/MEP_BUNDLE.md
+++ b/docs/MEP/MEP_BUNDLE.md
@@ -268,7 +268,7 @@ BUSINESS側を構築すると、例外・分岐・用語・台帳参照が急増
 - PR #881 | mergedAt=01/20/2026 03:00:50 | mergeCommit=ffd991e2d862d1ab13121373612700becfb820a6 | BUNDLE_VERSION=v0.0.0+20260120_014500+main_e06693d | audit=OK,WB0000 | acceptance:SUCCESS, Business Packet Guard (PR):SUCCESS, done_check:SUCCESS, enable_auto_merge:SUCCESS, gate:SUCCESS, guard:SUCCESS, merge_repair_pr:SKIPPED, self-heal:SUCCESS, semantic-audit-business:SUCCESS, semantic-audit:SUCCESS, suggest:SUCCESS, Text Integrity Guard (PR):SUCCESS, update-state-summary:SKIPPED | https://github.com/Osuu-ops/yorisoidou-system/pull/881
 - PR #883 | mergedAt=01/20/2026 03:03:55 | mergeCommit=2c42f74e8ef8387489356bcfb2ee5970fb745103 | BUNDLE_VERSION=v0.0.0+20260120_014500+main_e06693d | audit=NG,WB2001 | acceptance:SUCCESS, Business Packet Guard (PR):SUCCESS, done_check:SUCCESS, enable_auto_merge:SUCCESS, gate:SUCCESS, guard:SUCCESS, merge_repair_pr:FAILURE, self-heal:SUCCESS, semantic-audit-business:SUCCESS, semantic-audit:SUCCESS, suggest:SUCCESS, Text Integrity Guard (PR):SUCCESS, update-state-summary:SUCCESS | https://github.com/Osuu-ops/yorisoidou-system/pull/883
 - PR #885 | mergedAt=01/20/2026 03:06:33 | mergeCommit=581b8a635dc9bec61e82de7c9f9afc84d28f2eff | BUNDLE_VERSION=v0.0.0+20260120_014500+main_e06693d | audit=NG,WB2001 | acceptance:SUCCESS, Business Packet Guard (PR):SUCCESS, done_check:SUCCESS, enable_auto_merge:SUCCESS, gate:SUCCESS, guard:SUCCESS, merge_repair_pr:FAILURE, self-heal:SUCCESS, semantic-audit-business:SUCCESS, semantic-audit:SUCCESS, suggest:SUCCESS, Text Integrity Guard (PR):SUCCESS, update-state-summary:SUCCESS | https://github.com/Osuu-ops/yorisoidou-system/pull/885
-- PR #887 | mergedAt= | mergeCommit= | BUNDLE_VERSION=v0.0.0+20260120_014500+main_e06693d | audit=NG,WB2001 | acceptance:SUCCESS, Business Packet Guard (PR):SUCCESS, done_check:SUCCESS, enable_auto_merge:SUCCESS, gate:SUCCESS, guard:SUCCESS, merge_repair_pr:FAILURE, self-heal:SUCCESS, semantic-audit-business:SUCCESS, semantic-audit:SUCCESS, suggest:SUCCESS, Text Integrity Guard (PR):SUCCESS | https://github.com/Osuu-ops/yorisoidou-system/pull/887
+- PR #887 | mergedAt=01/20/2026 03:15:49 | mergeCommit=24cba453329335d96bdbec520011b157058cc43b | BUNDLE_VERSION=v0.0.0+20260120_014500+main_e06693d | audit=NG,WB2001 | acceptance:SUCCESS, Business Packet Guard (PR):SUCCESS, done_check:SUCCESS, enable_auto_merge:SUCCESS, gate:SUCCESS, guard:SUCCESS, merge_repair_pr:FAILURE, self-heal:SUCCESS, semantic-audit-business:SUCCESS, semantic-audit:SUCCESS, suggest:SUCCESS, Text Integrity Guard (PR):SUCCESS | https://github.com/Osuu-ops/yorisoidou-system/pull/887
 ## CARD: DIFF_POLICY / BOUNDARY AUDIT（差分運用・境界監査）  [Draft]
 
 ### 基本
@@ -472,6 +472,7 @@ Bundled 本文に基づき、
 
 以上。
 <!-- END: OFFICIAL_DESCRIPTION (MEP) -->
+
 
 
 


### PR DESCRIPTION
Automated repair after writeback: fill/remove empty mergedAt/mergeCommit in Evidence Log.