### PR TITLE
Fix Evidence Log: fill empty mergedAt/mergeCommit

### DIFF
--- a/docs/MEP/MEP_BUNDLE.md
+++ b/docs/MEP/MEP_BUNDLE.md
@@ -271,7 +271,7 @@ BUSINESS側を構築すると、例外・分岐・用語・台帳参照が急増
 - PR #887 | mergedAt=01/20/2026 03:15:49 | mergeCommit=24cba453329335d96bdbec520011b157058cc43b | BUNDLE_VERSION=v0.0.0+20260120_014500+main_e06693d | audit=NG,WB2001 | acceptance:SUCCESS, Business Packet Guard (PR):SUCCESS, done_check:SUCCESS, enable_auto_merge:SUCCESS, gate:SUCCESS, guard:SUCCESS, merge_repair_pr:FAILURE, self-heal:SUCCESS, semantic-audit-business:SUCCESS, semantic-audit:SUCCESS, suggest:SUCCESS, Text Integrity Guard (PR):SUCCESS | https://github.com/Osuu-ops/yorisoidou-system/pull/887
 - PR #889 | mergedAt=01/20/2026 03:20:03 | mergeCommit=a61a13161818ec14c4d134ac2404fc549a051253 | BUNDLE_VERSION=v0.0.0+20260120_014500+main_e06693d | audit=NG,WB2001 | acceptance:SUCCESS, Business Packet Guard (PR):SUCCESS, done_check:SUCCESS, enable_auto_merge:SUCCESS, gate:SUCCESS, guard:SUCCESS, merge_repair_pr:FAILURE, self-heal:SUCCESS, semantic-audit-business:SUCCESS, semantic-audit:SUCCESS, suggest:SUCCESS, Text Integrity Guard (PR):SUCCESS | https://github.com/Osuu-ops/yorisoidou-system/pull/889
 - PR #891 | mergedAt=01/20/2026 03:23:56 | mergeCommit=591ef833b082eb4b0b7809e9524b4b7d3009857f | BUNDLE_VERSION=v0.0.0+20260120_014500+main_e06693d | audit=NG,WB2001 | acceptance:SUCCESS, Business Packet Guard (PR):SUCCESS, done_check:SUCCESS, enable_auto_merge:SUCCESS, gate:SUCCESS, guard:SUCCESS, merge_repair_pr:FAILURE, self-heal:SUCCESS, semantic-audit-business:SUCCESS, semantic-audit:SUCCESS, suggest:SUCCESS, Text Integrity Guard (PR):SUCCESS | https://github.com/Osuu-ops/yorisoidou-system/pull/891
-- PR #893 | mergedAt= | mergeCommit= | BUNDLE_VERSION=v0.0.0+20260120_014500+main_e06693d | audit=NG,WB2001 | acceptance:SUCCESS, Business Packet Guard (PR):SUCCESS, done_check:SUCCESS, enable_auto_merge:SUCCESS, gate:SUCCESS, guard:SUCCESS, merge_repair_pr:FAILURE, self-heal:SUCCESS, semantic-audit-business:SUCCESS, semantic-audit:SUCCESS, suggest:SUCCESS, Text Integrity Guard (PR):SUCCESS | https://github.com/Osuu-ops/yorisoidou-system/pull/893
+- PR #893 | mergedAt=01/20/2026 03:26:53 | mergeCommit=b8017ad84696afb4ebae1f19d317ad46d65aa320 | BUNDLE_VERSION=v0.0.0+20260120_014500+main_e06693d | audit=NG,WB2001 | acceptance:SUCCESS, Business Packet Guard (PR):SUCCESS, done_check:SUCCESS, enable_auto_merge:SUCCESS, gate:SUCCESS, guard:SUCCESS, merge_repair_pr:FAILURE, self-heal:SUCCESS, semantic-audit-business:SUCCESS, semantic-audit:SUCCESS, suggest:SUCCESS, Text Integrity Guard (PR):SUCCESS | https://github.com/Osuu-ops/yorisoidou-system/pull/893
 ## CARD: DIFF_POLICY / BOUNDARY AUDIT（差分運用・境界監査）  [Draft]
 
 ### 基本
@@ -475,6 +475,7 @@ Bundled 本文に基づき、
 
 以上。
 <!-- END: OFFICIAL_DESCRIPTION (MEP) -->
+
 
 
 


### PR DESCRIPTION
Automated repair after writeback: fill/remove empty mergedAt/mergeCommit in Evidence Log.