### PR TITLE
Fix Evidence Log: fill empty mergedAt/mergeCommit

### DIFF
--- a/docs/MEP/MEP_BUNDLE.md
+++ b/docs/MEP/MEP_BUNDLE.md
@@ -278,8 +278,8 @@ BUSINESS側を構築すると、例外・分岐・用語・台帳参照が急増
 - PR #902 | mergedAt=01/20/2026 03:41:50 | mergeCommit=22416f2cce80c45b94e94e375beec63305acf89f | BUNDLE_VERSION=v0.0.0+20260120_014500+main_e06693d | audit=OK,WB0000 | acceptance:SUCCESS, Business Packet Guard (PR):SUCCESS, done_check:SUCCESS, enable_auto_merge:SUCCESS, gate:SUCCESS, guard:SUCCESS, merge_repair_pr:IN_PROGRESS, self-heal:SUCCESS, semantic-audit-business:SUCCESS, semantic-audit:SUCCESS, suggest:SUCCESS, Text Integrity Guard (PR):SUCCESS | https://github.com/Osuu-ops/yorisoidou-system/pull/902
 - PR #905 | mergedAt=01/20/2026 03:52:18 | mergeCommit=5144783bd8b77a9f429b87db85ea1b12573dd49a | BUNDLE_VERSION=v0.0.0+20260120_014500+main_e06693d | audit=OK,WB0000 | acceptance:IN_PROGRESS, Business Packet Guard (PR):SUCCESS, done_check:SUCCESS, enable_auto_merge:SUCCESS, gate:SUCCESS, merge_repair_pr:SKIPPED, semantic-audit-business:SUCCESS, semantic-audit:SUCCESS, suggest:SUCCESS, Text Integrity Guard (PR):SUCCESS | https://github.com/Osuu-ops/yorisoidou-system/pull/905
 - PR #908 | mergedAt=01/20/2026 03:56:45 | mergeCommit=c054ee1f0f08fddf71879addff5e8593247f9ff8 | BUNDLE_VERSION=v0.0.0+20260120_014500+main_e06693d | audit=OK,WB0000 | acceptance:SUCCESS, Business Packet Guard (PR):SUCCESS, done_check:SUCCESS, enable_auto_merge:SUCCESS, gate:SUCCESS, merge_repair_pr:SKIPPED, semantic-audit-business:SUCCESS, semantic-audit:SUCCESS, suggest:SUCCESS, Text Integrity Guard (PR):SUCCESS | https://github.com/Osuu-ops/yorisoidou-system/pull/908
-- PR #910 | mergedAt= | mergeCommit= | BUNDLE_VERSION=v0.0.0+20260120_014500+main_e06693d | audit=OK,WB0000 | acceptance:SUCCESS, Business Packet Guard (PR):SUCCESS, done_check:SUCCESS, enable_auto_merge:SUCCESS, gate:SUCCESS, guard:SUCCESS, merge_repair_pr:IN_PROGRESS, self-heal:SUCCESS, semantic-audit-business:SUCCESS, semantic-audit:SUCCESS, suggest:SUCCESS, Text Integrity Guard (PR):SUCCESS | https://github.com/Osuu-ops/yorisoidou-system/pull/910
-- PR #911 | mergedAt= | mergeCommit= | BUNDLE_VERSION=v0.0.0+20260120_014500+main_e06693d | audit=OK,WB0000 | acceptance:SUCCESS, Business Packet Guard (PR):SUCCESS, done_check:SUCCESS, enable_auto_merge:SUCCESS, gate:SUCCESS, guard:SUCCESS, merge_repair_pr:SKIPPED, self-heal:SUCCESS, semantic-audit-business:SUCCESS, semantic-audit:SUCCESS, suggest:SUCCESS, Text Integrity Guard (PR):SUCCESS | https://github.com/Osuu-ops/yorisoidou-system/pull/911
+- PR #910 | mergedAt=01/20/2026 03:57:22 | mergeCommit=fa5e46c97ae96f156f7c1c7b100ca7db3bf93144 | BUNDLE_VERSION=v0.0.0+20260120_014500+main_e06693d | audit=OK,WB0000 | acceptance:SUCCESS, Business Packet Guard (PR):SUCCESS, done_check:SUCCESS, enable_auto_merge:SUCCESS, gate:SUCCESS, guard:SUCCESS, merge_repair_pr:IN_PROGRESS, self-heal:SUCCESS, semantic-audit-business:SUCCESS, semantic-audit:SUCCESS, suggest:SUCCESS, Text Integrity Guard (PR):SUCCESS | https://github.com/Osuu-ops/yorisoidou-system/pull/910
+- PR #911 | mergedAt=01/20/2026 04:00:45 | mergeCommit=9f2838dceaf03f2db0a4a579ccb6dbdd93bbed5a | BUNDLE_VERSION=v0.0.0+20260120_014500+main_e06693d | audit=OK,WB0000 | acceptance:SUCCESS, Business Packet Guard (PR):SUCCESS, done_check:SUCCESS, enable_auto_merge:SUCCESS, gate:SUCCESS, guard:SUCCESS, merge_repair_pr:SKIPPED, self-heal:SUCCESS, semantic-audit-business:SUCCESS, semantic-audit:SUCCESS, suggest:SUCCESS, Text Integrity Guard (PR):SUCCESS | https://github.com/Osuu-ops/yorisoidou-system/pull/911
 ## CARD: DIFF_POLICY / BOUNDARY AUDIT（差分運用・境界監査）  [Draft]
 
 ### 基本
@@ -483,6 +483,7 @@ Bundled 本文に基づき、
 
 以上。
 <!-- END: OFFICIAL_DESCRIPTION (MEP) -->
+
 
 
 


### PR DESCRIPTION
Automated repair after writeback: fill/remove empty mergedAt/mergeCommit in Evidence Log.