### PR TITLE
Fix: Evidence Log status for PR #982

### DIFF
--- a/docs/MEP/MEP_BUNDLE.md
+++ b/docs/MEP/MEP_BUNDLE.md
@@ -304,7 +304,7 @@ BUSINESS側を構築すると、例外・分岐・用語・台帳参照が急増
 - PR #976 | mergedAt=01/21/2026 04:41:57 | mergeCommit=103f97efa20ff5771b44191108059cb1ab02505e | BUNDLE_VERSION=v0.0.0+20260121_043634+main_c7ba1a2 | audit=OK,WB0000 | acceptance:SUCCESS, Business Packet Guard (PR):SUCCESS, done_check:SUCCESS, enable_auto_merge:SUCCESS, gate:SUCCESS, guard:SUCCESS, merge_repair_pr:SKIPPED, self-heal:SUCCESS, semantic-audit-business:SUCCESS, semantic-audit:SUCCESS, suggest:SUCCESS, Text Integrity Guard (PR):SUCCESS | https://github.com/Osuu-ops/yorisoidou-system/pull/976
 - PR #979 | mergedAt=01/21/2026 04:47:17 | mergeCommit=a7117db9213c5bbf706c04bded8878dee48951e4 | BUNDLE_VERSION=v0.0.0+20260121_044253+main_103f97e | audit=OK,WB0000 | acceptance:SUCCESS, Business Packet Guard (PR):SUCCESS, done_check:SUCCESS, enable_auto_merge:SUCCESS, gate:SUCCESS, guard:SUCCESS, merge_repair_pr:SKIPPED, self-heal:SUCCESS, semantic-audit-business:SUCCESS, semantic-audit:SUCCESS, suggest:SUCCESS, Text Integrity Guard (PR):SUCCESS | https://github.com/Osuu-ops/yorisoidou-system/pull/979
 - PR #980 | mergedAt=01/21/2026 04:48:49 | mergeCommit=03a2df6c4858330986268acce9e0c1bde5ce61ae | BUNDLE_VERSION=v0.0.0+20260121_044253+main_103f97e | audit=OK,WB0000 | acceptance:SUCCESS, Business Packet Guard (PR):SUCCESS, done_check:SUCCESS, enable_auto_merge:SUCCESS, gate:SUCCESS, guard:SUCCESS, merge_repair_pr:SKIPPED, self-heal:SUCCESS, semantic-audit-business:SUCCESS, semantic-audit:SUCCESS, suggest:SUCCESS, Text Integrity Guard (PR):SUCCESS | https://github.com/Osuu-ops/yorisoidou-system/pull/980
-- PR #982 | mergedAt=01/21/2026 04:54:34 | mergeCommit=355031b23b060c30912d0f421588e85ef21172ac | BUNDLE_VERSION=v0.0.0+20260121_044253+main_103f97e | audit=OK,WB0000 | acceptance:SUCCESS, Business Packet Guard (PR):IN_PROGRESS, done_check:SUCCESS, enable_auto_merge:SUCCESS, gate:SUCCESS, guard:SUCCESS, merge_repair_pr:SKIPPED, self-heal:SUCCESS, semantic-audit-business:SUCCESS, semantic-audit:SUCCESS, suggest:SUCCESS, Text Integrity Guard (PR):SUCCESS | https://github.com/Osuu-ops/yorisoidou-system/pull/982
+- PR #982 | mergedAt=01/21/2026 04:54:34 | mergeCommit=355031b23b060c30912d0f421588e85ef21172ac | BUNDLE_VERSION=v0.0.0+20260121_044253+main_103f97e | audit=OK,WB0000 | acceptance:SUCCESS, Business Packet Guard (PR):SUCCESS, done_check:SUCCESS, enable_auto_merge:SUCCESS, gate:SUCCESS, guard:SUCCESS, merge_repair_pr:SKIPPED, self-heal:SUCCESS, semantic-audit-business:SUCCESS, semantic-audit:SUCCESS, suggest:SUCCESS, Text Integrity Guard (PR):SUCCESS | https://github.com/Osuu-ops/yorisoidou-system/pull/982
 ## CARD: DIFF_POLICY / BOUNDARY AUDIT（差分運用・境界監査）  [Draft]
 
 ### 基本
@@ -508,6 +508,7 @@ Bundled 本文に基づき、
 
 以上。
 <!-- END: OFFICIAL_DESCRIPTION (MEP) -->
+
 
 
 


### PR DESCRIPTION
変更内容:
- docs/MEP/MEP_BUNDLE.md の証跡ログ 1行のみ修正
  - PR #982 の 'Business Packet Guard (PR):IN_PROGRESS' を '...:SUCCESS' に訂正

根拠:
- gh pr checks 982 は SUCCESS
- Bundled 証跡行のみ不整合

制約:
- 差分は1行置換のみ（最小パッチ）