### PR TITLE
MEP: add DIFF_POLICY BOUNDARY AUDIT card (Draft)

### DIFF
--- a/docs/MEP/cards/DIFF_POLICY_BOUNDARY_AUDIT.md
+++ b/docs/MEP/cards/DIFF_POLICY_BOUNDARY_AUDIT.md
@@ -1,0 +1,10 @@
+<!-- BEGIN: DIFF_POLICY_BOUNDARY_AUDIT (MEP) -->
+## CARD: DIFF_POLICY / BOUNDARY AUDIT（差分運用・境界監査）  [Draft]
+
+### 基本
+- 大置換・全文書き換えは禁止。更新は **差分（最小パッチ）** を原則とする。
+
+### 境界監査（最小）
+- BEGIN/END は必ず対で存在し、片側欠損は DIRTY（停止）。
+- 同一BEGINの重複定義は禁止（検出したらNG）。
+<!-- END: DIFF_POLICY_BOUNDARY_AUDIT (MEP) -->


### PR DESCRIPTION
変更内容:
- docs/MEP/cards/DIFF_POLICY_BOUNDARY_AUDIT.md を新規追加（1ファイル）

形式:
- Markdown Card Block
- BEGIN/END 境界あり
- 状態: [Draft]

根拠:
- docs/MEP/MEP_BUNDLE.md（最新BUNDLE_VERSION）

意図:
- 差分最小パッチ運用と境界監査の最小ルールをカードとして固定