### PR TITLE
Fix: Gate(min5) scope guard quote-stripping

### DIFF
--- a/.github/workflows/mep_gate_min5.yml
+++ b/.github/workflows/mep_gate_min5.yml
@@ -43,7 +43,9 @@ jobs:
           changed="$(git diff --name-only "$base"...HEAD || true)"
           if [ -n "$changed" ]; then
             echo "$changed" | while IFS= read -r f; do
-              case "$f" in
+              # strip accidental quotes around filename
+f="${f#\"}"; f="${f%\"}"
+case "$f" in
                 business/*|seed/*|docs/MEP/*|mep/*|.github/workflows/*|tools/*|platform/MEP/03_BUSINESS/*) : ;;
                 *) echo "ERROR: out-of-scope change: $f"; exit 1 ;;
               esac
@@ -68,3 +70,4 @@ jobs:
           PY
 
           echo "OK: Gate(min5) passed"
+


### PR DESCRIPTION
変更内容:
- scope guard の判定前に changed file の先頭末尾の " を除去（最小パッチ）

根拠:
- Gate(min5) failure: out-of-scope change が \"platform/MEP/03_BUSINESS/.../business_spec.md\" 形式で出力され一致しなかった