### PR TITLE
Fix: Gate(min5) scope guard quote-stripping indentation

### DIFF
--- a/.github/workflows/mep_gate_min5.yml
+++ b/.github/workflows/mep_gate_min5.yml
@@ -43,7 +43,7 @@ jobs:
           changed="$(git diff --name-only "$base"...HEAD || true)"
           if [ -n "$changed" ]; then
             echo "$changed" | while IFS= read -r f; do
-              # strip accidental quotes around filename
+# strip accidental quotes around filename
 f="${f#\"}"; f="${f%\"}"
 case "$f" in
                 business/*|seed/*|docs/MEP/*|mep/*|.github/workflows/*|tools/*|platform/MEP/03_BUSINESS/*) : ;;


### PR DESCRIPTION
変更内容:
- mep_gate_min5.yml の scope guard で、quote-stripping 行のインデントを case 行に揃える（最小差分）

根拠:
- PR #994 で quote-stripping は導入済み
- YAML内のシェルブロック可読性/安全性のため整列のみ実施