### PR TITLE
Fix: Gate(min5) allow docs/MEP_SUB scope

### DIFF
--- a/.github/workflows/mep_gate_min5.yml
+++ b/.github/workflows/mep_gate_min5.yml
@@ -46,7 +46,7 @@ jobs:
 # strip accidental quotes around filename
 f="${f#\"}"; f="${f%\"}"
 case "$f" in
-                business/*|seed/*|docs/MEP/*|mep/*|.github/workflows/*|tools/*|platform/MEP/03_BUSINESS/*) : ;;
+                business/*|seed/*|docs/MEP/*|docs/MEP_SUB/*|mep/*|.github/workflows/*|tools/*|platform/MEP/03_BUSINESS/*) : ;;
                 *) echo "ERROR: out-of-scope change: $f"; exit 1 ;;
               esac
             done
@@ -70,4 +70,5 @@ case "$f" in
           PY
 
           echo "OK: Gate(min5) passed"
+
 


### PR DESCRIPTION
変更内容:
- mep_gate_min5.yml の scope guard に docs/MEP_SUB/* を追加（最小パッチ）

意図:
- EVIDENCE 子MEP Bundled（docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md）初回生成の前提を整える