### PR TITLE
MEP_SUB(EVIDENCE): init empty Bundled

### DIFF
--- a/docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md
+++ b/docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md
@@ -1,0 +1,4 @@
+BUNDLE_VERSION = v0.0.0+init
+
+### 証跡ログ（自動貼り戻し）
+# （初回は空。以降は EVIDENCE 子MEP writeback により追記される）


### PR DESCRIPTION
変更内容:
- docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md を初回生成（空Bundled）

意図:
- EVIDENCE 子MEPの確定点を物理的に分離
- 親MEPとは独立した Bundled を持たせる初期化