### PR TITLE
tools: split diagnose and dispatch (default no dispatch)

### DIFF
--- a/tools/mep_diagnose_writeback.ps1
+++ b/tools/mep_diagnose_writeback.ps1
@@ -5,7 +5,8 @@ param(
   [string]$WorkflowFile = "mep_writeback_bundle_dispatch.yml",
   [string]$Ref = "main",
   [int]$TimeoutSec = 900,
-  [int]$PollSec = 5
+  [int]$PollSec = 5,
+  [switch]$Dispatch
 )
 
 Set-StrictMode -Version Latest
@@ -22,33 +23,40 @@ function Ensure-GhAuth {
 
 Require-Cmd "gh"; Require-Cmd "git"; Ensure-GhAuth
 
-Write-Host "=== DISPATCH ==="
-Write-Host "repo=$Repo workflow=$WorkflowFile ref=$Ref pr_number=$PrNumber"
-& gh workflow run $WorkflowFile -R $Repo --ref $Ref -f pr_number=$PrNumber | Out-Host
+# 既定：dispatchしない（PR量産を防ぐ）
+if ($Dispatch) {
+  Write-Host "=== DISPATCH (explicit) ==="
+  Write-Host "repo=$Repo workflow=$WorkflowFile ref=$Ref pr_number=$PrNumber"
+  & gh workflow run $WorkflowFile -R $Repo --ref $Ref -f pr_number=$PrNumber | Out-Host
 
-$runId = (& gh run list -R $Repo --workflow $WorkflowFile -L 1 --json databaseId --jq '.[0].databaseId' 2>&1 | Out-String).Trim()
-if (-not $runId) { throw "Failed to get latest run databaseId" }
-Write-Host "latest_run_databaseId=$runId"
+  $runId = (& gh run list -R $Repo --workflow $WorkflowFile -L 1 --json databaseId --jq '.[0].databaseId' 2>&1 | Out-String).Trim()
+  if (-not $runId) { throw "Failed to get latest run databaseId" }
+  Write-Host "latest_run_databaseId=$runId"
 
-$deadline = (Get-Date).AddSeconds($TimeoutSec)
-while ($true) {
-  $statusJson = (& gh run view $runId -R $Repo --json status,conclusion,startedAt,updatedAt,headSha,url --jq '{status:.status,conclusion:.conclusion,startedAt:.startedAt,updatedAt:.updatedAt,headSha:.headSha,url:.url}' 2>&1 | Out-String)
-  $obj = $null; try { $obj = $statusJson | ConvertFrom-Json } catch { }
-  if ($obj -and $obj.status -notin @("in_progress","queued")) {
-    Write-Host "=== RUN RESULT ==="
-    $statusJson.Trim() | Write-Host
-    break
+  $deadline = (Get-Date).AddSeconds($TimeoutSec)
+  while ($true) {
+    $statusJson = (& gh run view $runId -R $Repo --json status,conclusion,startedAt,updatedAt,headSha,url --jq '{status:.status,conclusion:.conclusion,startedAt:.startedAt,updatedAt:.updatedAt,headSha:.headSha,url:.url}' 2>&1 | Out-String)
+    $obj = $null; try { $obj = $statusJson | ConvertFrom-Json } catch { }
+    if ($obj -and $obj.status -notin @("in_progress","queued")) {
+      Write-Host "=== RUN RESULT ==="
+      $statusJson.Trim() | Write-Host
+      break
+    }
+    if ((Get-Date) -gt $deadline) { throw "Timeout waiting run completion. runId=$runId" }
+    Start-Sleep -Seconds $PollSec
   }
-  if ((Get-Date) -gt $deadline) { throw "Timeout waiting run completion. runId=$runId" }
-  Start-Sleep -Seconds $PollSec
+
+  Write-Host "=== RUN LOG (tail 200) ==="
+  $log = (& gh run view $runId -R $Repo --log 2>&1 | Out-String)
+  ($log -split "`r?`n" | Select-Object -Last 200) -join "`n" | Write-Host
+} else {
+  Write-Host "=== DIAGNOSE ONLY (no dispatch) ==="
+  Write-Host "Dispatch is disabled. Reading latest Bundled only."
+  git fetch origin $Ref | Out-Host
 }
 
-Write-Host "=== RUN LOG (tail 200) ==="
-$log = (& gh run view $runId -R $Repo --log 2>&1 | Out-String)
-($log -split "`r?`n" | Select-Object -Last 200) -join "`n" | Write-Host
-
+# 共通：Bundled差分/PR行抽出（dispatch有無に関わらず実施）
 Write-Host "=== BUNDLED DIFF (origin/$Ref) ==="
-git fetch origin $Ref | Out-Host
 $bundledPath = "docs/MEP/MEP_BUNDLE.md"
 git diff --name-only HEAD..origin/$Ref -- $bundledPath | Out-Host
 git diff HEAD..origin/$Ref -- $bundledPath | Out-Host
@@ -62,4 +70,5 @@ if ($PrNumber -eq 0) {
 } else {
   ($lines | Where-Object { $_ -like ("*PR #{0} |*" -f $PrNumber) }) | ForEach-Object { $_ } | Write-Host
 }
+
 Write-Host "=== DONE ==="


### PR DESCRIPTION
Default is diagnose-only to prevent auto writeback PR spam. Use -Dispatch to run workflow.