### PR TITLE
fix(yorisoidou): align scope fence to actual BUSINESS dir

### DIFF
--- a/businesses/yorisoidou/TARGETS.yml
+++ b/businesses/yorisoidou/TARGETS.yml
@@ -1,10 +1,14 @@
 # Allowed targets for biz_key=yorisoidou (scope fence)
 allow:
-  - "/**"
+  - "platform/MEP/03_BUSINESS/繧医ｊ縺昴＞蝣・/**"
   - "business/**"
 deny:
   - ".github/**"
   - "platform/MEP/01_CORE/**"
+<<<<<<< HEAD
   - "docs/MEP/MEP_BUNDLE.md"
 
 
+=======
+  - "docs/MEP/MEP_BUNDLE.md"
+>>>>>>> parent of 4c65241 (Merge pull request #1062 from Osuu-ops/fix/yorisoidou-scope-fence-path)

--- a/platform/MEP/90_CHANGES/CURRENT_SCOPE.md
+++ b/platform/MEP/90_CHANGES/CURRENT_SCOPE.md
@@ -2,7 +2,7 @@
 
 ## 変更対象（Scope-IN）
 - .github/workflows/required_checks_drift_guard_manual.yml
-- /**
+- platform/MEP/03_BUSINESS/繧医ｊ縺昴＞蝣・/**
 - platform/MEP/90_CHANGES/CURRENT_SCOPE.md
 - .github/workflows/scope_guard_pr.yml
 - .github/workflows/business_packet_guard_pr.yml
@@ -161,6 +161,9 @@
 
 
 
+<<<<<<< HEAD
 
 
 
+=======
+>>>>>>> parent of 4c65241 (Merge pull request #1062 from Osuu-ops/fix/yorisoidou-scope-fence-path)


### PR DESCRIPTION
After reverting PR #1062, align TARGETS/CURRENT_SCOPE from 'よりそい堂/**' to the actual directory name under platform/MEP/03_BUSINESS.