### PR TITLE
docs(evidence): define completion/ops for child MEP bundle

### DIFF
--- a/docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md
+++ b/docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md
@@ -15,3 +15,28 @@ BUNDLE_VERSION = v0.0.0+20260121_185712+main+evidence-child
 - PR #1049 | mergedAt=01/21/2026 15:40:00 | mergeCommit=194a29a256ae05f126a2c158da45dd7785ed056c | BUNDLE_VERSION=v0.0.0+20260122_004000+fix/bundle-refresh-pr1015+evidence-child | audit=OK,WB0000 | acceptance:IN_PROGRESS, Business Packet Guard (PR):IN_PROGRESS, done_check:SUCCESS, enable_auto_merge:IN_PROGRESS, guard:IN_PROGRESS, merge_repair_pr:SKIPPED, self-heal:IN_PROGRESS, semantic-audit-business:IN_PROGRESS, semantic-audit:IN_PROGRESS, suggest:IN_PROGRESS | https://github.com/Osuu-ops/yorisoidou-system/pull/1049
 - PR #1065 | mergedAt=01/21/2026 17:53:21 | mergeCommit=7a498c06bc89d6382867ad4707413d46c0f4af76 | BUNDLE_VERSION=v0.0.0+20260121_183632+main+evidence-child | audit=OK,WB0000 | acceptance:SUCCESS, Business Packet Guard (PR):SUCCESS, Current Scope Format Guard (PR):SUCCESS, done_check:SUCCESS, enable_auto_merge:SUCCESS, merge_repair_pr:SKIPPED, semantic-audit-business:SUCCESS, semantic-audit:SUCCESS, suggest:SUCCESS, Text Integrity Guard (PR):SUCCESS | https://github.com/Osuu-ops/yorisoidou-system/pull/1065
 - PR #1069 | mergedAt=01/21/2026 18:52:40 | mergeCommit=373b1c1891dc947c7387c262aa35ae76c598711b | BUNDLE_VERSION=v0.0.0+20260121_185712+main+evidence-child | audit=OK,WB0000 | acceptance:SUCCESS, Business Packet Guard (PR):SUCCESS, Current Scope Format Guard (PR):SUCCESS, done_check:SUCCESS, enable_auto_merge:SUCCESS, merge_repair_pr:SKIPPED, semantic-audit-business:SUCCESS, semantic-audit:SUCCESS, suggest:SUCCESS, Text Integrity Guard (PR):SUCCESS | https://github.com/Osuu-ops/yorisoidou-system/pull/1069
+## CARD: EVIDENCE / CHILD MEP / COMPLETION
+
+### 目的（この子MEPで何を独立させるか）
+- EVIDENCE（証跡・貼り戻し・監査根拠）を子MEP単位で管理し、親MEP(main)の修正と分離して衝突を避ける。
+
+### 接続と切り離し（運用ルール）
+- 切り離し（独立運用）：
+  - 変更・議論・仕様更新は基本この子MEP配下で完結させる（docs/MEP_SUB/EVIDENCE と businesses/evidence）。
+- 接続（統合 / writeback）：
+  - 証跡の「Bundled への固定」は workflow_dispatch で writeback を回し、生成PRを main にマージする。
+  - evidence writeback は docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md に集約する（現行仕様の範囲で運用）。
+
+### 管理対象（TARGETSと整合）
+- businesses/evidence/TARGETS.yml に列挙された対象が、この子MEPの管理範囲（Scope）になる。
+
+### 成功条件（この子MEPが“完成”と言える状態）
+- [ ] EVIDENCE 子MEPの bundle に「目的 / 接続・切り離し / 管理対象 / 変更手順」が明記されている
+- [ ] Evidence writeback が main 上で再現可能で、生成PRがマージ可能（監査ログが残る）
+- [ ] businesses/evidence/TARGETS.yml が存在し、Scopeが運用できる
+
+### 次にやること（最短）
+1. businesses/evidence/TARGETS.yml の targets を実態に合わせて埋める
+2. EVIDENCEのカード（仕様・運用・監査の粒度）を追加していく
+3. 必要があれば「親MEPへ戻す情報」と「子MEPに留める情報」をルール化する
+


### PR DESCRIPTION
EVIDENCE 子MEPを「完成」に向けて進めるための固定カードを追加。

- 目的（独立運用）
- 接続/切り離し（writeback運用）
- 管理対象（TARGETS整合）
- 成功条件/次のタスク