### PR TITLE
fix(audit): ignore deleted business files in semantic-audit-business

### DIFF
--- a/.github/workflows/mep_semantic_audit.yml
+++ b/.github/workflows/mep_semantic_audit.yml
@@ -69,7 +69,7 @@ jobs:
           set -euo pipefail
           BASE_SHA="${{ github.event.pull_request.base.sha }}"
           HEAD_SHA="${{ github.event.pull_request.head.sha }}"
-          git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- platform/MEP/03_BUSINESS | sort > biz_all.txt || true
+          git diff --name-only --diff-filter=AM "$BASE_SHA" "$HEAD_SHA" -- platform/MEP/03_BUSINESS | sort > biz_all.txt || true
           sed -i 's/^"//; s/"$//' biz_all.txt || true
           cat biz_all.txt | grep -Ei '\.(md|txt|yaml|yml|json)$' | sort > biz_inputs.txt || true
           cat biz_all.txt | grep -F '/master_spec' >> biz_inputs.txt || true


### PR DESCRIPTION
Prevent semantic-audit-business from failing on delete-only PRs by excluding deleted paths from biz_inputs.