### PR TITLE
chore(mep): writeback evidence to Bundled (PR #1104)

### DIFF
--- a/docs/MEP/MEP_BUNDLE.md
+++ b/docs/MEP/MEP_BUNDLE.md
@@ -1,4 +1,4 @@
-BUNDLE_VERSION = v0.0.0+20260122_055822+main+parent
+BUNDLE_VERSION = v0.0.0+20260122_155938+main+parent
 OPS: Bundled writeback is executed via workflow_dispatch (mep_writeback_bundle_dispatch); local runs are for debugging only.
 # MEP_BUNDLE
 SOURCE_CONTEXT: 本ファイルは「MEPの唯一の正（main反映）」を前提に、次チャット開始時の再現性を最大化するための束ね（生成物）である。手編集は原則禁止。更新はゲートを経た反映（PR→main→Bundled）で行う。
@@ -343,6 +343,7 @@ BUSINESS側を構築すると、例外・分岐・用語・台帳参照が急増
 - PR #1092 | mergedAt=01/21/2026 20:39:54 | mergeCommit=8e8b15c2c75c652d5ee7b8ca3fb76e73dd87b81d | BUNDLE_VERSION=v0.0.0+20260122_054030+main+parent | audit=OK,WB0000 | acceptance:SUCCESS, Business Packet Guard (PR):SUCCESS, done_check:SUCCESS, enable_auto_merge:SUCCESS, merge_repair_pr:SKIPPED, semantic-audit-business:SUCCESS, semantic-audit:SUCCESS, suggest:SUCCESS, Text Integrity Guard (PR):SUCCESS | https://github.com/Osuu-ops/yorisoidou-system/pull/1092
 - PR #1096 | mergedAt=01/21/2026 20:44:19 | mergeCommit=777be0edb248330acedb840351b6fb42c8f3a92f | BUNDLE_VERSION=v0.0.0+20260122_054442+main+parent | audit=OK,WB0000 | acceptance:SUCCESS, Business Packet Guard (PR):SUCCESS, done_check:SUCCESS, enable_auto_merge:SUCCESS, merge_repair_pr:SKIPPED, semantic-audit-business:SUCCESS, semantic-audit:SUCCESS, suggest:SUCCESS, Text Integrity Guard (PR):SUCCESS | https://github.com/Osuu-ops/yorisoidou-system/pull/1096
 - PR #1100 | mergedAt=01/21/2026 20:55:20 | mergeCommit=8786069affa07699e7ea7bbcf0e45564709dd408 | BUNDLE_VERSION=v0.0.0+20260122_055822+main+parent | audit=NG,WB2001 | acceptance:SUCCESS, Business Packet Guard (PR):SUCCESS, done_check:SUCCESS, enable_auto_merge:SUCCESS, merge_repair_pr:SKIPPED, semantic-audit-business:FAILURE, semantic-audit:SUCCESS, suggest:SUCCESS, Text Integrity Guard (PR):SUCCESS | https://github.com/Osuu-ops/yorisoidou-system/pull/1100
+- PR #1104 | mergedAt=01/22/2026 06:54:51 | mergeCommit=7a285d7dc80effaa3612e517ba8fa7c50609228c | BUNDLE_VERSION=v0.0.0+20260122_155938+main+parent | audit=OK,WB0000 | acceptance:SUCCESS, Business Packet Guard (PR):SUCCESS, done_check:SUCCESS, enable_auto_merge:SUCCESS, merge_repair_pr:SKIPPED, semantic-audit-business:SUCCESS, semantic-audit:SUCCESS, suggest:SUCCESS, Text Integrity Guard (PR):SUCCESS | https://github.com/Osuu-ops/yorisoidou-system/pull/1104
 ## CARD: DIFF_POLICY / BOUNDARY AUDIT（差分運用・境界監査）  [Draft]
 
 ### 基本


### PR DESCRIPTION
Purpose
- Auto writeback evidence to Bundled (MEP_BUNDLE.md) as specified by EVIDENCE/WRITEBACK SPEC.

Evidence (source)
- latest merged PR: #1104
- mergeCommit: 7a285d7dc80effaa3612e517ba8fa7c50609228c
- BUNDLE_VERSION: v0.0.0+20260122_155938+main+parent

Notes
- Append-only evidence log; de-dup by PR number.