### PR TITLE
chore(mep): writeback evidence to Bundled (PR #1113)

### DIFF
--- a/docs/MEP/MEP_BUNDLE.md
+++ b/docs/MEP/MEP_BUNDLE.md
@@ -1,4 +1,4 @@
-BUNDLE_VERSION = v0.0.0+20260123_121106+main+parent
+BUNDLE_VERSION = v0.0.0+20260123_121245+main+parent
 OPS: Bundled writeback is executed via workflow_dispatch (mep_writeback_bundle_dispatch); local runs are for debugging only.
 # MEP_BUNDLE
 SOURCE_CONTEXT: 本ファイルは「MEPの唯一の正（main反映）」を前提に、次チャット開始時の再現性を最大化するための束ね（生成物）である。手編集は原則禁止。更新はゲートを経た反映（PR→main→Bundled）で行う。
@@ -346,6 +346,7 @@ BUSINESS側を構築すると、例外・分岐・用語・台帳参照が急増
 - PR #1104 | mergedAt=01/22/2026 06:54:51 | mergeCommit=7a285d7dc80effaa3612e517ba8fa7c50609228c | BUNDLE_VERSION=v0.0.0+20260122_155938+main+parent | audit=OK,WB0000 | acceptance:SUCCESS, Business Packet Guard (PR):SUCCESS, done_check:SUCCESS, enable_auto_merge:SUCCESS, merge_repair_pr:SKIPPED, semantic-audit-business:SUCCESS, semantic-audit:SUCCESS, suggest:SUCCESS, Text Integrity Guard (PR):SUCCESS | https://github.com/Osuu-ops/yorisoidou-system/pull/1104
 - PR #1105 | mergedAt=01/22/2026 06:59:51 | mergeCommit=803534c0cb99d8161b3c758a6520e93f1e50ab35 | BUNDLE_VERSION=v0.0.0+20260122_082601+main+parent | audit=OK,WB0000 | acceptance:SUCCESS, Business Packet Guard (PR):SUCCESS, done_check:SUCCESS, enable_auto_merge:SUCCESS, guard:SUCCESS, merge_repair_pr:SKIPPED, self-heal:SUCCESS, semantic-audit-business:SUCCESS, semantic-audit:SUCCESS, suggest:SUCCESS, Text Integrity Guard (PR):SUCCESS | https://github.com/Osuu-ops/yorisoidou-system/pull/1105
 - PR #1111 | mergedAt=01/23/2026 12:11:01 | mergeCommit=ef781f1d0d92f4968a45bce7ee028c9d73f3962f | BUNDLE_VERSION=v0.0.0+20260123_121106+main+parent | audit=OK,WB0000 | acceptance:SUCCESS, Business Packet Guard (PR):IN_PROGRESS, done_check:SUCCESS, enable_auto_merge:SUCCESS, merge_repair_pr:SKIPPED, semantic-audit-business:SUCCESS, semantic-audit:IN_PROGRESS, suggest:SUCCESS, Text Integrity Guard (PR):SUCCESS | https://github.com/Osuu-ops/yorisoidou-system/pull/1111
+- PR #1113 | mergedAt=01/23/2026 12:11:57 | mergeCommit=1da719e6952e4f7d390fdf3b3763b02df22a7bbe | BUNDLE_VERSION=v0.0.0+20260123_121245+main+parent | audit=OK,WB0000 | acceptance:SUCCESS, Business Packet Guard (PR):SUCCESS, Current Scope Format Guard (PR):SUCCESS, done_check:SUCCESS, enable_auto_merge:SUCCESS, merge_repair_pr:SKIPPED, semantic-audit-business:SUCCESS, semantic-audit:SUCCESS, suggest:SUCCESS, Text Integrity Guard (PR):SUCCESS | https://github.com/Osuu-ops/yorisoidou-system/pull/1113
 ## CARD: DIFF_POLICY / BOUNDARY AUDIT（差分運用・境界監査）  [Draft]
 
 ### 基本


### PR DESCRIPTION
Purpose
- Auto writeback evidence to Bundled (MEP_BUNDLE.md) as specified by EVIDENCE/WRITEBACK SPEC.

Evidence (source)
- latest merged PR: #1113
- mergeCommit: 1da719e6952e4f7d390fdf3b3763b02df22a7bbe
- BUNDLE_VERSION: v0.0.0+20260123_121245+main+parent

Notes
- Append-only evidence log; de-dup by PR number.