### PR TITLE
chore(mep): writeback evidence to Bundled (PR #1122)

### DIFF
--- a/docs/MEP/MEP_BUNDLE.md
+++ b/docs/MEP/MEP_BUNDLE.md
@@ -1,4 +1,4 @@
-BUNDLE_VERSION = v0.0.0+20260123_122004+main+parent
+BUNDLE_VERSION = v0.0.0+20260123_122404+main+parent
 OPS: Bundled writeback is executed via workflow_dispatch (mep_writeback_bundle_dispatch); local runs are for debugging only.
 # MEP_BUNDLE
 SOURCE_CONTEXT: 本ファイルは「MEPの唯一の正（main反映）」を前提に、次チャット開始時の再現性を最大化するための束ね（生成物）である。手編集は原則禁止。更新はゲートを経た反映（PR→main→Bundled）で行う。
@@ -350,6 +350,7 @@ BUSINESS側を構築すると、例外・分岐・用語・台帳参照が急増
 - PR #1114 | mergedAt=01/23/2026 12:12:56 | mergeCommit=15def009a1ccefd16387d9788b6cf4b1296ff721 | BUNDLE_VERSION=v0.0.0+20260123_121341+main+parent | audit=OK,WB0000 | acceptance:SUCCESS, Business Packet Guard (PR):SUCCESS, done_check:SUCCESS, enable_auto_merge:SUCCESS, guard:SUCCESS, merge_repair_pr:SKIPPED, self-heal:SUCCESS, semantic-audit-business:SUCCESS, semantic-audit:SUCCESS, suggest:SUCCESS, Text Integrity Guard (PR):SUCCESS | https://github.com/Osuu-ops/yorisoidou-system/pull/1114
 - PR #1116 | mergedAt=01/23/2026 12:14:41 | mergeCommit=1f909dadded1479add1e94480c9303659b0bfb37 | BUNDLE_VERSION=v0.0.0+20260123_121458+main+parent | audit=OK,WB0000 | acceptance:SUCCESS, Business Packet Guard (PR):SUCCESS, done_check:SUCCESS, enable_auto_merge:SUCCESS, integration-compiler:SUCCESS, merge_repair_pr:SKIPPED, semantic-audit-business:SUCCESS, semantic-audit:SUCCESS, suggest:SUCCESS, Text Integrity Guard (PR):SUCCESS | https://github.com/Osuu-ops/yorisoidou-system/pull/1116
 - PR #1120 | mergedAt=01/23/2026 12:20:03 | mergeCommit=2696f3bfb5812c9db590966cdaab71dc0ad5377f | BUNDLE_VERSION=v0.0.0+20260123_122004+main+parent | audit=OK,WB0000 | acceptance:QUEUED, Business Packet Guard (PR):QUEUED, done_check:QUEUED, enable_auto_merge:QUEUED, guard:QUEUED, merge_repair_pr:SKIPPED, self-heal:QUEUED, semantic-audit-business:QUEUED, semantic-audit:QUEUED, suggest:QUEUED, Text Integrity Guard (PR):QUEUED | https://github.com/Osuu-ops/yorisoidou-system/pull/1120
+- PR #1122 | mergedAt=01/23/2026 12:23:05 | mergeCommit=50893c93152ac1ccc54c1565285d8043a7745b6b | BUNDLE_VERSION=v0.0.0+20260123_122404+main+parent | audit=OK,WB0000 | acceptance:SUCCESS, Business Packet Guard (PR):SUCCESS, done_check:SUCCESS, enable_auto_merge:SUCCESS, guard:SUCCESS, merge_repair_pr:SKIPPED, self-heal:SUCCESS, semantic-audit-business:SUCCESS, semantic-audit:SUCCESS, suggest:SUCCESS, Text Integrity Guard (PR):SUCCESS | https://github.com/Osuu-ops/yorisoidou-system/pull/1122
 ## CARD: DIFF_POLICY / BOUNDARY AUDIT（差分運用・境界監査）  [Draft]
 
 ### 基本


### PR DESCRIPTION
Purpose
- Auto writeback evidence to Bundled (MEP_BUNDLE.md) as specified by EVIDENCE/WRITEBACK SPEC.

Evidence (source)
- latest merged PR: #1122
- mergeCommit: 50893c93152ac1ccc54c1565285d8043a7745b6b
- BUNDLE_VERSION: v0.0.0+20260123_122404+main+parent

Notes
- Append-only evidence log; de-dup by PR number.