### PR TITLE
Fix: keep CMEP 02_MEP_SCRIPTS with text placeholder

### DIFF
--- a/platform/MEP/03_BUSINESS/yorisoidou/CMEP/02_MEP_SCRIPTS/KEEP.md
+++ b/platform/MEP/03_BUSINESS/yorisoidou/CMEP/02_MEP_SCRIPTS/KEEP.md
@@ -1,0 +1,2 @@
+# placeholder
+


### PR DESCRIPTION
Add KEEP.md so 02_MEP_SCRIPTS exists without triggering BUSINESS binary_guard.