### PR TITLE
fix(ci): bypass gate for docs-only changes

### DIFF
--- a/.github/workflows/mep_gate_pr.yml
+++ b/.github/workflows/mep_gate_pr.yml
@@ -2,6 +2,8 @@ name: MEP Gate (PR)
 
 on:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Temporarily skip gate workflows for docs-only changes to unblock Bundled writeback.