### PR TITLE
[yorisoidou] Adopt: artifacts policy + PR audit script fix

### DIFF
--- a/docs/MEP/OPS/MEP_ARTIFACTS_POLICY.md
+++ b/docs/MEP/OPS/MEP_ARTIFACTS_POLICY.md
@@ -1,0 +1,19 @@
+# MEP Artifacts Tracking Policy (Adopted)
+
+This repository intentionally tracks a small subset of generated artifacts for auditability and reproducibility.
+
+## Tracked (canonical)
+The following paths are treated as canonical artifacts and are allowed to be committed:
+- .mep/allowlists/** (hash allowlists)
+- .mep/artifacts/** (artifact snapshots)
+
+## Not tracked (must stay out of git)
+The following are runtime / local-only outputs and must not be committed:
+- .mep/tmp/**
+- .mep-selftest/**
+- **/__pycache__/**, **/*.pyc, **/*.pyo
+
+## Rationale
+- Canonical artifacts: small, deterministic, used for verification/audit.
+- Local outputs: noisy, machine-specific, and cause Scope Guard / diff pollution.
+

--- a/tools/mep_pr_audit_merge.ps1
+++ b/tools/mep_pr_audit_merge.ps1
@@ -1,0 +1,106 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+param(
+  [Parameter(Mandatory=$true)][int]$PrNumber,
+  [Parameter()][switch]$DoMerge
+)
+
+function Normalize([string]$val){
+  if ([string]::IsNullOrWhiteSpace($val)) { return "(RUNNING/UNKNOWN)" }
+  return $val.ToUpperInvariant()
+}
+
+function Block([string]$msg){
+  Write-Host ""
+  Write-Host ("RESULT: AUDIT_BLOCKED - {0}" -f $msg)
+  Write-Host ""
+  return $false
+}
+
+function Ok([string]$msg){
+  Write-Host ""
+  Write-Host ("RESULT: {0}" -f $msg)
+  Write-Host ""
+  return $true
+}
+
+git rev-parse --show-toplevel | Out-Null
+gh auth status | Out-Null
+
+$base = "main"
+$j = gh pr view $PrNumber --json number,state,baseRefName,headRefName,title,url,mergeable,statusCheckRollup,files,commits,mergedAt,mergeCommit | ConvertFrom-Json
+
+Write-Host ""
+Write-Host ("=== PR #{0} AUDIT ===" -f $j.number)
+Write-Host ("URL       : {0}" -f $j.url)
+Write-Host ("TITLE     : {0}" -f $j.title)
+Write-Host ("STATE     : {0}" -f $j.state)
+Write-Host ("BASE      : {0}" -f $j.baseRefName)
+Write-Host ("HEAD      : {0}" -f $j.headRefName)
+Write-Host ("MERGEABLE : {0}" -f $j.mergeable)
+Write-Host ("FILES     : {0}" -f ($j.files.Count))
+Write-Host ("COMMITS   : {0}" -f ($j.commits.Count))
+if ($j.mergedAt) { Write-Host ("MERGEDAT  : {0}" -f $j.mergedAt) }
+if ($j.mergeCommit -and $j.mergeCommit.oid) { Write-Host ("MERGECOM  : {0}" -f $j.mergeCommit.oid) }
+Write-Host ""
+
+# State split
+if ($j.state -eq "MERGED") {
+  git fetch origin | Out-Null
+  git switch $base | Out-Null
+  git pull --ff-only origin $base | Out-Null
+
+  # best-effort cleanup for head branch (if still exists)
+  $head = $j.headRefName
+  if (-not [string]::IsNullOrWhiteSpace($head)) {
+    try { gh api "repos/Osuu-ops/yorisoidou-system/git/refs/heads/$head" | Out-Null; gh api -X DELETE "repos/Osuu-ops/yorisoidou-system/git/refs/heads/$head" | Out-Null } catch { }
+    try { if ((git branch --list $head)) { git branch -D $head | Out-Null } } catch { }
+  }
+
+  Ok "POST_MERGE_AUDIT_DONE"
+  return
+}
+
+if ($j.state -ne "OPEN") { Block "PR is not OPEN/MERGED."; return }
+
+# Hard gates
+if ($j.baseRefName -ne $base) { Block "baseRefName is not 'main'."; return }
+if ($j.mergeable -ne "MERGEABLE") { Block ("mergeable={0}" -f $j.mergeable); return }
+
+# Checks
+$rollup = @($j.statusCheckRollup)
+$failed = @()
+$pending = @()
+
+Write-Host "=== CHECKS ==="
+foreach ($s in $rollup) {
+  $name = $s.name
+  $conclusion = $null
+  if ($s.PSObject.Properties.Name -contains "conclusion") { $conclusion = $s.conclusion }
+  $state = $null
+  if ($s.PSObject.Properties.Name -contains "state") { $state = $s.state }
+
+  $raw = $(if($conclusion){$conclusion}elseif($state){$state}else{""})
+  $val = Normalize $raw
+  Write-Host ("- {0}: {1}" -f $name, $val)
+
+  if ($val -eq "(RUNNING/UNKNOWN)" -or $val -in @("PENDING","QUEUED","IN_PROGRESS")) { $pending += $name; continue }
+  if ($val -in @("SUCCESS","SKIPPED","NEUTRAL")) { continue }
+  $failed += ("{0}={1}" -f $name, $val)
+}
+Write-Host ""
+
+if ($pending.Count -gt 0) { Block ("checks pending/running: " + ($pending -join ", ")); return }
+if ($failed.Count -gt 0)  { Block ("checks not acceptable: " + ($failed -join ", ")); return }
+
+Write-Host "=== FILES CHANGED ==="
+foreach ($f in $j.files) { Write-Host ("- {0}" -f $f.path) }
+Write-Host ""
+
+if (-not $DoMerge) { Ok "AUDIT_PASS"; return }
+
+Write-Host "AUDIT PASS: Proceeding to merge..."
+Write-Host ""
+gh pr merge $PrNumber --merge --delete-branch
+Ok "MERGED"


### PR DESCRIPTION
A-1 Adopted: track canonical .mep artifacts (allowlists/artifacts); keep tmp/selftest/pyc out of git.

B Adopted: adds tools/mep_pr_audit_merge.ps1
 - OPEN => hard-gated audit; optional merge only if DoMerge
 - MERGED => post-merge audit only; no false PASS->merge flow
 - BLOCKED => returns immediately; fixed check normalization