### PR TITLE
MEP: make write_handoff single-PR (append into writeback-bundle)

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch.yml
@@ -40,34 +40,22 @@ jobs:
           GH_TOKEN: ${{ secrets.MEP_PR_TOKEN }}
         run: |
 
-          # 直近の auto/writeback-bundle_* PR を拾う（この run が作った直近が基本的に先頭になる）
-          $b = gh pr list --state open --limit 20 --json number,headRefName,createdAt `
-            | ConvertFrom-Json `
-            | Where-Object { name: MEP Writeback Bundle (Evidence)
+          # Pick latest open auto/writeback-bundle_* PR (created by this run)
+          $b = gh pr list --state open --limit 50 --json number,headRefName,createdAt |
+            ConvertFrom-Json |
+            Where-Object { $_.headRefName -like 'auto/writeback-bundle_*' } |
+            Sort-Object createdAt -Descending |
+            Select-Object -First 1
 
-on:
-  workflow_dispatch:
-    inputs:
-      pr_number:
-        description: 'PR number to write back (optional; 0 = auto latest merged PR)'
-        required: false
-        default: '0'
-      write_handoff:
-        description: 'Generate+Guard+Writeback HANDOFF_NEXT into Bundled'
-        required: false
-        default: 'false'
+          if (-not $b) { throw 'No open auto/writeback-bundle_* PR found.' }
 
-permissions:
-  contents: write
-  pull-requests: write
+          Write-Output ("[INFO] bundle PR #{0} head={1}" -f $b.number, $b.headRefName)
 
-jobs:
-  writeback:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+          git fetch origin $b.headRefName | Out-Null
+          git checkout -B $b.headRefName ("origin/" + $b.headRefName) | Out-Null
+          git rev-parse --abbrev-ref HEAD
+
+          pwsh -NoProfile -File tools/mep_writeback_handoff.ps1 -CI
       - name: Configure git identity
         shell: bash
         run: |
@@ -84,6 +72,21 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.MEP_PR_TOKEN }}
         run: |
+          # Pick latest open auto/writeback-bundle_* PR (created by this run)
+          $b = gh pr list --state open --limit 50 --json number,headRefName,createdAt |
+            ConvertFrom-Json |
+            Where-Object { $_.headRefName -like 'auto/writeback-bundle_*' } |
+            Sort-Object createdAt -Descending |
+            Select-Object -First 1
+
+          if (-not $b) { throw 'No open auto/writeback-bundle_* PR found.' }
+
+          Write-Output ("[INFO] bundle PR #{0} head={1}" -f $b.number, $b.headRefName)
+
+          git fetch origin $b.headRefName | Out-Null
+          git checkout -B $b.headRefName ("origin/" + $b.headRefName) | Out-Null
+          git rev-parse --abbrev-ref HEAD
+
           pwsh -NoProfile -File tools/mep_writeback_handoff.ps1 -CI
 
       - name: Repair Evidence Log (fill/remove empty mergedAt/mergeCommit)


### PR DESCRIPTION
Workflow checks out latest auto/writeback-bundle_* PR branch before running mep_writeback_handoff.ps1 -CI, so HANDOFF_NEXT appends into the same PR.