### PR TITLE
Bundled: FIXED_OPERATIONS (one-block PowerShell rule)

### DIFF
--- a/docs/MEP/MEP_BUNDLE.md
+++ b/docs/MEP/MEP_BUNDLE.md
@@ -739,13 +739,18 @@ Bundled 本文に基づき、
 - NG回収：WB2001 の FAILURE/NG を解消し audit=OK に収束
 <!-- END: HANDOFF_NEXT (MEP) -->
 
+## FIXED_OPERATIONS
 
+### CARD: ONE_BLOCK_POWERSHELL_OPERATION [Adopted]
 
-
-
-
-
-
-
-
+- Purpose:
+  - AI が人間に要求する操作は **PowerShell の単一コードブロックのみ**に固定する。
+- Rule:
+  - 人間に対して複数ステップ・対話的操作・分割実行を要求してはならない。
+  - 例外は AI が物理的に不可能な行為（権限付与・レビュー・承認）のみ。
+- Canonical Operation:
+  - `tools/yorisoidou/run-runtime-selftest.ps1`
+- Usage:
+  - 新チャット開始時、AI は本 CARD を前提として振る舞う。
+  - 本 CARD に反する指示は **無効**。
 


### PR DESCRIPTION
## What
Add Bundled-fixed rule: AI must request only ONE PowerShell code block from human (except unavoidable approvals).

## Where
docs/MEP/MEP_BUNDLE.md

## Why
Reduce manual operations; make rule discoverable from Bundled for every new chat.