### PR TITLE
chore(mep): wire Pre-Gate into entry

### DIFF
--- a/tools/mep_entry.ps1
+++ b/tools/mep_entry.ps1
@@ -1,0 +1,52 @@
+<#
+MEP Entry (入口)
+- Pre-Gate を先に通す
+- その後、既存の MEP 実行スクリプトがあれば自動検出して実行する
+規約:
+- Pre-Gate NG: exit 2
+- Pre-Gate OK + MEP runner OK: exit 0
+- Tooling error: exit 1
+#>
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Boom([string]$m){ Write-Error $m; exit 1 }
+function Info([string]$m){ Write-Host "[ENTRY] $m" -ForegroundColor Cyan }
+
+try {
+  $root = (git rev-parse --show-toplevel 2>$null)
+  if (-not $root) { Boom "Not in a git repo." }
+  Set-Location $root
+
+  $pregate = Join-Path $root "tools/mep_pregate.ps1"
+  if (!(Test-Path $pregate)) { Boom "Missing: tools/mep_pregate.ps1" }
+
+  Info "Running Pre-Gate..."
+  & $pregate
+  $pg = $LASTEXITCODE
+  if ($pg -ne 0) { exit $pg }
+
+  $toolsDir = Join-Path $root "tools"
+  $runner = $null
+  $preferred = @((Join-Path $toolsDir "mep_autopilot.ps1"), (Join-Path $toolsDir "mep_gate.ps1"))
+  foreach ($p in $preferred) { if (Test-Path $p) { $runner = $p; break } }
+
+  if (-not $runner -and (Test-Path $toolsDir)) {
+    $cands = Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
+      Where-Object { $_.Name -match "mep_(gate|runner|autopilot)" -and $_.Name -notmatch "entry|pregate" } |
+      Sort-Object Name
+    if ($cands.Count -gt 0) { $runner = $cands[0].FullName }
+  }
+
+  if ($runner) {
+    Info ("Running MEP runner: " + (Split-Path $runner -Leaf))
+    & $runner
+    exit $LASTEXITCODE
+  } else {
+    Info "No MEP runner found. Pre-Gate OK only."
+    exit 0
+  }
+}
+catch {
+  Boom $_.Exception.Message
+}

--- a/tools/mep_pregate.ps1
+++ b/tools/mep_pregate.ps1
@@ -1,0 +1,55 @@
+<#
+MEP Pre-Gate (入口の手前)
+目的:
+- MEP本体へ投入する前に、入力/状態が「承認①②済」の前提を満たすかを局所的に検査する。
+- 既存の read-only 監査スクリプトがあれば自動検出して実行する（存在しなければ最低限チェックのみでFAILしない）。
+出力規約:
+- OK: exit 0
+- NG: exit 2（入力/状態がPre-Gate不適合）
+- TOOLING ERROR: exit 1（実行環境/スクリプト破損）
+#>
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Fail([string]$m){ Write-Error $m; exit 2 }
+function Boom([string]$m){ Write-Error $m; exit 1 }
+function Info([string]$m){ Write-Host "[PREGATE] $m" -ForegroundColor Cyan }
+
+try {
+  $root = (git rev-parse --show-toplevel 2>$null)
+  if (-not $root) { Boom "Not in a git repo." }
+  Set-Location $root
+
+  # Pre-GateはBundledに依存しない運用も可能だが、ここでは「MEP投入前の最低条件」として存在確認だけ行う
+  $bundled = Join-Path $root "docs/MEP/MEP_BUNDLE.md"
+  if (!(Test-Path $bundled)) { Info "Bundled not found (docs/MEP/MEP_BUNDLE.md). Continuing with minimal checks." }
+
+  $status = (git status --porcelain)
+  if ($status) { Fail "Working tree is dirty. Commit/stash before entering MEP." }
+
+  $toolsDir = Join-Path $root "tools"
+  $candidates = @()
+  if (Test-Path $toolsDir) {
+    $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
+      Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
+      Sort-Object Name
+  }
+
+  if ($candidates.Count -gt 0) {
+    Info "Found read-only audit candidates:"
+    $candidates | ForEach-Object { Write-Host ("  - " + $_.FullName) }
+    foreach ($c in $candidates) {
+      Info ("Running: " + $c.Name)
+      & $c.FullName
+      if ($LASTEXITCODE -ne 0) { Fail ("Audit script failed (exit=" + $LASTEXITCODE + "): " + $c.Name) }
+    }
+  } else {
+    Info "No read-only audit script found. Minimal checks only."
+  }
+
+  Info "OK"
+  exit 0
+}
+catch {
+  Boom $_.Exception.Message
+}


### PR DESCRIPTION
目的:
- 入口(Entry)の手前にPre-Gateを恒常接続する（入口→Pre-Gate→MEP）。

変更:
- tools/mep_pregate.ps1: Pre-Gate（作業ツリー汚染防止＋既存read-only監査の自動検出→実行）
- tools/mep_entry.ps1: Entry（Pre-Gate実行後、既存MEP runnerを自動検出→実行）

補足:
- Bundledは「確定の根拠化」で必要。Pre-Gate自体は実装上はBundled非依存でも動く。