### PR TITLE
chore(mep): MEP_AUTO runs read-only suite (safe)

### DIFF
--- a/.mep/CURRENT_STAGE.txt
+++ b/.mep/CURRENT_STAGE.txt
@@ -1,0 +1,1 @@
+PRE_GATE


### PR DESCRIPTION
目的:
- Pre-Gate（tools/pre_gate.ps1）通過後の MEP_AUTO を「read-only監査のみ」に固定し、安全に回せる段階を作る。

変更:
- tools/mep_auto.ps1: MEP_AUTO で read-only suite を実行（存在するものだけ実行・fail-fast）
  - scripts/evidence_check.ps1
  - tools/acceptance_tests.ps1
  - tools/mep_handoff_guard.ps1
- .mep/CURRENT_STAGE.txt が追跡できるように .gitignore に例外を追加（必要時）

備考:
- tools/pre_gate.ps1 は単一の正として維持（変更なし）