### PR TITLE
fix(mep): do not track CURRENT_STAGE (Scope Guard safe)

### DIFF
--- a/.mep/CURRENT_STAGE.txt
+++ b/.mep/CURRENT_STAGE.txt
@@ -1,1 +1,0 @@
-PRE_GATE


### PR DESCRIPTION
目的:
- Scope Guard (PR) が .mep/CURRENT_STAGE.txt を out-of-scope として落とすため、CURRENT_STAGE を runtime 状態として repo追跡から外す。

変更:
- .gitignore: .mep/ を ignore（CURRENT_STAGE の unignore 行があれば削除）
- .mep/CURRENT_STAGE.txt: 追跡を解除（git rm --cached）。ローカル実行時は既存ロジックで自動生成/維持。

注:
- Pre-Gate（tools/pre_gate.ps1）は単一の正として変更なし。