### PR TITLE
fix(mep): pre_gate non-interactive + entry StrictMode-safe

### DIFF
--- a/tools/mep_entry.ps1
+++ b/tools/mep_entry.ps1
@@ -12,6 +12,9 @@ if (!(Test-Path -LiteralPath (Join-Path $root ".git"))) { Fail "Not a git repo r
 $auto = Join-Path $root "tools/mep_auto.ps1"
 if (!(Test-Path -LiteralPath $auto)) { Fail "Missing: tools/mep_auto.ps1" }
 
-Info "Delegating to tools/mep_auto.ps1"
-& $auto -Once:$Once
+$onceFlag = $false
+if ($PSBoundParameters.ContainsKey('Once')) { $onceFlag = [bool]$Once }
+
+Info ("Delegating to tools/mep_auto.ps1 (Once=" + $onceFlag + ")")
+if ($onceFlag) { & $auto -Once } else { & $auto }
 exit $LASTEXITCODE

--- a/tools/pre_gate.ps1
+++ b/tools/pre_gate.ps1
@@ -31,8 +31,174 @@ try {
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
+  Where-Object {
+    <#
+MEP Pre-Gate (入口の手前)
+目的:
+- MEP本体へ投入する前に、入力/状態が「承認①②済」の前提を満たすかを局所的に検査する。
+- 既存の read-only 監査スクリプトがあれば自動検出して実行する（存在しなければ最低限チェックのみでFAILしない）。
+出力規約:
+- OK: exit 0
+- NG: exit 2（入力/状態がPre-Gate不適合）
+- TOOLING ERROR: exit 1（実行環境/スクリプト破損）
+#>
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Fail([string]$m){ Write-Error $m; exit 2 }
+function Boom([string]$m){ Write-Error $m; exit 1 }
+function Info([string]$m){ Write-Host "[PREGATE] $m" -ForegroundColor Cyan }
+
+try {
+  $root = (git rev-parse --show-toplevel 2>$null)
+  if (-not $root) { Boom "Not in a git repo." }
+  Set-Location $root
+
+  # Pre-GateはBundledに依存しない運用も可能だが、ここでは「MEP投入前の最低条件」として存在確認だけ行う
+  $bundled = Join-Path $root "docs/MEP/MEP_BUNDLE.md"
+  if (!(Test-Path $bundled)) { Info "Bundled not found (docs/MEP/MEP_BUNDLE.md). Continuing with minimal checks." }
+
+  $status = (git status --porcelain)
+  if ($status) { Fail "Working tree is dirty. Commit/stash before entering MEP." }
+
+  $toolsDir = Join-Path $root "tools"
+  $candidates = @()
+  if (Test-Path $toolsDir) {
+    $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
+  }
+
+  if ($candidates.Count -gt 0) {
+    Info "Found read-only audit candidates:"
+    $candidates | ForEach-Object { Write-Host ("  - " + $_.FullName) }
+    foreach ($c in $candidates) {
+      Info ("Running: " + $c.Name)
+      & $c.FullName
+      if ($LASTEXITCODE -ne 0) { Fail ("Audit script failed (exit=" + $LASTEXITCODE + "): " + $c.Name) }
+    }
+  } else {
+    Info "No read-only audit script found. Minimal checks only."
+  }
+
+  Info "OK"
+  exit 0
+}
+catch {
+  Boom $_.Exception.Message
+}.Name -match "mep_.*(audit|readonly)" -and
+    <#
+MEP Pre-Gate (入口の手前)
+目的:
+- MEP本体へ投入する前に、入力/状態が「承認①②済」の前提を満たすかを局所的に検査する。
+- 既存の read-only 監査スクリプトがあれば自動検出して実行する（存在しなければ最低限チェックのみでFAILしない）。
+出力規約:
+- OK: exit 0
+- NG: exit 2（入力/状態がPre-Gate不適合）
+- TOOLING ERROR: exit 1（実行環境/スクリプト破損）
+#>
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Fail([string]$m){ Write-Error $m; exit 2 }
+function Boom([string]$m){ Write-Error $m; exit 1 }
+function Info([string]$m){ Write-Host "[PREGATE] $m" -ForegroundColor Cyan }
+
+try {
+  $root = (git rev-parse --show-toplevel 2>$null)
+  if (-not $root) { Boom "Not in a git repo." }
+  Set-Location $root
+
+  # Pre-GateはBundledに依存しない運用も可能だが、ここでは「MEP投入前の最低条件」として存在確認だけ行う
+  $bundled = Join-Path $root "docs/MEP/MEP_BUNDLE.md"
+  if (!(Test-Path $bundled)) { Info "Bundled not found (docs/MEP/MEP_BUNDLE.md). Continuing with minimal checks." }
+
+  $status = (git status --porcelain)
+  if ($status) { Fail "Working tree is dirty. Commit/stash before entering MEP." }
+
+  $toolsDir = Join-Path $root "tools"
+  $candidates = @()
+  if (Test-Path $toolsDir) {
+    $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
+      Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
+      Sort-Object Name
+  }
+
+  if ($candidates.Count -gt 0) {
+    Info "Found read-only audit candidates:"
+    $candidates | ForEach-Object { Write-Host ("  - " + $_.FullName) }
+    foreach ($c in $candidates) {
+      Info ("Running: " + $c.Name)
+      & $c.FullName
+      if ($LASTEXITCODE -ne 0) { Fail ("Audit script failed (exit=" + $LASTEXITCODE + "): " + $c.Name) }
+    }
+  } else {
+    Info "No read-only audit script found. Minimal checks only."
+  }
+
+  Info "OK"
+  exit 0
+}
+catch {
+  Boom $_.Exception.Message
+}.Name -notmatch "entry|pregate" -and
+    <#
+MEP Pre-Gate (入口の手前)
+目的:
+- MEP本体へ投入する前に、入力/状態が「承認①②済」の前提を満たすかを局所的に検査する。
+- 既存の read-only 監査スクリプトがあれば自動検出して実行する（存在しなければ最低限チェックのみでFAILしない）。
+出力規約:
+- OK: exit 0
+- NG: exit 2（入力/状態がPre-Gate不適合）
+- TOOLING ERROR: exit 1（実行環境/スクリプト破損）
+#>
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Fail([string]$m){ Write-Error $m; exit 2 }
+function Boom([string]$m){ Write-Error $m; exit 1 }
+function Info([string]$m){ Write-Host "[PREGATE] $m" -ForegroundColor Cyan }
+
+try {
+  $root = (git rev-parse --show-toplevel 2>$null)
+  if (-not $root) { Boom "Not in a git repo." }
+  Set-Location $root
+
+  # Pre-GateはBundledに依存しない運用も可能だが、ここでは「MEP投入前の最低条件」として存在確認だけ行う
+  $bundled = Join-Path $root "docs/MEP/MEP_BUNDLE.md"
+  if (!(Test-Path $bundled)) { Info "Bundled not found (docs/MEP/MEP_BUNDLE.md). Continuing with minimal checks." }
+
+  $status = (git status --porcelain)
+  if ($status) { Fail "Working tree is dirty. Commit/stash before entering MEP." }
+
+  $toolsDir = Join-Path $root "tools"
+  $candidates = @()
+  if (Test-Path $toolsDir) {
+    $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
+      Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
+      Sort-Object Name
+  }
+
+  if ($candidates.Count -gt 0) {
+    Info "Found read-only audit candidates:"
+    $candidates | ForEach-Object { Write-Host ("  - " + $_.FullName) }
+    foreach ($c in $candidates) {
+      Info ("Running: " + $c.Name)
+      & $c.FullName
+      if ($LASTEXITCODE -ne 0) { Fail ("Audit script failed (exit=" + $LASTEXITCODE + "): " + $c.Name) }
+    }
+  } else {
+    Info "No read-only audit script found. Minimal checks only."
+  }
+
+  Info "OK"
+  exit 0
+}
+catch {
+  Boom $_.Exception.Message
+}.Name -notmatch "^mep_pr_audit_merge\.ps1$"
+  } |
+  Sort-Object Name
   }
 
   if ($candidates.Count -gt 0) {


### PR DESCRIPTION
目的:
- Pre-Gate が対話入力を要求して止まるのを防止し、AUTO運転を止めない。
- StrictMode 下で mep_entry.ps1 -Once が落ちないようにする。

変更:
- tools/pre_gate.ps1: read-only候補から tools/mep_pr_audit_merge.ps1 を除外（PrNumber必須の対話系）
- tools/mep_entry.ps1: -Once 指定時の未定義変数参照を回避（$PSBoundParameters で判定）

注:
- Pre-Gate / AUTO は安全側（対話・破壊操作をPre-Gateに入れない）