### PR TITLE
fix(mep): pre_gate excludes interactive audit-merge script

### DIFF
--- a/tools/pre_gate.ps1
+++ b/tools/pre_gate.ps1
@@ -67,6 +67,8 @@ try {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
+  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_pr_audit_merge.ps1' })
+
   }
 
   if ($candidates.Count -gt 0) {


### PR DESCRIPTION
目的:
- Pre-Gateが対話入力(PrNumber)で停止しないようにする。

変更:
- tools/pre_gate.ps1: mep_pr_audit_merge.ps1 を候補から常に除外（対話が必要なためPre-Gate不適合）