### PR TITLE
fix(mep): mep_entry StrictMode-safe (-Once)

### DIFF
--- a/tools/mep_entry.ps1
+++ b/tools/mep_entry.ps1
@@ -12,6 +12,7 @@ if (!(Test-Path -LiteralPath (Join-Path $root ".git"))) { Fail "Not a git repo r
 $auto = Join-Path $root "tools/mep_auto.ps1"
 if (!(Test-Path -LiteralPath $auto)) { Fail "Missing: tools/mep_auto.ps1" }
 
+# StrictMode-safe: do not read $Once unless caller passed it
 $onceFlag = $false
 if ($PSBoundParameters.ContainsKey('Once')) { $onceFlag = [bool]$Once }
 


### PR DESCRIPTION
目的:
- StrictMode 下で tools/mep_entry.ps1 -Once が落ちないようにする。

変更:
- tools/mep_entry.ps1: $PSBoundParameters で -Once の有無を判定し、未定義変数参照を回避。

注:
- Pre-Gate / AUTO の安全側運用は維持（挙動変更なし、例外防止のみ）