### PR TITLE
feat(mep): Pre-Gate + handoff scaffold (v1)

### DIFF
--- a/.github/workflows/mep_pregate_handoff_dispatch_v1.yml
+++ b/.github/workflows/mep_pregate_handoff_dispatch_v1.yml
@@ -1,0 +1,142 @@
+name: mep_pregate_handoff_dispatch_v1
+
+on:
+  workflow_dispatch:
+    inputs:
+      context:
+        description: "Context label (e.g., CORE / BUSINESS/yorisoidou). Default: CORE"
+        required: false
+        default: "CORE"
+      status:
+        description: "handoff STATUS (DRAFT/ACTIVE/COMPLETED/ABANDONED). Default: DRAFT"
+        required: false
+        default: "DRAFT"
+
+permissions:
+  contents: read
+
+jobs:
+  pregate-handoff:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Generate handoff.md (fixed path) + Pre-Gate count
+        shell: pwsh
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = "Stop"
+
+          function Fail([string]$m){ throw $m }
+          function Info([string]$m){ Write-Host "[INFO] $m" }
+
+          $ctx = "${{ inputs.context }}"
+          if ([string]::IsNullOrWhiteSpace($ctx)) { $ctx = "CORE" }
+
+          $status = "${{ inputs.status }}"
+          if ([string]::IsNullOrWhiteSpace($status)) { $status = "DRAFT" }
+
+          $bundled = "docs/MEP/MEP_BUNDLE.md"
+          if (!(Test-Path $bundled)) { Fail "Bundled not found: $bundled" }
+
+          $bvLine = Select-String -Path $bundled -Pattern "^\s*BUNDLE_VERSION\s*=" -SimpleMatch -ErrorAction Stop | Select-Object -First 1
+          if (-not $bvLine) { Fail "BUNDLE_VERSION not found in $bundled" }
+
+          $bv = ($bvLine.Line -replace "^\s*BUNDLE_VERSION\s*=\s*","").Trim()
+          if ([string]::IsNullOrWhiteSpace($bv)) { Fail "BUNDLE_VERSION empty" }
+
+          $genAt = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+          $short = ($bv -replace "^v","") -replace "[^0-9A-Za-z]+",""
+          if ($short.Length -gt 24) { $short = $short.Substring(0,24) }
+          $handoffId = "$(Get-Date -Format yyyyMMdd)-$($ctx -replace '[^0-9A-Za-z/_-]','')-$short"
+
+          $outDir = "HANDOFF/ACTIVE"
+          New-Item -ItemType Directory -Force -Path $outDir | Out-Null
+          $outTmp = Join-Path $outDir "handoff.tmp.md"
+          $out    = Join-Path $outDir "handoff.md"
+
+          # Build minimal packet first (META only). Sections are placeholders intentionally.
+          @"
+# HANDOFF
+
+## 0. META
+HANDOFF_ID = $handoffId
+CONTEXT = $ctx
+GENERATED_AT = $genAt
+SOURCE = $bundled
+BUNDLE_VERSION = $bv
+PRE_GATE_EXPECTED = 10
+PRE_GATE_FOUND_OK = 0
+PRE_GATE_FOUND_NG = 0
+PRE_GATE_MISSING = []
+STATUS = $status
+
+## 1. CONFIRMED (Bundled-only facts)
+- (to be filled by Gate/meaning phase; keep Bundled references only)
+
+## 2. UNCONFIRMED / DRAFT
+- (to be filled explicitly as unconfirmed; never assert as confirmed)
+
+## 3. NEXT
+- (single-thread continuation steps)
+"@ | Set-Content -Encoding UTF8 $outTmp
+
+          # Mechanical Pre-Gate checks (EXPECTED=10)
+          $expected = 10
+          $missing = New-Object System.Collections.Generic.List[string]
+          $ng = New-Object System.Collections.Generic.List[string]
+
+          # helpers
+          function HasLine([string]$path, [string]$pattern){
+            return [bool](Select-String -Path $path -Pattern $pattern -ErrorAction SilentlyContinue | Select-Object -First 1)
+          }
+
+          # PG-01
+          if (-not (HasLine $bundled "^\s*BUNDLE_VERSION\s*=")) { $missing.Add("PG-01") }
+          # PG-02
+          if (-not (Test-Path $bundled)) { $missing.Add("PG-02") }
+          # PG-03..PG-10 check in handoff.tmp.md
+          if (-not (HasLine $outTmp "^\s*HANDOFF_ID\s*=")) { $missing.Add("PG-03") }
+          if (-not (HasLine $outTmp "^\s*CONTEXT\s*=")) { $missing.Add("PG-04") }
+          if (-not (HasLine $outTmp "^\s*GENERATED_AT\s*=")) { $missing.Add("PG-05") }
+          if (-not (HasLine $outTmp "^\s*STATUS\s*=")) { $missing.Add("PG-06") }
+          if (-not (HasLine $outTmp "^\s*PRE_GATE_EXPECTED\s*=")) { $missing.Add("PG-07") }
+          if (-not (HasLine $outTmp "^\s*PRE_GATE_FOUND_OK\s*=")) { $missing.Add("PG-08") }
+          if (-not (HasLine $outTmp "^\s*PRE_GATE_MISSING\s*=")) { $missing.Add("PG-09") }
+          if (-not (HasLine $outTmp "^\s*SOURCE\s*=\s*docs/MEP/MEP_BUNDLE\.md")) { $missing.Add("PG-10") }
+
+          $foundOk = $expected - $missing.Count
+          if ($foundOk -lt 0) { $foundOk = 0 }
+
+          $missingJson = ($missing | ConvertTo-Json -Compress)
+          if (-not $missingJson) { $missingJson = "[]" }
+
+          # Patch counts into file
+          $txt = Get-Content -Raw -Encoding UTF8 $outTmp
+          $txt = $txt -replace "PRE_GATE_FOUND_OK\s*=\s*\d+","PRE_GATE_FOUND_OK = $foundOk"
+          $txt = $txt -replace "PRE_GATE_FOUND_NG\s*=\s*\d+","PRE_GATE_FOUND_NG = 0"
+          $txt = $txt -replace "PRE_GATE_MISSING\s*=\s*\[[^\]]*\]","PRE_GATE_MISSING = $missingJson"
+          Set-Content -Encoding UTF8 -Path $outTmp -Value $txt
+
+          # Atomic replace
+          Move-Item -Force $outTmp $out
+
+          # Emit summary
+          "PRE_GATE_EXPECTED=$expected" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding UTF8
+          "PRE_GATE_FOUND_OK=$foundOk" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding UTF8
+          "PRE_GATE_MISSING=$missingJson" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding UTF8
+          "BUNDLE_VERSION=$bv" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding UTF8
+          "HANDOFF_ID=$handoffId" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding UTF8
+
+          if ($foundOk -ne $expected) {
+            Fail "Pre-Gate failed: FOUND_OK($foundOk) != EXPECTED($expected). MISSING=$missingJson"
+          }
+
+      - name: Upload handoff.md artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: handoff_md
+          path: HANDOFF/ACTIVE/handoff.md

--- a/platform/MEP/01_CORE/cards/HANDOFF_PACKET_SPEC.md
+++ b/platform/MEP/01_CORE/cards/HANDOFF_PACKET_SPEC.md
@@ -1,0 +1,30 @@
+# CARD: HANDOFF_PACKET_SPEC [Draft]
+
+## Purpose
+handoff.md is a self-contained transfer packet.
+It must be the only input to the next chat (no ID typing, no prose instructions outside the file).
+
+## File: HANDOFF/ACTIVE/handoff.md (fixed path, overwrite)
+### 0. META (must be first)
+- HANDOFF_ID = <auto>
+- CONTEXT = <auto> (e.g., CORE / BUSINESS/yorisoidou / SUBMEP/...)
+- GENERATED_AT = <auto ISO8601>
+- SOURCE = docs/MEP/MEP_BUNDLE.md
+- BUNDLE_VERSION = <from Bundled header>
+- PRE_GATE_EXPECTED = 10
+- PRE_GATE_FOUND_OK = <auto>
+- PRE_GATE_FOUND_NG = <auto>
+- PRE_GATE_MISSING = <auto JSON array>
+
+### 1. CONFIRMED (Bundled-only facts)
+- list of confirmed facts with Bundled references
+
+### 2. UNCONFIRMED / DRAFT (explicitly not confirmed)
+- list of drafts / pending decisions
+- must not contain assertive language as confirmed facts
+
+### 3. NEXT (single-thread continuation)
+- next mechanical steps (no branching prose)
+
+## Status
+- STATUS = DRAFT | ACTIVE | COMPLETED | ABANDONED

--- a/platform/MEP/01_CORE/cards/PRE_GATE_CHECKLIST.md
+++ b/platform/MEP/01_CORE/cards/PRE_GATE_CHECKLIST.md
@@ -1,0 +1,30 @@
+# CARD: PRE_GATE_CHECKLIST [Draft]
+
+## Purpose
+Pre-Gate is a *mechanical* gate. It does NOT judge meaning. It only verifies that required slots exist and are countable.
+If EXPECTED != FOUND_OK, processing must stop.
+
+## Output Contract (machine summary)
+- PRE_GATE_EXPECTED: integer
+- PRE_GATE_FOUND_OK: integer
+- PRE_GATE_FOUND_NG: integer
+- PRE_GATE_MISSING: JSON array of IDs
+- STOP_RULE: FOUND_OK == EXPECTED only
+
+## Checklist (EXPECTED=10)
+ID | Description | How to detect (machine)
+---|-------------|-------------------------
+PG-01 | BUNDLE_VERSION present in docs/MEP/MEP_BUNDLE.md | regex `^BUNDLE_VERSION\s*=`
+PG-02 | Bundled file exists | Test-Path docs/MEP/MEP_BUNDLE.md
+PG-03 | Handoff meta has HANDOFF_ID | handoff.md contains `^HANDOFF_ID\s*=`
+PG-04 | Handoff meta has CONTEXT | handoff.md contains `^CONTEXT\s*=`
+PG-05 | Handoff meta has GENERATED_AT | handoff.md contains `^GENERATED_AT\s*=`
+PG-06 | Handoff meta has STATUS | handoff.md contains `^STATUS\s*=`
+PG-07 | Handoff meta has PRE_GATE_EXPECTED | handoff.md contains `^PRE_GATE_EXPECTED\s*=`
+PG-08 | Handoff meta has PRE_GATE_FOUND_OK | handoff.md contains `^PRE_GATE_FOUND_OK\s*=`
+PG-09 | Handoff meta has PRE_GATE_MISSING | handoff.md contains `^PRE_GATE_MISSING\s*=`
+PG-10 | Handoff declares SOURCE (Bundled path) | handoff.md contains `^SOURCE\s*=`
+
+## Notes
+- This checklist intentionally avoids semantic judgement.
+- Semantic judgement is Gate-phase only.


### PR DESCRIPTION
Purpose:
- Fix the structure in GitHub: Pre-Gate (mechanical count) + handoff packet contract.
- Provide a dispatch workflow that generates HANDOFF/ACTIVE/handoff.md and fails if Pre-Gate count is not satisfied.

Notes:
- This is scaffold only (Draft cards). Semantic/meaning gate content stays separate.
- Workflow is read-only on repo contents (permissions: contents: read) and uploads handoff.md as artifact.