### PR TITLE
fix(mep): args-based -Once + stage (avoid StrictMode param issues)

### DIFF
--- a/tools/mep_current_stage.ps1
+++ b/tools/mep_current_stage.ps1
@@ -4,10 +4,10 @@ $ErrorActionPreference = "Stop"
 function Fail([string]$m){ throw $m }
 function Info([string]$m){ Write-Host "[STAGE] $m" -ForegroundColor Cyan }
 
-# Args-based protocol (no param block):
-#   .\tools\mep_current_stage.ps1 get
-#   .\tools\mep_current_stage.ps1 set <VALUE>
-#   .\tools\mep_current_stage.ps1 advance
+# Args-based protocol (no param):
+#   tools\mep_current_stage.ps1 get
+#   tools\mep_current_stage.ps1 set <VALUE>
+#   tools\mep_current_stage.ps1 advance
 $op = "get"
 $value = ""
 if ($args -and $args.Count -ge 1) { $op = [string]$args[0] }

--- a/tools/mep_entry.ps1
+++ b/tools/mep_entry.ps1
@@ -1,8 +1,6 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
-param([switch]$Once)
-
 function Fail([string]$m){ throw $m }
 function Info([string]$m){ Write-Host "[ENTRY] $m" -ForegroundColor Cyan }
 
@@ -12,9 +10,9 @@ if (!(Test-Path -LiteralPath (Join-Path $root ".git"))) { Fail "Not a git repo r
 $auto = Join-Path $root "tools/mep_auto.ps1"
 if (!(Test-Path -LiteralPath $auto)) { Fail "Missing: tools/mep_auto.ps1" }
 
-# StrictMode-safe: do not read $Once unless caller passed it
+# StrictMode-safe: detect -Once in $args (no param)
 $onceFlag = $false
-if ($PSBoundParameters.ContainsKey('Once')) { $onceFlag = [bool]$Once }
+if ($args -and ($args -contains "-Once")) { $onceFlag = $true }
 
 Info ("Delegating to tools/mep_auto.ps1 (Once=" + $onceFlag + ")")
 if ($onceFlag) { & $auto -Once } else { & $auto }


### PR DESCRIPTION
目的:
- StrictMode 環境で param([switch]$Once) 周りが不安定なため、entry/auto/stage を args-based に統一して AUTO を確実に完走させる。

変更:
- tools/mep_entry.ps1: param廃止、$args に -Once があるかで判定
- tools/mep_auto.ps1: param廃止、$args に -Once があるかで判定
- tools/mep_current_stage.ps1: param廃止、get/set/advance を $args で処理

注:
- Pre-Gate は clean を要求する仕様のまま