### PR TITLE
chore(writeback): add manual dispatch wrapper (workflow_dispatch)

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch_manual.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch_manual.yml
@@ -1,0 +1,16 @@
+name: mep_writeback_bundle_dispatch_manual
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number (0 = auto latest merged PR)'
+        required: false
+        default: '0'
+
+jobs:
+  call:
+    uses: ./.github/workflows/mep_writeback_bundle_dispatch_v3.yml
+    with:
+      pr_number: ${{ inputs.pr_number }}
+    secrets: inherit


### PR DESCRIPTION
目的:
- v3 writeback workflow が workflow_dispatch を持たず、gh workflow run が HTTP 422 で不可能なため
- workflow_call を wrapper 経由で手動起動できるようにする（既存v3は改変しない）

内容:
- .github/workflows/mep_writeback_bundle_dispatch_manual.yml を追加
- workflow_dispatch inputs.pr_number を v3 に転送

期待:
- 以後 `gh workflow run mep_writeback_bundle_dispatch_manual.yml -f pr_number=XXXX` が可能