### PR TITLE
fix(ci): repair v3 workflow YAML (unblock wrapper dispatch)

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch_v3.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch_v3.yml
@@ -116,7 +116,7 @@ jobs:
             echo "no diff; skip repair PR"
           fi
 
-.headRefName -like "auto/writeback-bundle_*" } `
+          $b = $prs | Where-Object { $_.headRefName -like "auto/writeback-bundle_*" } `
             | Sort-Object createdAt -Descending `
             | Select-Object -First 1
 


### PR DESCRIPTION
目的:
- wrapper dispatch が「called workflow YAML syntax error line 119」で 422 になるため、v3の該当箇所を修正する。

原因:
- PowerShell のパイプライン断片（.headRefName...) が run ブロック外（列1）に飛び出し、YAMLとして解釈不能。

修正:
- line 119-121 を run ブロック内へ戻し、欠落していた $_ を補って $b の代入パイプラインとして成立させる。