### PR TITLE
fix(mep): make handoff audit tool parse-safe in pwsh

### DIFF
--- a/tools/mep_handoff_audit.ps1
+++ b/tools/mep_handoff_audit.ps1
@@ -1,20 +1,24 @@
-﻿Set-StrictMode -Version Latest
+﻿param(
+  [Parameter(Mandatory=$false)]
+  [int]$PrNumber,
+
+  [Parameter(Mandatory=$false)]
+  [string]$RepoOrigin,
+
+  [Parameter(Mandatory=$false)]
+  [switch]$SaveToDesktop
+)
+
+Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 $ProgressPreference = "SilentlyContinue"
 [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
 $OutputEncoding = [Console]::OutputEncoding
 $env:GIT_PAGER="cat"; $env:PAGER="cat"
 
-param(
-  [Parameter(Mandatory=$false)]
-  [int]$PrNumber = 0,
-
-  [Parameter(Mandatory=$false)]
-  [string]$RepoOrigin = "https://github.com/Osuu-ops/yorisoidou-system.git",
-
-  [Parameter(Mandatory=$false)]
-  [switch]$SaveToDesktop
-)
+# Defaults (set here; NEVER in param block)
+if (-not $PSBoundParameters.ContainsKey('PrNumber'))   { $PrNumber   = 0 }
+if (-not $PSBoundParameters.ContainsKey('RepoOrigin')) { $RepoOrigin = "https://github.com/Osuu-ops/yorisoidou-system.git" }
 
 function Info([string]$m){ Write-Host "[INFO] $m" -ForegroundColor Cyan }
 function Fail([string]$m){ throw $m }
@@ -25,38 +29,49 @@ try { $root = (git rev-parse --show-toplevel 2>$null).Trim() } catch { $root = $
 if (-not $root) { Fail "repo root not found (run inside git repo)" }
 Set-Location $root
 
-$parentBundled   = Join-Path $root "docs\MEP\MEP_BUNDLE.md"
-$evidenceBundled = Join-Path $root "docs\MEP_SUB\EVIDENCE\MEP_BUNDLE.md"
-if (!(Test-Path $parentBundled))   { Fail "Not found: docs/MEP/MEP_BUNDLE.md" }
-if (!(Test-Path $evidenceBundled)) { Fail "Not found: docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md" }
+# --- always read Bundled from origin/main (branch-independent) ---
+git fetch origin | Out-Null
 
-# --- parent BUNDLE_VERSION ---
-$bvHit = Select-String -LiteralPath $parentBundled -Pattern '^\s*BUNDLE_VERSION\s*=' -Encoding UTF8 | Select-Object -First 1
-if (-not $bvHit) { Fail "BUNDLE_VERSION not found in parent bundled" }
-$bundleVersionLine = $bvHit.Line.TrimEnd()
-
-# --- choose PR line ---
-$targetPr = $PrNumber
-if ($targetPr -le 0) {
-  $okLines = Select-String -LiteralPath $evidenceBundled -Pattern '(?i)\baudit=OK,WB0000\b' -Encoding UTF8
-  if (-not $okLines) { Fail "No audit=OK,WB0000 lines found in EVIDENCE_BUNDLE" }
-
-  $candidates = @()
-  foreach ($h in $okLines) {
-    if ($h.Line -match '(?i)\bPR\s*#\s*(\d+)\b') {
-      $candidates += [pscustomobject]@{ Pr=[int]$Matches[1]; Line=$h.Line.TrimEnd() }
-    }
-  }
-  if ($candidates.Count -eq 0) { Fail "audit=OK,WB0000 lines found but PR # not parsed" }
-  $targetPr = ($candidates | Select-Object -Last 1).Pr
+function Get-FileLinesFromOriginMain([string]$repoPath){
+  $spec = ("origin/main:{0}" -f $repoPath.Replace("\","/"))
+  $out = @()
+  try { $out = @(git show $spec 2>$null) } catch { $out = @() }
+  if (-not $out -or $out.Count -eq 0) { Fail ("git show failed or empty: {0}" -f $spec) }
+  return $out
 }
 
-$eviHits = Select-String -LiteralPath $evidenceBundled -Pattern ("(?i)\bPR\s*#\s*{0}\b" -f $targetPr) -Encoding UTF8
-if (-not $eviHits) { Fail ("PR line not found in EVIDENCE_BUNDLE: PR #{0}" -f $targetPr) }
+# --- parent BUNDLE_VERSION ---
+$parentLines = Get-FileLinesFromOriginMain "docs/MEP/MEP_BUNDLE.md"
+$bvLine = ($parentLines | Where-Object { $_ -match '^\s*BUNDLE_VERSION\s*=' } | Select-Object -First 1)
+if (-not $bvLine) { Fail "BUNDLE_VERSION not found in parent bundled (origin/main:docs/MEP/MEP_BUNDLE.md)" }
+$bundleVersionLine = $bvLine.TrimEnd()
 
-$eviOk = $eviHits | Where-Object { $_.Line -match "(?i)audit=OK,WB0000" } | Select-Object -First 1
-if (-not $eviOk) { Fail ("PR line found but audit=OK,WB0000 not detected: PR #{0}" -f $targetPr) }
-$evidenceLine = $eviOk.Line.TrimEnd()
+# --- evidence PR line ---
+$evidenceLines = Get-FileLinesFromOriginMain "docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md"
+
+$targetPr = $PrNumber
+if ($targetPr -le 0) {
+  $ok = @()
+  foreach ($ln in $evidenceLines) {
+    if ($ln -match '(?i)\baudit=OK,WB0000\b' -and $ln -match '(?i)\bPR\s*#\s*(\d+)\b') {
+      $ok += [pscustomobject]@{ Pr=[int]$Matches[1]; Line=$ln.TrimEnd() }
+    }
+  }
+  if ($ok.Count -eq 0) { Fail "No parsable audit=OK,WB0000 lines found in EVIDENCE_BUNDLE (origin/main)" }
+  $targetPr = ($ok | Select-Object -Last 1).Pr
+}
+
+$hit = $null
+foreach ($ln in $evidenceLines) {
+  if ($ln -match ("(?i)\bPR\s*#\s*{0}\b" -f $targetPr) -and $ln -match '(?i)\baudit=OK,WB0000\b') {
+    $hit = $ln.TrimEnd()
+    break
+  }
+}
+if (-not $hit) { Fail ("PR line not found or not OK (audit=OK,WB0000) in EVIDENCE_BUNDLE (origin/main): PR #{0}" -f $targetPr) }
+
+# normalize "- PR ..." -> "PR ..."
+$evidenceLine = ($hit -replace '^\s*[-*]\s+', '')
 
 # --- build HANDOFF text (audit-safe) ---
 $sb = New-Object System.Text.StringBuilder


### PR DESCRIPTION
原因:
- tools/mep_handoff_audit.ps1 が param ブロック内にデフォルト代入を含み、pwsh で ParserError になる

修正:
- param ブロックからデフォルト代入を撤去（デフォルトはブロック後に設定）
- UTF-8 BOM で保存（powershell.exe / pwsh の双方で安定）
- Bundled参照は origin/main:... を git show で読む（ブランチ汚染回避）