### PR TITLE
chore(mep): writeback evidence to Bundled (PR #1280)

### DIFF
--- a/docs/MEP/MEP_BUNDLE.md
+++ b/docs/MEP/MEP_BUNDLE.md
@@ -1,4 +1,4 @@
-BUNDLE_VERSION = v0.0.0+20260130_133030+main+parent
+BUNDLE_VERSION = v0.0.0+20260130_133843+main+parent
 OPS: Bundled writeback is executed via workflow_dispatch (mep_writeback_bundle_dispatch); local runs are for debugging only.
 # MEP_BUNDLE
 SOURCE_CONTEXT: 本ファイルは「MEPの唯一の正（main反映）」を前提に、次チャット開始時の再現性を最大化するための束ね（生成物）である。手編集は原則禁止。更新はゲートを経た反映（PR→main→Bundled）で行う。
@@ -366,6 +366,7 @@ BUSINESS側を構築すると、例外・分岐・用語・台帳参照が急増
 - PR #1183 | mergedAt=01/25/2026 13:04:16 | mergeCommit=751df56ecd20e1fedbe1ce81f0d75cd2baebf4db | BUNDLE_VERSION=v0.0.0+20260125_152243+main+parent | audit=OK,WB0000 | acceptance:SUCCESS, bom-check:SUCCESS, Business Packet Guard (PR):SUCCESS, done_check:SUCCESS, enable_auto_merge:SUCCESS, guard:SUCCESS, merge_repair_pr:SKIPPED, Scope Guard (PR):SUCCESS, self-heal:SUCCESS, semantic-audit-business:SUCCESS, semantic-audit:SUCCESS, suggest:SUCCESS, Text Integrity Guard (PR):SUCCESS | https://github.com/Osuu-ops/yorisoidou-system/pull/1183
 - PR #1258 | mergedAt=01/30/2026 08:47:54 | mergeCommit=b6a76a5ed0e0044de48c4e22376c9b21f0c4b552 | BUNDLE_VERSION=v0.0.0+20260130_092453+main+parent | audit=NG,WB2001 | bom-check:SUCCESS, Business Packet Guard (PR):SUCCESS, Current Scope Format Guard (PR):FAILURE, done_check:SUCCESS, enable_auto_merge:SUCCESS, merge_repair_pr:SKIPPED, Scope Guard (PR):FAILURE, semantic-audit-business:SUCCESS, semantic-audit:SUCCESS, suggest:SUCCESS, Text Integrity Guard (PR):SUCCESS | https://github.com/Osuu-ops/yorisoidou-system/pull/1258
 - PR #1277 | mergedAt=01/30/2026 13:29:13 | mergeCommit=b1e61da91eff91956025295455751d3111d88f1f | BUNDLE_VERSION=v0.0.0+20260130_133030+main+parent | audit=OK,WB0000 | bom-check:SUCCESS, Business Packet Guard (PR):SUCCESS, done_check:SUCCESS, enable_auto_merge:SUCCESS, merge_repair_pr:SKIPPED, Scope Guard (PR):SUCCESS, semantic-audit-business:SUCCESS, semantic-audit:SUCCESS, suggest:SUCCESS, Text Integrity Guard (PR):SUCCESS | https://github.com/Osuu-ops/yorisoidou-system/pull/1277
+- PR #1280 | mergedAt=01/30/2026 13:30:48 | mergeCommit=89b62192d359dcf03841fcf95c9b1f0eca63f099 | BUNDLE_VERSION=v0.0.0+20260130_133843+main+parent | audit=OK,WB0000 | bom-check:SUCCESS, Business Packet Guard (PR):SUCCESS, done_check:SUCCESS, enable_auto_merge:SUCCESS, guard:SUCCESS, merge_repair_pr:SKIPPED, Scope Guard (PR):SUCCESS, self-heal:SUCCESS, semantic-audit-business:SUCCESS, semantic-audit:SUCCESS, suggest:SUCCESS, Text Integrity Guard (PR):SUCCESS, update-state-summary:SKIPPED | https://github.com/Osuu-ops/yorisoidou-system/pull/1280
 ## CARD: DIFF_POLICY / BOUNDARY AUDIT（差分運用・境界監査）  [Draft]
 
 ### 基本


### PR DESCRIPTION
Purpose
- Auto writeback evidence to Bundled (MEP_BUNDLE.md) as specified by EVIDENCE/WRITEBACK SPEC.

Evidence (source)
- latest merged PR: #1280
- mergeCommit: 89b62192d359dcf03841fcf95c9b1f0eca63f099
- BUNDLE_VERSION: v0.0.0+20260130_133843+main+parent

Notes
- Append-only evidence log; de-dup by PR number.