### PR TITLE
fix(mep): pwsh-safe handoff tool (no defaults in param)

### DIFF
--- a/tools/mep_handoff_audit.ps1
+++ b/tools/mep_handoff_audit.ps1
@@ -16,7 +16,7 @@ $ProgressPreference = "SilentlyContinue"
 $OutputEncoding = [Console]::OutputEncoding
 $env:GIT_PAGER="cat"; $env:PAGER="cat"
 
-# Defaults (set here; NEVER in param block)
+# Defaults (NEVER in param block)
 if (-not $PSBoundParameters.ContainsKey('PrNumber'))   { $PrNumber   = 0 }
 if (-not $PSBoundParameters.ContainsKey('RepoOrigin')) { $RepoOrigin = "https://github.com/Osuu-ops/yorisoidou-system.git" }
 
@@ -70,7 +70,7 @@ foreach ($ln in $evidenceLines) {
 }
 if (-not $hit) { Fail ("PR line not found or not OK (audit=OK,WB0000) in EVIDENCE_BUNDLE (origin/main): PR #{0}" -f $targetPr) }
 
-# normalize "- PR ..." -> "PR ..."
+# normalize "- PR ..." / "* PR ..." -> "PR ..."
 $evidenceLine = ($hit -replace '^\s*[-*]\s+', '')
 
 # --- build HANDOFF text (audit-safe) ---


### PR DESCRIPTION
原因:
- main上の tools/mep_handoff_audit.ps1 が param ブロック内デフォルト代入を含む版が残っており、pwsh で ParserError が出ることがある
- 以前のガードは [Parameter(Mandatory=$false)] の "=" を誤検知し得る

修正:
- param ブロックからデフォルト代入を排除（デフォルトは param 後に設定）
- UTF-8 BOM 保存
- Bundled参照は origin/main を git show で読む（ブランチ差分遮断）
- ガードは param ブロック内の "$Name =" のみ禁止（属性内 "=" は許容）