### PR TITLE
chore(ci): disable schedule for mep_bundle_autofix

### DIFF
--- a/.github/workflows/mep_bundle_autofix.yml
+++ b/.github/workflows/mep_bundle_autofix.yml
@@ -2,8 +2,8 @@ name: MEP Bundle AutoFix (Allowlist)
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "13 */2 * * *"
+  # schedule: (disabled)
+    # - cron: "13 */2 * * *" (disabled)
 
 permissions:
   contents: write
@@ -22,3 +22,4 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           pwsh -NoProfile -File tools/mep_bundle_autofix.ps1 -Mode pr -AutoMerge
+


### PR DESCRIPTION
Disable scheduled trigger in mep_bundle_autofix.yml to stop recurring auto PR generation during Pre-Gate.