### PR TITLE
chore(mep): writeback evidence to Bundled (PR #1286)

### DIFF
--- a/docs/MEP/MEP_BUNDLE.md
+++ b/docs/MEP/MEP_BUNDLE.md
@@ -1,4 +1,4 @@
-BUNDLE_VERSION = v0.0.0+20260130_141500+main+parent
+BUNDLE_VERSION = v0.0.0+20260130_141506+auto/writeback-bundle_20260130_141501+parent
 OPS: Bundled writeback is executed via workflow_dispatch (mep_writeback_bundle_dispatch); local runs are for debugging only.
 # MEP_BUNDLE
 SOURCE_CONTEXT: 本ファイルは「MEPの唯一の正（main反映）」を前提に、次チャット開始時の再現性を最大化するための束ね（生成物）である。手編集は原則禁止。更新はゲートを経た反映（PR→main→Bundled）で行う。


### PR DESCRIPTION
Purpose
- Auto writeback evidence to Bundled (MEP_BUNDLE.md) as specified by EVIDENCE/WRITEBACK SPEC.

Evidence (source)
- latest merged PR: #1286
- mergeCommit: e7bab50724fdd4e9f1edd21ecfea43103b15fe86
- BUNDLE_VERSION: v0.0.0+20260130_141506+auto/writeback-bundle_20260130_141501+parent

Notes
- Append-only evidence log; de-dup by PR number.