### PR TITLE
chore(mep): normalize parent BUNDLE_VERSION to main+parent

### DIFF
--- a/docs/MEP/MEP_BUNDLE.md
+++ b/docs/MEP/MEP_BUNDLE.md
@@ -1,4 +1,4 @@
-BUNDLE_VERSION = v0.0.0+20260130_141506+auto/writeback-bundle_20260130_141501+parent
+BUNDLE_VERSION = v0.0.0+20260130_141506+main+parent
 OPS: Bundled writeback is executed via workflow_dispatch (mep_writeback_bundle_dispatch); local runs are for debugging only.
 # MEP_BUNDLE
 SOURCE_CONTEXT: 本ファイルは「MEPの唯一の正（main反映）」を前提に、次チャット開始時の再現性を最大化するための束ね（生成物）である。手編集は原則禁止。更新はゲートを経た反映（PR→main→Bundled）で行う。


### PR DESCRIPTION
目的:
- docs/MEP/MEP_BUNDLE.md の BUNDLE_VERSION が "+auto/<branch>+parent" になっているため、表記を "+main+parent" に整流する（内容・証跡行は変更しない）

変更:
- 先頭行の "+auto/...+parent" 部分のみ "+main+parent" に置換