### PR TITLE
fix(business): allowlist .gitkeep for binary guard (PR #1126) v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ __pycache__/
 
 *.bak
 
+
+!.mep/allowlists/
+!.mep/allowlists/*.sha256
+!.mep/allowlists/business.sha256

--- a/.mep/allowlists/business.sha256
+++ b/.mep/allowlists/business.sha256
@@ -1,5 +1,5 @@
-﻿# sha256 allowlist (BUSINESS non-text assets)
+# sha256 allowlist (BUSINESS non-text assets)
 # Format: "<sha256>  <path>"
 # Example:
 # e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  platform/MEP/03_BUSINESS/path/to/asset.pdf
-jobs:
+e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  platform/MEP/03_BUSINESS/yorisoidou/CMEP/02_MEP_SCRIPTS/.gitkeep


### PR DESCRIPTION
NG回収(#1126): semantic-audit-business の Binary guard が .gitkeep の allowlist 未登録で FAIL。.mep/allowlists/business.sha256 を追跡可能にするため .gitignore に例外を追加し、空ファイルsha(e3b0...)の行を追記して収束させる。旧PR(#1291)は置換予定。