### PR TITLE
chore(mep): fix two-layer handoff spec + tools

### DIFF
--- a/platform/MEP/01_CORE/cards/HANDOFF_TWO_LAYER_SPEC.md
+++ b/platform/MEP/01_CORE/cards/HANDOFF_TWO_LAYER_SPEC.md
@@ -1,0 +1,36 @@
+# HANDOFF TWO-LAYER INPUT SPEC (Fixed)
+
+## Purpose
+Prevent audit contamination by strictly separating:
+- Audit-truth (Bundled/EVIDENCE only)
+- Work-continuation (unfinished tasks / next steps)
+
+## Non-negotiable principles
+1. Truth source is Bundled/EVIDENCE only (PR→main→Bundled).
+2. Conversation logs are NOT primary evidence.
+3. Unfinished tasks must be preserved as "unfinished" (not silently dropped).
+4. Confirmation is allowed ONLY at exit points:
+   - Approval 1: merge implementation PR to main
+   - Approval 2: confirm evidence is appended to Bundled (Evidence Log)
+
+## Required two-layer format (new chat first message)
+
+[監査用引継ぎ]（一次根拠・確定事実）
+- BUNDLE_VERSION = <value>
+- PR #<number> | audit=OK,WB0000 | <optional fields>
+
+[作業用引継ぎ]（監査外・未確定）
+- 未完タスク:
+  - ...
+- 次工程候補:
+  - ...
+- 注意点:
+  - ...
+
+## Interpretation rules (system behavior)
+- Only [監査用引継ぎ] is treated as confirmed facts.
+- [作業用引継ぎ] is NEVER treated as confirmed facts; it is a work memo only.
+- Mixing layers or missing a layer is WB0001 input contamination and must stop processing.
+
+## Error code
+- WB0001: Input contamination (missing layer / mixed content / audit layer contains non-evidence)

--- a/tools/mep_handoff_two_layer_template.ps1
+++ b/tools/mep_handoff_two_layer_template.ps1
@@ -1,0 +1,18 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+$OutputEncoding = [Console]::OutputEncoding
+
+Write-Output @'
+[監査用引継ぎ]（一次根拠・確定事実）
+- BUNDLE_VERSION =
+- PR # | audit=OK,WB0000 |
+
+[作業用引継ぎ]（監査外・未確定）
+- 未完タスク:
+  -
+- 次工程候補:
+  -
+- 注意点:
+  -
+'@

--- a/tools/mep_handoff_two_layer_validate.ps1
+++ b/tools/mep_handoff_two_layer_validate.ps1
@@ -1,0 +1,38 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+$OutputEncoding = [Console]::OutputEncoding
+
+param(
+  [Parameter(Mandatory=$true)]
+  [string]$Path
+)
+
+function Fail([string]$m){
+  Write-Host "[NG] $m"
+  exit 2
+}
+
+if (-not (Test-Path -LiteralPath $Path)) { Fail "File not found: $Path" }
+
+$text = Get-Content -LiteralPath $Path -Raw
+
+$idxA = $text.IndexOf("[監査用引継ぎ]")
+$idxB = $text.IndexOf("[作業用引継ぎ]")
+
+if ($idxA -lt 0) { Fail "WB0001: Missing [監査用引継ぎ]" }
+if ($idxB -lt 0) { Fail "WB0001: Missing [作業用引継ぎ]" }
+if ($idxB -lt $idxA) { Fail "WB0001: Layer order invalid (作業用 before 監査用)" }
+
+$a = $text.Substring($idxA, $idxB - $idxA)
+
+if ($a -notmatch "(?m)^\s*-\s*BUNDLE_VERSION\s*=") { Fail "WB0001: Audit layer lacks BUNDLE_VERSION line" }
+if ($a -notmatch "(?m)PR\s*#\d+") { Fail "WB0001: Audit layer lacks PR #<number> evidence line" }
+
+$forbidden = @("未完タスク","次工程","注意点","TODO","todo","やること")
+foreach($w in $forbidden){
+  if ($a -match [regex]::Escape($w)) { Fail "WB0001: Audit layer contains non-evidence token: $w" }
+}
+
+Write-Host "[OK] Two-layer handoff format validated."
+exit 0


### PR DESCRIPTION
Add fixed two-layer handoff input spec (audit/work) and helper tools (template + validator). Audit layer is Bundled/EVIDENCE only; mixed layers are WB0001.