### PR TITLE
fix(mep): repair writeback script ParserError (PrNumber default)

### DIFF
--- a/tools/mep_writeback_bundle.ps1
+++ b/tools/mep_writeback_bundle.ps1
@@ -14,7 +14,7 @@ function Assert-NoConflictMarkersInBundled {
 }
 
 param(
-  [int]$PrNumber = 0,
+  [int]$PrNumber = 0
   [ValidateSet("update","pr")]
   [string]$Mode = "update",
   [string]$BundlePath = "docs/MEP/MEP_BUNDLE.md",
@@ -391,4 +391,5 @@ Run "gh pr view" { gh pr view $targetBranch --repo $repo --json number,url,headR
 
 # CONFLICT_MARKER_GUARD: stop if Bundled contains unresolved merge markers
 Assert-NoConflictMarkersInBundled -BundledPath (Join-Path (git rev-parse --show-toplevel) "docs/MEP/MEP_BUNDLE.md")
+
 


### PR DESCRIPTION
一次根拠:
- writeback run が tools/mep_writeback_bundle.ps1:17 で ParserError
- 該当行: [int]$PrNumber = 0,  (param ブロック内の末尾カンマで構文エラー)

対策:
- 末尾カンマを除去し、PowerShell パーサで構文OKを確認