### PR TITLE
fix(mep): repair writeback script ParserError (param block)

### DIFF
--- a/tools/mep_writeback_bundle.ps1
+++ b/tools/mep_writeback_bundle.ps1
@@ -1,8 +1,11 @@
 # CONFLICT_MARKER_GUARD: prevent committing Bundled with unresolved merge markers
 function Assert-NoConflictMarkersInBundled {
-  param(
-    [Parameter(Mandatory=$true)][string]$BundledPath
-  )
+param(
+  [int]$PrNumber = 0
+  ,[string]$Mode = "update"
+  ,[string]$BundlePath = "docs/MEP/MEP_BUNDLE.md"
+  ,[string]$BundleScope = "parent"
+)
   if (-not (Test-Path -LiteralPath $BundledPath)) {
     throw "Bundled not found: $BundledPath"
   }


### PR DESCRIPTION
一次根拠:
- writeback run が tools/mep_writeback_bundle.ps1 で ParserError（param ブロック破損 / Missing closing ')'）
- 以降の [string]$Mode / $BundlePath / $BundleScope が「代入式として不正」扱いになっていた

対策:
- param(...) ブロックを既知の正常形へ丸ごと置換し、PowerShell パーサで構文OKを確認