### PR TITLE
Fix: mep_writeback_bundle.ps1 param() must be first statement (unblocks writeback workflow)

### DIFF
--- a/tools/mep_writeback_bundle.ps1
+++ b/tools/mep_writeback_bundle.ps1
@@ -1,11 +1,22 @@
 param(
   [Parameter()]
-  [ValidateSet("pr","main")]
-  [string]$Mode = "pr"
+  [int]$PrNumber = 0,
 
   [Parameter()]
-  [int]$PrNumber = 0
+  [ValidateSet("pr","main","update")]
+  [string]$Mode = "update",
+
+  [Parameter()]
+  [string]$BundlePath = "docs/MEP/MEP_BUNDLE.md",
+
+  [Parameter()]
+  [ValidateSet("parent","sub")]
+  [string]$BundleScope = "parent"
 )
+
+# normalize variable used by guards (if referenced later)
+$BundledPath = $BundlePath
+
 
 # CONFLICT_MARKER_GUARD: prevent committing Bundled with unresolved merge markers
 function Assert-NoConflictMarkersInBundled {


### PR DESCRIPTION
CI writeback run failed with ParserError at tools/mep_writeback_bundle.ps1 (global param() appeared after function definitions). This PR moves the script-level param() to the top (after comments) and removes the late global param block. Local ParseCheck OK.