### PR TITLE
fix(ci): repair mep_writeback_bundle.ps1 (unblock writeback)

### DIFF
--- a/tools/mep_writeback_bundle.ps1
+++ b/tools/mep_writeback_bundle.ps1
@@ -1,19 +1,9 @@
 param(
-  [Parameter()]
-  [int]$PrNumber = 0,
+  [ValidateSet("pr","latest")]
+  [string]$Mode = "pr",
 
-  [Parameter()]
-  [ValidateSet("pr","main","update")]
-  [string]$Mode = "update",
-
-  [Parameter()]
-  [string]$BundlePath = "docs/MEP/MEP_BUNDLE.md",
-
-  [Parameter()]
-  [ValidateSet("parent","sub")]
-  [string]$BundleScope = "parent"
+  [int]$PrNumber = 0
 )
-
 # normalize variable used by guards (if referenced later)
 $BundledPath = $BundlePath
 


### PR DESCRIPTION
Fix PowerShell ParserError in tools/mep_writeback_bundle.ps1 by replacing the param block with a known-good definition for -Mode and -PrNumber.