### PR TITLE
fix(mep): writeback bundle ParserError (script param must be top-of-file)

### DIFF
--- a/tools/mep_writeback_bundle.ps1
+++ b/tools/mep_writeback_bundle.ps1
@@ -1,9 +1,14 @@
 param(
-  [ValidateSet("pr","latest")]
-  [string]$Mode = "pr",
 
+param(
   [int]$PrNumber = 0
+  [string]$Mode = "pr"
+  [string]$BundlePath = "docs/MEP/MEP_BUNDLE.md"
+  [string]$BundleScope = "parent"
 )
+
+param(
+
 # normalize variable used by guards (if referenced later)
 $BundledPath = $BundlePath
 


### PR DESCRIPTION
一次根拠:
- wfDbId=222304615 の run が tools/mep_writeback_bundle.ps1 で ParserError (Missing closing ')' / function parameter list)。
- 原因は「関数内 param(...) を誤って先頭param扱いで移動」or「スクリプト本体 param が先頭に無い」。
- PowerShell の script-level param(...) はスクリプト先頭でのみ有効。

対策:
- 列頭(param() / インデント無し)のみを “script-level param” として扱い、先頭へ正規化。
- 関数内 param(...)（インデントあり）は一切触らない。
- PowerShell パーサで 0 errors を確認。