### PR TITLE
Fix: create stable writeback dispatch entry workflow (avoid 422 ID mismatch)

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch_entry.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch_entry.yml
@@ -1,0 +1,21 @@
+name: MEP Writeback Bundle (Entry)
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: '0 = auto latest merged PR'
+        required: false
+        default: '0'
+      write_handoff:
+        description: 'Generate+Guard+Writeback HANDOFF_NEXT into Bundled'
+        required: false
+        default: 'false'
+
+jobs:
+  call:
+    uses: ./.github/workflows/mep_writeback_bundle_dispatch.yml
+    secrets: inherit
+    with:
+      pr_number: ${{ inputs.pr_number }}
+      write_handoff: ${{ inputs.write_handoff }}


### PR DESCRIPTION
Fixes HTTP 422 dispatch mismatch by adding a fresh workflow_dispatch entry workflow (new file => new ID) that calls the reusable writeback workflow via workflow_call. Entry becomes the single dispatch point.