### PR TITLE
fix(ci): repair writeback dispatch workflow YAML

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch.yml
@@ -213,7 +213,7 @@ jobs:
           $prsJson = gh pr list --state open --limit 200 --json number,headRefName,createdAt
           $prs = $prsJson | ConvertFrom-Json
           $b = $prs | Where-Object { name: MEP Writeback Bundle (Evidence)
-.headRefName -like "auto/writeback-bundle_*" } | Sort-Object createdAt -Descending | Select-Object -First 1)
+          .headRefName -like "auto/writeback-bundle_*" } | Sort-Object createdAt -Descending | Select-Object -First 1)
           }
 
           $b = FindBundlePr


### PR DESCRIPTION
Fix YAML syntax error at line 216 in mep_writeback_bundle_dispatch.yml which blocks workflow_dispatch wrapper from running.