### PR TITLE
fix(mep): add writeback dispatch entrypoint

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch_entry.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch_entry.yml
@@ -1,21 +1,20 @@
-name: MEP Writeback Bundle (Entry)
+name: MEP Writeback Bundle Entry (Dispatch)
 
 on:
   workflow_dispatch:
     inputs:
       pr_number:
-        description: '0 = auto latest merged PR'
+        description: "0 = auto latest merged PR"
         required: false
-        default: '0'
-      write_handoff:
-        description: 'Generate+Guard+Writeback HANDOFF_NEXT into Bundled'
-        required: false
-        default: 'false'
+        default: "0"
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
-  call:
+  writeback:
     uses: ./.github/workflows/mep_writeback_bundle_dispatch.yml
     secrets: inherit
     with:
       pr_number: ${{ inputs.pr_number }}
-      write_handoff: ${{ inputs.write_handoff }}


### PR DESCRIPTION
目的:
- 'workflow_dispatch の入口' を新設して、既存の writeback 本体（workflow_call）を安全に起動できるようにする。

一次根拠:
- 既存の .github/workflows/mep_writeback_bundle_dispatch.yml が workflow_dispatch を持たず、dispatch できない（HTTP 422）。

対策:
- 新規: .github/workflows/mep_writeback_bundle_dispatch_entry.yml を追加（workflow_dispatch -> uses: .github/workflows/mep_writeback_bundle_dispatch.yml）。
- pr_number は workflow_call 側が受ける場合のみ with で渡す（unknown inputs 回避）。