### PR TITLE
fix(mep): activate writeback dispatch entrypoint

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch_entry.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch_entry.yml
@@ -1,4 +1,4 @@
-name: MEP Writeback Bundle Entry (Dispatch)
+name: MEP Writeback Bundle Entry (Dispatch) [20260131_015643]
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
目的:
- writeback の入口 workflow_dispatch（entry）を main に確実に反映し、gh workflow list / view で認識できる状態へ収束。

一次根拠:
- entry が active workflow として認識されておらず、dispatch/run が成立しない。

対策:
- entry YAML を PowerShell 展開なしで生成し、かつ name にスタンプを入れて “必ず差分” を作る。
- called(workflow_call) が pr_number を受ける場合のみ with で渡す。