### PR TITLE
fix(ci): evidence dispatch accepts inputs.pr_number

### DIFF
--- a/.github/workflows/mep_writeback_bundle_evidence_dispatch.yml
+++ b/.github/workflows/mep_writeback_bundle_evidence_dispatch.yml
@@ -35,3 +35,84 @@ jobs:
             -BundleScope "evidence-child" `
             -TargetBranchPrefix "auto/writeback-evidence-bundle"
 
+
+name: mep_writeback_bundle_evidence_dispatch
+
+on:
+  workflow_dispatch:
+    inputs:
+      prNumber:
+        description: "Optional: PR number to record (0 = auto latest merged)"
+        required: false
+        default: "0"
+
+jobs:
+  writeback-evidence:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure git identity (CI)
+        run: |
+          git config --global user.name  "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Writeback EVIDENCE child MEP bundle (create PR)
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ./tools/mep_writeback_bundle.ps1 `
+            -Mode "pr" `
+            -PrNumber ([int]"${{ github.event.inputs.prNumber }}") `
+            -BundlePath "docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md" `
+            -BundleScope "evidence-child" `
+            -TargetBranchPrefix "auto/writeback-evidence-bundle"
+
+
+  inputs:
+    pr_number:
+      description: 'PR number to writeback (0 = latest)'
+      required: false
+      default: '0'
+name: mep_writeback_bundle_evidence_dispatch
+
+on:
+  workflow_dispatch:
+    inputs:
+      prNumber:
+        description: "Optional: PR number to record (0 = auto latest merged)"
+        required: false
+        default: "0"
+
+jobs:
+  writeback-evidence:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure git identity (CI)
+        run: |
+          git config --global user.name  "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Writeback EVIDENCE child MEP bundle (create PR)
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ./tools/mep_writeback_bundle.ps1 `
+            -Mode "pr" `
+            -PrNumber ([int]"${{ github.event.inputs.prNumber }}") `
+            -BundlePath "docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md" `
+            -BundleScope "evidence-child" `
+            -TargetBranchPrefix "auto/writeback-evidence-bundle"
+


### PR DESCRIPTION
Expand workflow_dispatch mapping (handle shorthand), add inputs.pr_number, and pass it to tools/mep_writeback_bundle.ps1 (was effectively fixed to 0). Enables evidence writeback for a specific implementation PR.