### PR TITLE
fix(ci): generate Bundled before writeback

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch.yml
@@ -41,6 +41,17 @@ jobs:
         run: |
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Generate Bundled (update docs/MEP/MEP_BUNDLE.md)
+        shell: pwsh
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = "Stop"
+
+          # Generate/update Bundled BEFORE writeback diff-check
+          pwsh -NoProfile -File tools/mep_bump_bundle_version.ps1 -BundlePath "docs/MEP/MEP_BUNDLE.md"
+
+          # Show diff status for evidence (non-fatal)
+          git status --porcelain -- docs/MEP/MEP_BUNDLE.md || true
 
       - name: Writeback evidence -> PR (slim)
         shell: pwsh


### PR DESCRIPTION
目的:
- writeback が常に "No diff" で終了して BV が動かない問題を収束させる。

一次根拠:
- ENTRY run ログで tools/mep_writeback_bundle.ps1 が "No diff for bundle. Exit 0." となり PR が作られていない。
- Bundled( docs/MEP/MEP_BUNDLE.md ) を更新する生成処理が writeback の前に走っていない。

対策:
- called workflow(.github/workflows/mep_writeback_bundle_dispatch.yml) に
  "Generate Bundled (update docs/MEP/MEP_BUNDLE.md)" step を追加し、
  その直後に既存の writeback(diff/PR作成) を実行する。