### PR TITLE
fix(ci): generate Bundled via integration compiler before writeback

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch.yml
@@ -1,3 +1,4 @@
+# PATCH_MARKER: generate-via-compiler 20260131_021532
 name: MEP Writeback Bundle (Evidence)
 
 on:
@@ -42,17 +43,8 @@ jobs:
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
       - name: Generate Bundled (update docs/MEP/MEP_BUNDLE.md)
-        shell: pwsh
-        run: |
-          Set-StrictMode -Version Latest
-          $ErrorActionPreference = "Stop"
-
-          # Generate/update Bundled BEFORE writeback diff-check
-          pwsh -NoProfile -File tools/mep_bump_bundle_version.ps1 -BundlePath "docs/MEP/MEP_BUNDLE.md"
-
-          # Show diff status for evidence (non-fatal)
-          git status --porcelain -- docs/MEP/MEP_BUNDLE.md || true
-
+        uses: ./.github/workflows/mep_integration_compiler.yml
+        secrets: inherit
       - name: Writeback evidence -> PR (slim)
         shell: pwsh
         env:


### PR DESCRIPTION
目的:
- writeback が "No diff" で終わって PR が作られない問題を収束させる。

一次根拠:
- ENTRY run で tools/mep_writeback_bundle.ps1 が "No diff for bundle. Exit 0." となり auto/writeback PR が作られていない。

対策:
- called workflow の "Generate Bundled" を bump系の tools 実行ではなく、
  .github/workflows/mep_integration_compiler.yml を uses で呼び出す形に置換/注入して、
  Bundled再生成→差分→writeback PR 作成へ繋げる。