### PR TITLE
fix(ci): writeback called-workflow parse fix (remove invalid secrets)

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch.yml
@@ -1,3 +1,4 @@
+# PATCH_MARKER: gen-runstep 20260131_021740
 # PATCH_MARKER: generate-via-compiler 20260131_021532
 name: MEP Writeback Bundle (Evidence)
 
@@ -43,8 +44,16 @@ jobs:
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
       - name: Generate Bundled (update docs/MEP/MEP_BUNDLE.md)
-        uses: ./.github/workflows/mep_integration_compiler.yml
-        secrets: inherit
+        shell: pwsh
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = "Stop"
+
+          # (re)generate Bundled so diff can exist BEFORE writeback
+          pwsh -NoProfile -File tools/mep_bump_bundle_version.ps1 -BundlePath "docs/MEP/MEP_BUNDLE.md"
+
+          # evidence (non-fatal)
+          git status --porcelain -- docs/MEP/MEP_BUNDLE.md || true
       - name: Writeback evidence -> PR (slim)
         shell: pwsh
         env:


### PR DESCRIPTION
目的:
- ENTRY dispatch が 422 (called workflow YAML parse) で落ちるのを収束し、
  writeback が "No diff" で終わらず PR を作れるようにする。

一次根拠:
- called workflow の Generate Bundled step を uses+secrets で書いた結果、
  YAML parse エラー: Unexpected value 'secrets' が発生。

対策:
- Generate Bundled step を通常の run-step に戻し、secrets フィールドを排除。
- Bundled の再生成には tools/mep_bump_bundle_version.ps1 を使用し、
  その後に既存 writeback(diff/PR作成) を実行する。