### PR TITLE
fix(ci): rebuild evidence dispatch workflow (accept pr_number)

### DIFF
--- a/.github/workflows/mep_writeback_bundle_evidence_dispatch.yml
+++ b/.github/workflows/mep_writeback_bundle_evidence_dispatch.yml
@@ -1,4 +1,5 @@
 name: MEP Writeback Bundle (Evidence)
+
 on:
   workflow_dispatch:
     inputs:
@@ -7,24 +8,16 @@ on:
         required: false
         default: '0'
 
-name: mep_writeback_bundle_evidence_dispatch
-
-on:
-  workflow_dispatch:
-    inputs:
-      prNumber:
-        description: "Optional: PR number to record (0 = auto latest merged)"
-        required: false
-        default: "0"
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   writeback-evidence:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -32,215 +25,14 @@ jobs:
         run: |
           git config --global user.name  "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
       - name: Writeback EVIDENCE child MEP bundle (create PR)
-        shell: pwsh
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          ./tools/mep_writeback_bundle.ps1 `
+          pwsh -NoProfile -File tools/mep_writeback_bundle.ps1 `
             -Mode "pr" `
-            -PrNumber ([int]"${{ github.event.inputs.prNumber }}") `
+            -PrNumber ([int]"${{ github.event.inputs.pr_number }}") `
             -BundlePath "docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md" `
             -BundleScope "evidence-child" `
             -TargetBranchPrefix "auto/writeback-evidence-bundle"
-
-
-name: mep_writeback_bundle_evidence_dispatch
-
-on:
-  workflow_dispatch:
-    inputs:
-      prNumber:
-        description: "Optional: PR number to record (0 = auto latest merged)"
-        required: false
-        default: "0"
-
-jobs:
-  writeback-evidence:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Configure git identity (CI)
-        run: |
-          git config --global user.name  "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-      - name: Writeback EVIDENCE child MEP bundle (create PR)
-        shell: pwsh
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          ./tools/mep_writeback_bundle.ps1 `
-            -Mode "pr" `
-            -PrNumber ([int]"${{ github.event.inputs.prNumber }}") `
-            -BundlePath "docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md" `
-            -BundleScope "evidence-child" `
-            -TargetBranchPrefix "auto/writeback-evidence-bundle"
-
-
-  inputs:
-    pr_number:
-      description: 'PR number to writeback (0 = latest)'
-      required: false
-      default: '0'
-name: mep_writeback_bundle_evidence_dispatch
-
-on:
-  workflow_dispatch:
-    inputs:
-      prNumber:
-        description: "Optional: PR number to record (0 = auto latest merged)"
-        required: false
-        default: "0"
-
-jobs:
-  writeback-evidence:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Configure git identity (CI)
-        run: |
-          git config --global user.name  "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-      - name: Writeback EVIDENCE child MEP bundle (create PR)
-        shell: pwsh
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          ./tools/mep_writeback_bundle.ps1 `
-            -Mode "pr" `
-            -PrNumber ([int]"${{ github.event.inputs.prNumber }}") `
-            -BundlePath "docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md" `
-            -BundleScope "evidence-child" `
-            -TargetBranchPrefix "auto/writeback-evidence-bundle"
-
-
-name: mep_writeback_bundle_evidence_dispatch
-
-on:
-  workflow_dispatch:
-    inputs:
-      prNumber:
-        description: "Optional: PR number to record (0 = auto latest merged)"
-        required: false
-        default: "0"
-
-jobs:
-  writeback-evidence:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Configure git identity (CI)
-        run: |
-          git config --global user.name  "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-      - name: Writeback EVIDENCE child MEP bundle (create PR)
-        shell: pwsh
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          ./tools/mep_writeback_bundle.ps1 `
-            -Mode "pr" `
-            -PrNumber ([int]"${{ github.event.inputs.prNumber }}") `
-            -BundlePath "docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md" `
-            -BundleScope "evidence-child" `
-            -TargetBranchPrefix "auto/writeback-evidence-bundle"
-
-
-name: mep_writeback_bundle_evidence_dispatch
-
-on:
-  workflow_dispatch:
-    inputs:
-      prNumber:
-        description: "Optional: PR number to record (0 = auto latest merged)"
-        required: false
-        default: "0"
-
-jobs:
-  writeback-evidence:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Configure git identity (CI)
-        run: |
-          git config --global user.name  "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-      - name: Writeback EVIDENCE child MEP bundle (create PR)
-        shell: pwsh
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          ./tools/mep_writeback_bundle.ps1 `
-            -Mode "pr" `
-            -PrNumber ([int]"${{ github.event.inputs.prNumber }}") `
-            -BundlePath "docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md" `
-            -BundleScope "evidence-child" `
-            -TargetBranchPrefix "auto/writeback-evidence-bundle"
-
-
-  inputs:
-    pr_number:
-      description: 'PR number to writeback (0 = latest)'
-      required: false
-      default: '0'
-name: mep_writeback_bundle_evidence_dispatch
-
-on:
-  workflow_dispatch:
-    inputs:
-      prNumber:
-        description: "Optional: PR number to record (0 = auto latest merged)"
-        required: false
-        default: "0"
-
-jobs:
-  writeback-evidence:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Configure git identity (CI)
-        run: |
-          git config --global user.name  "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-      - name: Writeback EVIDENCE child MEP bundle (create PR)
-        shell: pwsh
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          ./tools/mep_writeback_bundle.ps1 `
-            -Mode "pr" `
-            -PrNumber ([int]"${{ github.event.inputs.prNumber }}") `
-            -BundlePath "docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md" `
-            -BundleScope "evidence-child" `
-            -TargetBranchPrefix "auto/writeback-evidence-bundle"
-


### PR DESCRIPTION
Rebuild .github/workflows/mep_writeback_bundle_evidence_dispatch.yml into a minimal valid workflow_dispatch with inputs.pr_number and run tools/mep_writeback_bundle.ps1 using github.event.inputs.pr_number. This removes 422 Unexpected inputs and unblocks evidence writeback targeting a specific PR.