### PR TITLE
Fix: auto writeback should create PR (mep_writeback_bundle.ps1)

### DIFF
--- a/tools/mep_writeback_bundle.ps1
+++ b/tools/mep_writeback_bundle.ps1
@@ -1,4 +1,17 @@
-param(
+
+# --- create PR for the writeback branch (Mode=pr) ---
+try {
+  $prTitle = ("Writeback bundle evidence (PrNumber={0})" -f $PrNumber)
+  $prBody  = ("Automated writeback bundle evidence. Mode={0} PrNumber={1} BundleScope={2} BundlePath={3}" -f $Mode,$PrNumber,$BundleScope,$BundlePath)
+  $prUrl = (gh pr create --title $prTitle --body $prBody --base "main" --head $br)
+  if ($prUrl) {
+    Write-Host ("[INFO] Created PR: {0}" -f $prUrl)
+  } else {
+    Write-Host "[WARN] gh pr create returned empty. A PR may already exist."
+  }
+} catch {
+  Write-Host ("[WARN] gh pr create failed: {0}" -f $_.Exception.Message)
+}param(
   [int]$PrNumber = 0
   ,[ValidateSet("pr","update")][string]$Mode = "pr"
   ,[string]$BundlePath = "docs/MEP/MEP_BUNDLE.md"


### PR DESCRIPTION
tools/mep_writeback_bundle.ps1 created writeback branches but did not run 'gh pr create', forcing manual PR creation and blocking Bundled evidence. This adds PR creation right after branch push.