### PR TITLE
Fix: writeback workflow should auto-create PR for auto/writeback-bundle branch

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch.yml
@@ -61,6 +61,35 @@ jobs:
         run: |
           pwsh -NoProfile -File tools/mep_writeback_bundle.ps1 -Mode pr -PrNumber ${{ inputs.pr_number }} -BundlePath "docs/MEP/MEP_BUNDLE.md" -BundleScope "parent"
 
+      - name: Create PR for writeback branch
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.MEP_PR_TOKEN }}
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+          function Info([string]$m){ Write-Host ('[INFO] {0}' -f $m) }
+          function Warn([string]$m){ Write-Host ('[WARN] {0}' -f $m) }
+          
+          # If current branch is auto/writeback-bundle_*, create PR (if not exists)
+          $head = (git rev-parse --abbrev-ref HEAD).Trim()
+          Info ('HEAD=' + $head)
+          if ($head -notlike 'auto/writeback-bundle_*') {
+            Warn 'Not on auto/writeback-bundle_* branch; skip PR create.'
+            exit 0
+          }
+          
+          # if PR already exists for this head, skip
+          $exists = gh pr list --state open --head $head --json number --jq '.[0].number' 2>$null
+          if ($exists) {
+            Info ('PR already exists for head ' + $head + ': #' + $exists)
+            exit 0
+          }
+          
+          $title = ('Writeback bundle evidence ({0})' -f $head)
+          $body  = ('Automated writeback: created from branch {0} (run_id=' + ${{ github.run_id }} + ')' -f $head)
+          $url = gh pr create --title $title --body $body --base 'main' --head $head
+          Info ('Created PR: ' + $url)
       - name: Writeback HANDOFF_NEXT -> PR (slim)
         if: ${{ inputs.write_handoff == 'true' }}
         shell: pwsh
@@ -68,3 +97,4 @@ jobs:
           GH_TOKEN: ${{ secrets.MEP_PR_TOKEN }}
         run: |
           pwsh -NoProfile -File tools/mep_writeback_handoff.ps1 -CI
+


### PR DESCRIPTION
Writeback run creates and pushes auto/writeback-bundle_* branches but does not create a PR, forcing manual work and blocking Bundled evidence. Add a workflow step to create the PR when HEAD is auto/writeback-bundle_*.