### PR TITLE
feat(mep): Scope-IN + DoD for pre-gate automation

### DIFF
--- a/platform/MEP/01_CORE/cards/PRE_GATE_AUTOMATION_DOD.md
+++ b/platform/MEP/01_CORE/cards/PRE_GATE_AUTOMATION_DOD.md
@@ -1,0 +1,18 @@
+# PRE-GATE完全自動化：DoD（完成定義）
+
+## 1. Done（成立条件：必須）
+- PRが main にマージされ、Bundled（MEP_BUNDLE.md）の先頭 `BUNDLE_VERSION = ...` が更新されている
+- Bundled内に、対象PRの証跡行として以下を含む行が存在する
+  - `audit=OK,WB0000`
+  - `acceptance:SUCCESS`
+  - `guard:SUCCESS`
+  - `Scope Guard (PR):SUCCESS`
+  - `Text Integrity Guard (PR):SUCCESS`
+
+## 2. 例外（SKIPPED許容の条件）
+- `merge_repair_pr:SKIPPED` は既存運用上の発生があり得るため、他の必須がSUCCESSなら許容
+- その他のSKIPPED許容は、ここへ追記してからのみ許容（追記もPR→main→Bundledが前提）
+
+## 3. 監査一次根拠
+- 会話やメモは確定根拠にしない
+- 確定は **PR → main → Bundled** の証跡でのみ成立

--- a/platform/MEP/01_CORE/cards/PRE_GATE_AUTOMATION_SCOPE_IN.md
+++ b/platform/MEP/01_CORE/cards/PRE_GATE_AUTOMATION_SCOPE_IN.md
@@ -1,0 +1,20 @@
+# PRE-GATE完全自動化：Scope-IN（対象固定）
+
+## 1. IN（対象）
+- MEPの **pre-gate / read-only suite** を「毎回ブレずに回す」ために必要な更新
+  - 運用ドキュメント（ガード仕様・証跡仕様・実行ルール）
+  - それらに付随する workflow / script の **最小修正**（チェックが安定して回る範囲）
+- PR→main→Bundled（BUNDLE_VERSION更新）で **証跡を残せる**変更のみ
+
+## 2. OUT（対象外：当面）
+- BUSINESSの大規模再編・大量生成・ディレクトリ移動
+- Required checks（B運用）への全面移行（別スコープで扱う）
+- UI/UX屋上のFULLAUTO拡張（別スコープで扱う）
+
+## 3. 境界・例外
+- 既存チェックが SKIPPED になり得る項目は、DoD側で「許容条件」を明文化した場合のみ許容
+- 監査一次根拠（Bundled）に載らない状態の主張は確定扱いしない
+
+## 4. 検証（このScopeを担保する方法）
+- PR checks が SUCCESS で揃うこと（最低限：acceptance / guard / Scope Guard / Text Integrity Guard）
+- Bundledに `audit=OK,WB0000` を含む証跡行が残ること（PR→main→Bundled）


### PR DESCRIPTION
目的：
- PRE-GATE完全自動化の土台として「対象（Scope-IN）」と「Done判定（DoD）」を Bundled入力対象（platform/MEP/01_CORE）に固定する。

追加：
- platform/MEP/01_CORE/cards/PRE_GATE_AUTOMATION_SCOPE_IN.md
- platform/MEP/01_CORE/cards/PRE_GATE_AUTOMATION_DOD.md