### PR TITLE
fix(scope): allow cards/** in CURRENT_SCOPE Scope-IN

### DIFF
--- a/platform/MEP/90_CHANGES/CURRENT_SCOPE.md
+++ b/platform/MEP/90_CHANGES/CURRENT_SCOPE.md
@@ -1,6 +1,7 @@
 # CURRENT_SCOPE（唯一の正：変更範囲の許可リスト）
 
 ## 変更対象（Scope-IN）
+- platform/MEP/01_CORE/cards/**
 - START_HERE.md
 - .mep/CURRENT_STAGE.txt
 - .github/ISSUE_TEMPLATE/mep_dispatch.yml


### PR DESCRIPTION
Scope Guard (PR) を通すため、CURRENT_SCOPE の「変更対象（Scope-IN）」へ以下を追加：
- platform/MEP/01_CORE/cards/**

目的：
- 以後、platform/MEP/01_CORE/cards 配下のカード追加・更新が out-of-scope にならないようにする。