### PR TITLE
Fix: mep_append_evidence_line.ps1 param binding (BundlePath -> Int32 bug)

### DIFF
--- a/tools/mep_append_evidence_line.ps1
+++ b/tools/mep_append_evidence_line.ps1
@@ -7,28 +7,75 @@ param(
   [Parameter(Mandatory=$true)]
   [int]$PrNumber,
 
-  [string]$BundlePath = "docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md"
+  [Parameter(Mandatory=$true)]
+  [string]$BundlePath
 )
 
+
+
+
+
 function Fail([string]$m){ throw $m }
+
+
 function Info([string]$m){ Write-Host "[INFO] $m" }
+
+
 function Ok([string]$m){ Write-Host "[OK]   $m" }
 
+
+
+
+
 # repo root
+
+
 $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+
+
 $abs = Join-Path $RepoRoot $BundlePath
+
+
 if (-not (Test-Path -LiteralPath $abs)) { Fail "Bundle not found: $BundlePath" }
 
+
+
+
+
 # if already present, no-op
+
+
 $already = Select-String -LiteralPath $abs -Pattern ("PR\s*#"+$PrNumber) -ErrorAction SilentlyContinue | Select-Object -First 1
+
+
 if ($already) {
+
+
   Ok ("already_present=PR #{0}" -f $PrNumber)
+
+
   exit 0
+
+
 }
 
+
+
+
+
 # append evidence line (minimal: your verifier searches 'PR #1310' anywhere)
+
+
 $utc = [DateTime]::UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ")
+
+
 $line = ("PR #{0} | audit=OK,WB0000 | appended_at={1} | via=mep_append_evidence_line.ps1" -f $PrNumber,$utc)
 
+
+
+
+
 Add-Content -LiteralPath $abs -Value $line -Encoding utf8
+
+
 Ok ("appended={0}" -f $line)


### PR DESCRIPTION
Evidence writeback fails with:
  Cannot convert value "docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md" to type System.Int32

Root cause: tools/mep_append_evidence_line.ps1 param() is corrupted, causing -BundlePath to bind into Int32.
Fix: replace the first param() block with a known-good (PrNumber:int, BundlePath:string) block.