### PR TITLE
Fix: mep_append_evidence_line.ps1 param() must be first statement (fix InvalidOperation at param)

### DIFF
--- a/tools/mep_append_evidence_line.ps1
+++ b/tools/mep_append_evidence_line.ps1
@@ -1,24 +1,39 @@
-Set-StrictMode -Version Latest
-$ErrorActionPreference = "Stop"
-[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
-$OutputEncoding = [Console]::OutputEncoding
-
 param(
+
+
   [Parameter(Mandatory=$true)]
+
+
   [int]$PrNumber,
 
+
+
+
+
   [Parameter(Mandatory=$true)]
+
+
   [string]$BundlePath
+
+
 )
-
-
-
-
 
 function Fail([string]$m){ throw $m }
 
 
+
+
+
+
+
+
 function Info([string]$m){ Write-Host "[INFO] $m" }
+
+
+
+
+
+
 
 
 function Ok([string]$m){ Write-Host "[OK]   $m" }
@@ -27,13 +42,43 @@ function Ok([string]$m){ Write-Host "[OK]   $m" }
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
 # repo root
+
+
+
+
+
+
 
 
 $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
 
 
+
+
+
+
+
+
 $abs = Join-Path $RepoRoot $BundlePath
+
+
+
+
+
+
 
 
 if (-not (Test-Path -LiteralPath $abs)) { Fail "Bundle not found: $BundlePath" }
@@ -42,19 +87,61 @@ if (-not (Test-Path -LiteralPath $abs)) { Fail "Bundle not found: $BundlePath" }
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
 # if already present, no-op
+
+
+
+
+
+
 
 
 $already = Select-String -LiteralPath $abs -Pattern ("PR\s*#"+$PrNumber) -ErrorAction SilentlyContinue | Select-Object -First 1
 
 
+
+
+
+
+
+
 if ($already) {
+
+
+
+
+
+
 
 
   Ok ("already_present=PR #{0}" -f $PrNumber)
 
 
+
+
+
+
+
+
   exit 0
+
+
+
+
+
+
 
 
 }
@@ -63,10 +150,34 @@ if ($already) {
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
 # append evidence line (minimal: your verifier searches 'PR #1310' anywhere)
 
 
+
+
+
+
+
+
 $utc = [DateTime]::UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ")
+
+
+
+
+
+
 
 
 $line = ("PR #{0} | audit=OK,WB0000 | appended_at={1} | via=mep_append_evidence_line.ps1" -f $PrNumber,$utc)
@@ -75,7 +186,28 @@ $line = ("PR #{0} | audit=OK,WB0000 | appended_at={1} | via=mep_append_evidence_
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
 Add-Content -LiteralPath $abs -Value $line -Encoding utf8
 
 
+
+
+
+
+
+
 Ok ("appended={0}" -f $line)
+
+
+


### PR DESCRIPTION
Evidence writeback fails with:
  InvalidOperation ... Line | param( ... ) The function or command was called as if it were a method.

Root cause:
  tools/mep_append_evidence_line.ps1 had executable statements before param(), so PowerShell treated param( as a command call.

Fix:
  Move param() to the top of the script (after comments/#requires only), keep the existing param block and body.