### PR TITLE
chore(mep): append evidence lines into parent Bundled (target=1353, writeback=1382)

### DIFF
--- a/docs/MEP/MEP_BUNDLE.md
+++ b/docs/MEP/MEP_BUNDLE.md
@@ -765,3 +765,5 @@ Bundled 本文に基づき、
 
 
 
+PR #1353 | audit=OK,WB0000 | appended_at=2026-01-30T19:00:58Z | via=mep_append_evidence_line.ps1
+PR #1382 | audit=OK,WB0000 | appended_at=2026-01-30T19:00:58Z | via=mep_append_evidence_line.ps1


### PR DESCRIPTION
Append audit evidence lines into parent Bundled so checks can succeed.

- target PR: #1353
- latest writeback-bundle PR: #1382

Files:
- docs/MEP/MEP_BUNDLE.md
Tool:
- tools/mep_append_evidence_line.ps1