### PR TITLE
fix(mep): writeback bundle path should point to parent Bundled

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch.yml
@@ -43,23 +43,23 @@ jobs:
         run: |
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-      - name: Generate Bundled (update docs/MEP_SUB/HANDOFF/MEP_BUNDLE.md)
+      - name: Generate Bundled (update docs/MEP/MEP_BUNDLE.md)
         shell: pwsh
         run: |
           Set-StrictMode -Version Latest
           $ErrorActionPreference = "Stop"
 
           # (re)generate Bundled so diff can exist BEFORE writeback
-          pwsh -NoProfile -File tools/mep_bump_bundle_version.ps1 -BundlePath "docs/MEP_SUB/HANDOFF/MEP_BUNDLE.md"
+          pwsh -NoProfile -File tools/mep_bump_bundle_version.ps1 -BundlePath "docs/MEP/MEP_BUNDLE.md"
 
           # evidence (non-fatal)
-          git status --porcelain -- docs/MEP_SUB/HANDOFF/MEP_BUNDLE.md || true
+          git status --porcelain -- docs/MEP/MEP_BUNDLE.md || true
       - name: Writeback evidence -> PR (slim)
         shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.MEP_PR_TOKEN }}
         run: |
-          pwsh -NoProfile -File tools/mep_writeback_bundle.ps1 -Mode pr -PrNumber ${{ inputs.pr_number }} -BundlePath "docs/MEP_SUB/HANDOFF/MEP_BUNDLE.md" -BundleScope "parent"
+          pwsh -NoProfile -File tools/mep_writeback_bundle.ps1 -Mode pr -PrNumber ${{ inputs.pr_number }} -BundlePath "docs/MEP/MEP_BUNDLE.md" -BundleScope "parent"
 
       - name: Create PR for writeback branch
         shell: pwsh
@@ -104,8 +104,9 @@ jobs:
           set -euo pipefail
           if git diff --name-only | grep -q '^docs/MEP/MEP_BUNDLE\.md$'; then
             echo "ERROR: HANDOFF_NEXT must not modify docs/MEP/MEP_BUNDLE.md (parent Bundled)."
-            echo "This prevents writeback-order rollback. Write to docs/MEP_SUB/HANDOFF/MEP_BUNDLE.md instead."
+            echo "This prevents writeback-order rollback. Write to docs/MEP/MEP_BUNDLE.md instead."
             git diff -- docs/MEP/MEP_BUNDLE.md || true
             exit 1
           fi
+
 


### PR DESCRIPTION
Fixes workflow_dispatch writeback failure:
- tools/mep_writeback_bundle.ps1 was invoked with BundleScope=parent but BundlePath pointed to a non-existent file.
- Replace BundlePath: docs/MEP_SUB/HANDOFF/MEP_BUNDLE.md -> docs/MEP/MEP_BUNDLE.md
This restores reproducible parent Bundled writeback for PR-number targets (e.g., #1388).