### PR TITLE
chore(mep): restore evidence lines (PR #1353/#1395)

### DIFF
--- a/docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md
+++ b/docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md
@@ -8,3 +8,7 @@ PR #1081 | mergedAt=01/21/2026 19:58:11 | mergeCommit=fe1ef735bd1cedc57fc81ec6bf
 PR #1082 | mergedAt=01/21/2026 19:58:51 | mergeCommit=291bd76adc85dd3c7e71d53006374fe77504f372 | BUNDLE_VERSION=v0.0.0+20260122_045853+main+child | audit=OK,WB0000 | acceptance:SUCCESS, Business Packet Guard (PR):SUCCESS, done_check:SUCCESS, enable_auto_merge:SUCCESS, merge_repair_pr:SKIPPED, semantic-audit-business:SUCCESS, semantic-audit:SUCCESS, suggest:SUCCESS, Text Integrity Guard (PR):SUCCESS | https://github.com/Osuu-ops/yorisoidou-system/pull/1082
 
 
+PR #1353 | audit=OK,WB0000 | appended_at=2026-01-30T18:46:42Z | via=mep_append_evidence_line.ps1
+
+PR #1395 | audit=OK,WB0000 | appended_at=2026-01-31T05:15:56Z | via=mep_append_evidence_line.ps1
+


### PR DESCRIPTION
目的: EVIDENCE_BUNDLE から欠落した可能性のある証跡行（PR #1353 / PR #1395）を、過去コミットから抽出して復元する。
変更: docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md の末尾に該当行を追記（重複は追加しない）。