### PR TITLE
fix(actions): writeback GH_TOKEN/permissions (401)

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch.yml
@@ -32,7 +32,11 @@ permissions:
 
 jobs:
   writeback:
-    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}    permissions:
+      contents: write
+      pull-requests: write
+      actions: read    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -108,5 +112,6 @@ jobs:
             git diff -- docs/MEP/MEP_BUNDLE.md || true
             exit 1
           fi
+
 
 


### PR DESCRIPTION
Fix writeback failures: GH CLI got HTTP 401 (Bad credentials). Add job permissions (contents/pr write) and set GH_TOKEN from github.token.