### PR TITLE
chore(decontam): remove unreferenced EVIDENCE_BUNDLE.md

### DIFF
--- a/docs/MEP/EVIDENCE_BUNDLE.md
+++ b/docs/MEP/EVIDENCE_BUNDLE.md
@@ -1,2 +1,0 @@
-## appended_at=2026-01-31T05:15:56Z
-via=mep_append_evidence_line.ps1


### PR DESCRIPTION
Bundled/EVIDENCE基準で「参照されない成果物」は汚染候補。
docs/MEP/EVIDENCE_BUNDLE.md が repo 内から参照されないため、削除PRとして隔離します（必要なら差し戻し可能）。

- Action: remove docs/MEP/EVIDENCE_BUNDLE.md
- Note: local untracked workflow was backed up separately to avoid accidental commit