### PR TITLE
chore(ci): restore valid workflow YAML (from last SUCCESS) to fix jobs=0

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch.yml
@@ -1,20 +1,38 @@
 # PATCH_MARKER: gen-runstep 20260131_021740
 # PATCH_MARKER: generate-via-compiler 20260131_021532
 name: MEP Writeback Bundle (Evidence)
+
 on:
+  workflow_call:
+    inputs:
+      pr_number:
+        description: 'PR number (0 = auto latest merged PR)'
+        required: false
+        type: string
+        default: '0'
+      write_handoff:
+        description: 'Generate+Guard+Writeback HANDOFF_NEXT into Bundled'
+        required: false
+        type: string
+        default: 'false'
   workflow_dispatch:
     inputs:
       pr_number:
-        description: 'PR number (0 = latest merged PR)'
-        required: true
+        description: 'PR number (0 = auto latest merged PR)'
+        required: false
         default: '0'
+      write_handoff:
+        description: 'Generate+Guard+Writeback HANDOFF_NEXT into Bundled'
+        required: false
+        default: 'false'
+
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   writeback:
-    env:
-      GH_TOKEN: ${{ github.token }}    permissions:
-      contents: write
-      pull-requests: write
-      actions: read    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -90,7 +108,6 @@ jobs:
             git diff -- docs/MEP/MEP_BUNDLE.md || true
             exit 1
           fi
-
 
 
 


### PR DESCRIPTION
Context:
- Symptom: runs show jobs.total_count=0 and logs are unavailable ("log not found") => jobs never materialized.
- Restore workflow YAML from latest SUCCESS run to regain valid evaluation.

Fix:
- Replace .github/workflows/mep_writeback_bundle_dispatch.yml with the version from SUCCESS run 21527724970.

Evidence:
- SUCCESS sha: 04f6f175579c3a948d1e2a83fa12a35a481a0748
- SUCCESS url: https://github.com/Osuu-ops/yorisoidou-system/actions/runs/21527724970