### PR TITLE
chore(ci): enable push trigger for mep_writeback workflow

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch.yml
@@ -1,8 +1,9 @@
 # PATCH_MARKER: gen-runstep 20260131_021740
 # PATCH_MARKER: generate-via-compiler 20260131_021532
 name: MEP Writeback Bundle (Evidence)
-
 on:
+  push:
+    branches: [ main ]
   workflow_call:
     inputs:
       pr_number:
@@ -108,6 +109,7 @@ jobs:
             git diff -- docs/MEP/MEP_BUNDLE.md || true
             exit 1
           fi
+
 
 
 


### PR DESCRIPTION
Context:
- Workflow runs show jobs.total_count=0 and logs unavailable ("log not found"), meaning jobs never materialized.
- Also observed: no new run was created after merging workflow-related changes, suggesting push trigger missing or filters not matching.

Change:
- Ensure workflow triggers on push to main (or force re-evaluation with no-op if push already present).

Goal:
- After merge, a new workflow run should be created, and jobs.total_count should be > 0.