### PR TITLE
chore(ci): add push caller for mep writeback (fix jobs=0)

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch.yml
@@ -2,8 +2,6 @@
 # PATCH_MARKER: generate-via-compiler 20260131_021532
 name: MEP Writeback Bundle (Evidence)
 on:
-  push:
-    branches: [ main ]
   workflow_call:
     inputs:
       pr_number:
@@ -109,6 +107,7 @@ jobs:
             git diff -- docs/MEP/MEP_BUNDLE.md || true
             exit 1
           fi
+
 
 
 

--- a/.github/workflows/mep_writeback_bundle_on_push.yml
+++ b/.github/workflows/mep_writeback_bundle_on_push.yml
@@ -1,0 +1,18 @@
+name: MEP Writeback Bundle (Push Caller)
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  call_writeback:
+    uses: ./.github/workflows/mep_writeback_bundle_dispatch.yml
+    with:
+      pr_number: '0'
+      write_handoff: 'false'
+    secrets: inherit


### PR DESCRIPTION
Problem:
- The reusable workflow '.github/workflows/mep_writeback_bundle_dispatch.yml' has 'workflow_call/workflow_dispatch' inputs (inputs.pr_number etc).
- Direct 'push' execution can lead to evaluation-time failure (inputs undefined), producing jobs.total_count=0 and no logs.

Fix:
- Keep '.github/workflows/mep_writeback_bundle_dispatch.yml' reusable only (workflow_call/workflow_dispatch).
- Add '.github/workflows/mep_writeback_bundle_on_push.yml' which triggers on push(main) and calls the reusable workflow with explicit inputs and secrets:inherit.

Expected:
- New runs should materialize jobs (>0) and produce logs.