### PR TITLE
Handoff: generate minimal 2-line audit paste (parent BV + latest OK evidence)

### DIFF
--- a/tools/mep_handoff_two_line.ps1
+++ b/tools/mep_handoff_two_line.ps1
@@ -1,0 +1,75 @@
+#requires -version 7.0
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+$OutputEncoding = [Console]::OutputEncoding
+
+param(
+  [switch]$ToClipboard,
+  [switch]$ToDesktopFile
+)
+
+function Fail([string]$m){ throw $m }
+
+# Repo root
+$root = (git rev-parse --show-toplevel 2>$null)
+if (-not $root) { Fail "Not a git repo (git rev-parse failed)." }
+Set-Location $root
+
+# Fixed paths (canonical)
+$repoOrigin     = (git remote get-url origin 2>$null)
+$parentBundled  = "docs/MEP/MEP_BUNDLE.md"
+$evidenceBundled= "docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md"
+
+if (!(Test-Path $parentBundled))   { Fail "Missing: $parentBundled" }
+if (!(Test-Path $evidenceBundled)) { Fail "Missing: $evidenceBundled" }
+
+# Extract: parent BUNDLE_VERSION line (first occurrence)
+$parentLines = Get-Content -LiteralPath $parentBundled -Encoding UTF8
+$parentBV = ($parentLines | Select-String -Pattern '^\s*\*?\s*BUNDLE_VERSION\s*=\s*.+$' -SimpleMatch:$false | Select-Object -First 1).Line
+if (-not $parentBV) { Fail "BUNDLE_VERSION line not found in parent bundled." }
+
+# Extract: latest evidence PR line with audit=OK,WB0000 (last occurrence)
+$evLines = Get-Content -LiteralPath $evidenceBundled -Encoding UTF8
+$hits = ($evLines | Select-String -Pattern 'PR\s*#\d+.*audit=OK,WB0000' -SimpleMatch:$false)
+if (-not $hits -or $hits.Count -eq 0) { Fail "No evidence line matched: PR #... audit=OK,WB0000" }
+$evLine = $hits[-1].Line
+
+# Compose minimal handoff (2-line evidence)
+$out = @()
+$out += "【HANDOFF｜次チャット冒頭に貼る本文（監査用・一次根拠のみ）】"
+$out += ""
+$out += "REPO_ORIGIN: $repoOrigin"
+$out += "PARENT_BUNDLED: $parentBundled"
+$out += "EVIDENCE_BUNDLE: $evidenceBundled"
+$out += ""
+$out += "基準点（親Bundled）"
+$out += ""
+$out += $parentBV
+$out += ""
+$out += "確定（子EVIDENCE：最新audit=OK,WB0000）"
+$out += ""
+$out += "* $evLine"
+$out += ""
+$out += "次（監査チャットの継続点）"
+$out += ""
+$out += "* 上記2行（親BUNDLE_VERSION行＋子EVIDENCEのPR行）だけで監査が再現可能"
+$out += "* 以降はこの確定点を前提に次テーマへ進む"
+
+$text = ($out -join "`n")
+
+if ($ToClipboard) {
+  Set-Clipboard -Value $text
+}
+
+if ($ToDesktopFile) {
+  $dir = Join-Path $env:USERPROFILE "Desktop\MEP_HANDOFF"
+  if (!(Test-Path $dir)) { New-Item -ItemType Directory -Path $dir | Out-Null }
+  $file = Join-Path $dir ("HANDOFF_TWO_LINE_" + (Get-Date).ToString("yyyyMMdd_HHmmss") + ".txt")
+  $text | Set-Content -LiteralPath $file -Encoding UTF8
+  Write-Host ("[OK] wrote: " + $file)
+}
+
+# Always emit to stdout for copy/paste
+$text


### PR DESCRIPTION
目的: 次チャット冒頭に貼る「監査用・一次根拠のみ」を機械生成し、混在（汚染）を防ぐ。

追加:
- tools/mep_handoff_two_line.ps1
  - 親Bundled: BUNDLE_VERSION 行（先頭一致の最初の1行）
  - 子EVIDENCE: PR #... audit=OK,WB0000（最後の1行）
  - stdout 出力 + オプションで clipboard / desktop 保存
- docs/MEP/HANDOFF_TWO_LINE.md（docs/MEP が存在する場合）

次:
- ①再発ゼロ化（入口条件/Scope-IN最小）→②B運用移行→④親Bundled整備 の順で進める。