### PR TITLE
chore(ci): fix 401 by switching to github.token

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Writeback evidence -> PR (slim)
         shell: pwsh
         env:
-          GH_TOKEN: ${{ secrets.MEP_PR_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           $pr = '${{ inputs.pr_number }}'
           if ([string]::IsNullOrWhiteSpace($pr)) { $pr = '0' }
@@ -65,7 +65,7 @@ jobs:
       - name: Create PR for writeback branch
         shell: pwsh
         env:
-          GH_TOKEN: ${{ secrets.MEP_PR_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           Set-StrictMode -Version Latest
           $ErrorActionPreference = 'Stop'
@@ -95,7 +95,7 @@ jobs:
         if: ${{ inputs.write_handoff == 'true' }}
         shell: pwsh
         env:
-          GH_TOKEN: ${{ secrets.MEP_PR_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           pwsh -NoProfile -File tools/mep_writeback_handoff.ps1 -CI
 
@@ -109,6 +109,7 @@ jobs:
             git diff -- docs/MEP/MEP_BUNDLE.md || true
             exit 1
           fi
+
 
 
 


### PR DESCRIPTION
Fix:
- Replace GH_TOKEN: ${{ secrets.MEP_PR_TOKEN }} with GH_TOKEN: ${{ github.token }}

Reason:
- Workflow logs show HTTP 401 Bad credentials against GitHub GraphQL when running gh commands.
- Using github.token + permissions(contents:write, pull-requests:write) should authorize gh api / gh pr create inside the workflow.