### PR TITLE
Docs: parent Bundled reference for two-line audit handoff + WB2001 recurrence

### DIFF
--- a/docs/MEP/MEP_BUNDLE.md
+++ b/docs/MEP/MEP_BUNDLE.md
@@ -767,3 +767,12 @@ Bundled 本文に基づき、
 
 PR #1353 | audit=OK,WB0000 | appended_at=2026-01-30T19:00:58Z | via=mep_append_evidence_line.ps1
 PR #1382 | audit=OK,WB0000 | appended_at=2026-01-30T19:00:58Z | via=mep_append_evidence_line.ps1
+
+---
+
+## Ops Note: Audit Handoff (two-line) / WB2001 recurrence-zero
+
+- TOOL_REF: tools/mep_handoff_two_line.ps1  # 親BUNDLE_VERSION行 + 子EVIDENCE最新audit=OK,WB0000行 を抽出
+- DOC_REF:  docs/MEP/HANDOFF_TWO_LINE.md    # 使い方
+- DOC_REF:  docs/MEP/WB2001_RECURRENCE_ZERO.md  # 再発ゼロ化の最小ルール
+


### PR DESCRIPTION
目的: 親Bundled側に「監査用2行HANDOFF生成」と「WB2001再発ゼロ化最小ルール」への参照を置き、
監査説明力を上げる（既存の一次根拠行は変更しない）。

変更:
- docs/MEP/MEP_BUNDLE.md に Ops Note を追記（TOOL_REF / DOC_REF）

参照:
- tools/mep_handoff_two_line.ps1
- docs/MEP/HANDOFF_TWO_LINE.md
- docs/MEP/WB2001_RECURRENCE_ZERO.md