### PR TITLE
Fix ParserError in mep_sync_evidence_to_parent.ps1 (run 21539274722)

### DIFF
--- a/tools/mep_sync_evidence_to_parent.ps1
+++ b/tools/mep_sync_evidence_to_parent.ps1
@@ -2,7 +2,7 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
 param(
-  [int]$PrNumber = 0,
+  [int]$PrNumber = 0
   [string]$EvidenceBundledPath = "docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md",
   [string]$ParentBundledPath   = "docs/MEP/MEP_BUNDLE.md",
   [switch]$NoAppendScriptFallback


### PR DESCRIPTION
Fix PowerShell ParserError seen in Actions run 21539274722.
Error (from log_failed):
- tools/mep_sync_evidence_to_parent.ps1: line ~5
- '[int]$PrNumber = 0,' caused ParserError because param syntax was broken
This PR restores valid param() syntax / removes trailing comma at end of param list.