### PR TITLE
Fix missing closing ')' in param() for mep_sync_evidence_to_parent (run 21545987563)

### DIFF
--- a/tools/mep_sync_evidence_to_parent.ps1
+++ b/tools/mep_sync_evidence_to_parent.ps1
@@ -7,6 +7,7 @@ param(
   [string]$ParentBundledPath   = "docs/MEP/MEP_BUNDLE.md",
   [switch]$NoAppendScriptFallback
 )
+)
 
 function Fail([string]$m){ throw $m }
 function Info([string]$m){ Write-Host "[INFO] $m" -ForegroundColor Cyan }


### PR DESCRIPTION
Fix Actions failure in run 21545987563.
Evidence:
- tools/mep_sync_evidence_to_parent.ps1:5
- Missing closing ')' in expression
Change:
- Ensure param() block is properly closed with ')'
- Remove trailing comma on last param declaration line (if present)