### PR TITLE
Fix extra ')' after param() in mep_sync_evidence_to_parent (run 21546090242)

### DIFF
--- a/tools/mep_sync_evidence_to_parent.ps1
+++ b/tools/mep_sync_evidence_to_parent.ps1
@@ -7,7 +7,6 @@ param(
   [string]$ParentBundledPath   = "docs/MEP/MEP_BUNDLE.md",
   [switch]$NoAppendScriptFallback
 )
-)
 
 function Fail([string]$m){ throw $m }
 function Info([string]$m){ Write-Host "[INFO] $m" -ForegroundColor Cyan }


### PR DESCRIPTION
Fix Actions ParserError in run 21546090242.
Evidence:
- tools/mep_sync_evidence_to_parent.ps1 had two consecutive standalone ')' lines after param()
- Remove the extra ')' so param() is properly closed exactly once.