### PR TITLE
Canonicalize param() in mep_sync_evidence_to_parent.ps1 (run 21546193472)

### DIFF
--- a/tools/mep_sync_evidence_to_parent.ps1
+++ b/tools/mep_sync_evidence_to_parent.ps1
@@ -2,7 +2,7 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
 param(
-  [int]$PrNumber = 0
+  [int]$PrNumber = 0,
   [string]$EvidenceBundledPath = "docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md",
   [string]$ParentBundledPath   = "docs/MEP/MEP_BUNDLE.md",
   [switch]$NoAppendScriptFallback


### PR DESCRIPTION
Fix Actions ParserError in run 21546193472.
Root cause:
- param() block had invalid parameter separation (missing comma) and/or stray parens.
Change:
- Replace the entire param() block with a canonical, syntactically valid form (commas correct).