### PR TITLE
Fix PowerShell param() placement in mep_sync_evidence_to_parent.ps1 (run 21546340313)

### DIFF
--- a/tools/mep_sync_evidence_to_parent.ps1
+++ b/tools/mep_sync_evidence_to_parent.ps1
@@ -1,12 +1,12 @@
-Set-StrictMode -Version Latest
-$ErrorActionPreference = "Stop"
-
 param(
   [int]$PrNumber = 0,
   [string]$EvidenceBundledPath = "docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md",
   [string]$ParentBundledPath   = "docs/MEP/MEP_BUNDLE.md",
   [switch]$NoAppendScriptFallback
 )
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
 
 function Fail([string]$m){ throw $m }
 function Info([string]$m){ Write-Host "[INFO] $m" -ForegroundColor Cyan }


### PR DESCRIPTION
Fix Actions run 21546340313 ParserError.
Root cause:
- In PowerShell scripts, param() must appear at the top of the script (before executable statements).
- Script had Set-StrictMode / assignments before param(), so parameters were parsed as invalid expressions on runner.
Change:
- Move the existing param() block to the top of the file (first executable block).
- Keep Set-StrictMode and ErrorActionPreference immediately after param().