### PR TITLE
fix(ci): disable push trigger for writeback

### DIFF
--- a/.github/workflows/mep_writeback_bundle_evidence_dispatch.yml
+++ b/.github/workflows/mep_writeback_bundle_evidence_dispatch.yml
@@ -2,12 +2,6 @@ name: MEP Writeback Bundle (Evidence)
 
 on:
   workflow_dispatch:
-    inputs:
-      pr_number:
-        description: 'PR number to append evidence for (0 = latest merged PR)'
-        required: false
-        default: '0'
-
 permissions:
   contents: write
   pull-requests: write


### PR DESCRIPTION
Stopgap: push-triggered writeback is failing at evaluation stage (0s). Keep workflow_dispatch only.