### PR TITLE
Fix missing BundlePath for append script (run 21546483555)

### DIFF
--- a/tools/mep_sync_evidence_to_parent.ps1
+++ b/tools/mep_sync_evidence_to_parent.ps1
@@ -70,7 +70,7 @@ if ($already) {
 $appendScript = Join-Path (Split-Path -Parent $PSCommandPath) "mep_append_evidence_line.ps1"
 if ((Test-Path -LiteralPath $appendScript) -and (-not $NoAppendScriptFallback)) {
   Info "Using existing append script: $appendScript"
-  & $appendScript -PrNumber $targetPr
+  & $appendScript -PrNumber $targetPr -BundlePath $ParentBundledPath
   exit 0
 }
 


### PR DESCRIPTION
Fix Actions run 21546483555 failure.
Evidence:
- mep_sync_evidence_to_parent.ps1 calls mep_append_evidence_line.ps1 without mandatory -BundlePath
- Runner prompts for BundlePath and fails in non-interactive Actions
Change:
- Pass -BundlePath $ParentBundledPath when invoking the append script.