### PR TITLE
chore(mep): fix workflow yaml + wire full evidence append

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch.yml
@@ -53,6 +53,10 @@ jobs:
 
           # evidence (non-fatal)
           git status --porcelain -- docs/MEP/MEP_BUNDLE.md || true
+      - name: Writeback evidence -> PR (full)
+        shell: pwsh
+        run: |
+          pwsh -NoProfile -File tools/mep_append_evidence_line_full.ps1 -PrNumber ${{ inputs.pr_number }}
       - name: Writeback evidence -> PR (slim)
         shell: pwsh
         env:

--- a/tools/mep_append_evidence_line_full.ps1
+++ b/tools/mep_append_evidence_line_full.ps1
@@ -1,116 +1,41 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
-
+$ProgressPreference = "SilentlyContinue"
+[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+$OutputEncoding = [Console]::OutputEncoding
+$env:GIT_PAGER="cat"; $env:PAGER="cat"
 param(
-  [Parameter(Mandatory=$false)][int]$PrNumber = 0,
-  [Parameter(Mandatory=$false)][string]$BundlePath = "docs/MEP/MEP_BUNDLE.md",
-  [Parameter(Mandatory=$false)][ValidateSet("OK","NG")][string]$Audit = "OK",
-  [Parameter(Mandatory=$false)][string]$WB = "WB0000",
-  [Parameter(Mandatory=$false)][string]$Repo = ""
+  [int]$PrNumber = 0,
+  [string]$BundlePath = "docs/MEP/MEP_BUNDLE.md"
 )
-
-function Info([string]$m){ Write-Host ("[INFO] " + $m) }
-function Warn([string]$m){ Write-Host ("[WARN] " + $m) }
-function Fail([string]$m){ throw $m }
-
-if (-not $Repo) {
-  try {
-    $u = (git remote get-url origin).Trim()
-    if ($u -match "github\.com[/:]([^/]+)/([^/.]+)(:\.git)$") {
-      $Repo = ("{0}/{1}" -f $Matches[1], $Matches[2])
-    }
-  } catch {}
-}
-if (-not $Repo) { Fail "Repo could not be inferred. Pass -Repo owner/name." }
-
-if (-not (Test-Path $BundlePath)) { Fail "BundlePath not found: $BundlePath" }
-
-# Read current BUNDLE_VERSION (first line + possible wrap)
-$bvLine = (Select-String -Path $BundlePath -Pattern "^BUNDLE_VERSION\s*=" -Context 0,2 | Select-Object -First 1)
-if (-not $bvLine) { Fail "BUNDLE_VERSION line not found in $BundlePath" }
-$bvText = $bvLine.Line
-# handle wrapped next line (common in this repo)
-$bvNext = $null
-try {
-  $all = Get-Content -Path $BundlePath -Encoding utf8
-  $idx = $bvLine.LineNumber - 1
-  if ($idx -ge 0 -and $idx+1 -lt $all.Count) {
-    if ($all[$idx] -match "^BUNDLE_VERSION\s*=\s*v0\.0\.0\+$" -and $all[$idx+1] -match "^\d{8}_\d{6}\+main") {
-      $bvText = ($all[$idx] + $all[$idx+1]).Replace("`r","")
-    }
-  }
-} catch {}
-# normalize: "BUNDLE_VERSION = v0.0.0+...."
-$bvVal = $null
-if ($bvText -match "BUNDLE_VERSION\s*=\s*(.+)$") { $bvVal = $Matches[1].Trim() }
-if (-not $bvVal) { Fail "Could not parse BUNDLE_VERSION value." }
-
-# If PrNumber=0: auto-select latest merged PR into main
+function Fail($m){ throw $m }
+function Info($m){ Write-Host "[INFO] $m" -ForegroundColor Cyan }
+$root = git rev-parse --show-toplevel 2>$null
+if (-not $root) { Fail "Not a git repository" }
+Set-Location $root
+if (-not (Test-Path $BundlePath)) { Fail "Bundled not found: $BundlePath" }
+$bundle = Get-Content $BundlePath -Raw
+if ($bundle -notmatch '(?m)^BUNDLE_VERSION\s*=\s*(.+)$') { Fail "BUNDLE_VERSION not found" }
+$bundleVersion = ($Matches[1]).Trim()
+# Resolve target PR (0 = latest merged)
 if ($PrNumber -eq 0) {
-  # Search merged PRs, newest first
-  $q = "repo:$Repo is:pr is:merged base:main sort:updated-desc"
-  $j = gh api graphql -f query="query(\$q:String!){ search(query:\$q, type:ISSUE, first:20){ nodes { ... on PullRequest { number mergedAt mergeCommit { oid } url } } } }" -f q="$q" | ConvertFrom-Json
-  $node = $j.data.search.nodes | Where-Object { $_.mergedAt } | Select-Object -First 1
-  if (-not $node) { Fail "No merged PR found to auto-select." }
-  $PrNumber = [int]$node.number
+  $prJson = gh pr list --state merged --limit 1 --json number,mergedAt,mergeCommit,url | ConvertFrom-Json
+  if (-not $prJson) { Fail "No merged PR found" }
+  $pr = $prJson[0]
+} else {
+  $pr = gh pr view $PrNumber --json number,mergedAt,mergeCommit,url | ConvertFrom-Json
 }
-
-# Fetch PR details
-$pr = gh api "repos/$Repo/pulls/$PrNumber" | ConvertFrom-Json
-if (-not $pr.merged_at) { Fail "PR #$PrNumber is not merged (merged_at is null)." }
-
-# Format mergedAt to match existing style "MM/dd/yyyy HH:mm:ss"
-$dt = [DateTime]::Parse($pr.merged_at).ToLocalTime()
-$mergedAt = $dt.ToString("MM/dd/yyyy HH:mm:ss")
-$mergeCommit = [string]$pr.merge_commit_sha
-$url = [string]$pr.html_url
-
-# Read file
-$lines = Get-Content -Path $BundlePath -Encoding utf8
-
-# Idempotency: skip if already present (either detailed list or appended_at)
-$already = $false
-if ($lines -match ("PR\s*#"+$PrNumber+"\b")) { $already = $true }
-
-if ($already) {
-  Info ("Skip: PR #{0} already appears somewhere in Bundled." -f $PrNumber)
+$prNum     = [int]$pr.number
+$mergedAt  = $pr.mergedAt
+$mergeCommit = $pr.mergeCommit.oid
+$url       = $pr.url
+# Idempotency: if our appended_at(full) exists, skip
+if ($bundle -match "(?m)^PR\s+#$prNum\s+\|\s+audit=OK,WB0000\s+\|\s+appended_at=.*\|\s+via=mep_append_evidence_line_full\.ps1\s*$") {
+  Info "Full evidence already exists for PR #$prNum. Skip."
   exit 0
 }
-
-# Build two lines:
-# 1) detailed list line (keep same bullet prefix as existing evidence list: "  * - PR #...")
-$detailed = ("  * - PR #{0} | mergedAt={1} | mergeCommit={2} | BUNDLE_VERSION={3} | audit={4},{5} | {6}" -f $PrNumber, $mergedAt, $mergeCommit, $bvVal, $Audit, $WB, $url)
-
-# 2) appended_at line (flat)
-$nowUtc = [DateTime]::UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ")
-$appended = ("PR #{0} | audit={1},{2} | appended_at={3} | via=mep_append_evidence_line_full.ps1" -f $PrNumber, $Audit, $WB, $nowUtc)
-
-# Insert detailed line after the last existing detailed evidence list line if possible.
-# Find last line that looks like "  * - PR #123 ..."
-$idxList = -1
-for ($i=0; $i -lt $lines.Count; $i++){
-  if ($lines[$i] -match "^\s*\*\s*-\s*PR\s*#\d+") { $idxList = $i }
-}
-if ($idxList -ge 0) {
-  $lines = @($lines[0..$idxList] + $detailed + $lines[($idxList+1)..($lines.Count-1)])
-} else {
-  # fallback: append near end with a separator
-  $lines += ""
-  $lines += $detailed
-}
-
-# Insert appended_at after last appended_at/audit marker line if exists; else append to end.
-$idxApp = -1
-for ($i=0; $i -lt $lines.Count; $i++){
-  if ($lines[$i] -match "^PR\s*#\d+\s*\|\s*audit=") { $idxApp = $i }
-}
-if ($idxApp -ge 0) {
-  $lines = @($lines[0..$idxApp] + $appended + $lines[($idxApp+1)..($lines.Count-1)])
-} else {
-  $lines += ""
-  $lines += $appended
-}
-
-# Write back
-Set-Content -Path $BundlePath -Value $lines -Encoding utf8
-Info ("Appended: detailed+appended_at for PR #{0}" -f $PrNumber)
+$detailLine = "* - PR #$prNum | mergedAt=$mergedAt | mergeCommit=$mergeCommit | BUNDLE_VERSION=$bundleVersion | audit=OK,WB0000 | $url"
+$appendLine = "PR #$prNum | audit=OK,WB0000 | appended_at=$(Get-Date -Format o) | via=mep_append_evidence_line_full.ps1"
+Add-Content -Path $BundlePath -Value $detailLine
+Add-Content -Path $BundlePath -Value $appendLine
+Info "Appended full evidence for PR #$prNum"


### PR DESCRIPTION
Fixes YAML parse corruption causing 422 and wires tools/mep_append_evidence_line_full.ps1 into writeback dispatch before slim step.