### PR TITLE
Fix workflow auth: use github.token for PR creation

### DIFF
--- a/.github/workflows/mep_sync_evidence_to_parent_dispatch.yml
+++ b/.github/workflows/mep_sync_evidence_to_parent_dispatch.yml
@@ -40,6 +40,8 @@ jobs:
           echo "GH_TOKEN=$tok" >> "$GITHUB_ENV"
           echo "[INFO] prepared GH_TOKEN (sanitized)"
       - name: Create PR if changed
+        env:
+          GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail


### PR DESCRIPTION
Fix workflow so gh pr create uses github.token (not MEP_BOT_PAT) and YAML has a single permissions block.
- permissions: contents/pull-requests write
- Create PR step sets GH_TOKEN from github.token