### PR TITLE
fix(mep): remove trailing comma in evidence full tool param

### DIFF
--- a/tools/mep_append_evidence_line_full.ps1
+++ b/tools/mep_append_evidence_line_full.ps1
@@ -50,3 +50,4 @@ Add-Content -Path $BundlePath -Value $detailLine
 Add-Content -Path $BundlePath -Value $appendLine
 
 Info ("Appended full evidence for PR #" + $prNum)
+


### PR DESCRIPTION
Fixes PowerShell ParserError in tools/mep_append_evidence_line_full.ps1 by removing trailing comma in param() default assignment.