### PR TITLE
fix(mep): remove trailing comma in evidence full tool

### DIFF
--- a/tools/mep_append_evidence_line_full.ps1
+++ b/tools/mep_append_evidence_line_full.ps1
@@ -51,3 +51,4 @@ Add-Content -Path $BundlePath -Value $appendLine
 
 Info ("Appended full evidence for PR #" + $prNum)
 
+


### PR DESCRIPTION
Removes trailing comma in param default assignment that causes ParserError on ubuntu pwsh.