### PR TITLE
fix(mep): add GH_TOKEN env to full evidence step

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch.yml
@@ -55,6 +55,8 @@ jobs:
           git status --porcelain -- docs/MEP/MEP_BUNDLE.md || true
       - name: Writeback evidence -> PR (full)
         shell: pwsh
+  env:
+    GH_TOKEN: ${{ secrets.MEP_BOT_PAT }}
         run: |
           pwsh -NoProfile -File tools/mep_append_evidence_line_full.ps1 -PrNumber ${{ inputs.pr_number }}
       - name: Writeback evidence -> PR (slim)
@@ -113,6 +115,7 @@ jobs:
             git diff -- docs/MEP/MEP_BUNDLE.md || true
             exit 1
           fi
+
 
 
 


### PR DESCRIPTION
Adds env: GH_TOKEN to 'Writeback evidence -> PR (full)' so gh CLI works in Actions.