### PR TITLE
fix(mep): restore workflow_dispatch trigger

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch.yml
@@ -2,6 +2,7 @@
 # PATCH_MARKER: generate-via-compiler 20260131_021532
 name: MEP Writeback Bundle (Evidence)
 on:
+  workflow_dispatch:
   workflow_call:
     inputs:
       pr_number:
@@ -115,6 +116,7 @@ jobs:
             git diff -- docs/MEP/MEP_BUNDLE.md || true
             exit 1
           fi
+
 
 
 


### PR DESCRIPTION
Restores workflow_dispatch on mep_writeback_bundle_dispatch so it can be run manually via gh workflow run.