### PR TITLE
fix(mep): quote on key for workflow_dispatch

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch.yml
@@ -1,7 +1,7 @@
 # PATCH_MARKER: gen-runstep 20260131_021740
 # PATCH_MARKER: generate-via-compiler 20260131_021532
 name: MEP Writeback Bundle (Evidence)
-on:
+"on":
   workflow_dispatch:
   workflow_call:
     inputs:
@@ -116,6 +116,7 @@ jobs:
             git diff -- docs/MEP/MEP_BUNDLE.md || true
             exit 1
           fi
+
 
 
 


### PR DESCRIPTION
Quotes the top-level "on" key to avoid YAML 1.1 on/Off boolean edge-cases and ensure workflow_dispatch is recognized by GitHub Actions.