### PR TITLE
fix(mep): PR0 guard v2 (fallback to parent bundled)

### DIFF
--- a/tools/mep_append_evidence_line.ps1
+++ b/tools/mep_append_evidence_line.ps1
@@ -1,3 +1,71 @@
+### PR0_GUARD_V2_FALLBACK (AUTO) ###
+# Policy:
+# - "0" は内部表現（auto-latest）のみ。Bundled/Evidence へ "PR #0" を出力させない。
+# - 0 を受け取ったら、(a) Evidence bundle の最新 実PR (>0) を探す。
+#   見つからなければ、(b) 親Bundled（docs/MEP/MEP_BUNDLE.md）の最新 実PR (>0) にフォールバック。
+# - 両方で実PRが取れない場合のみ停止（=PR #0 を増殖させない）。
+function Resolve-RealPrNumber_V2 {
+  param([int]$InputPr, [string[]]$EvidenceBundleCandidates)
+  if ($InputPr -ne 0) { return $InputPr }
+  $rt = (git rev-parse --show-toplevel)
+  $cands = @()
+  foreach ($p in ($EvidenceBundleCandidates | Where-Object { $_ -and (Test-Path $_) })) {
+    try { $cands += (Resolve-Path $p).Path } catch { }
+  }
+  $preferred = Join-Path $rt 'docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md'
+  if (Test-Path $preferred) { try { $cands += (Resolve-Path $preferred).Path } catch { } }
+  try {
+    Get-ChildItem -Path (Join-Path $rt 'docs') -Recurse -File -Filter 'MEP_BUNDLE.md' -ErrorAction SilentlyContinue |
+      Where-Object { $_.FullName -match '\\MEP_SUB\\EVIDENCE\\' -or $_.FullName -match '\\EVIDENCE\\' } |
+      ForEach-Object { $cands += $_.FullName }
+  } catch { }
+  $cands = @($cands | Select-Object -Unique)
+  # (a) evidence bundles
+  foreach ($p in $cands) {
+    try {
+      $hits = @(Select-String -LiteralPath $p -Pattern 'PR #(\d+)\s*\|\s*audit=OK,WB0000' -ErrorAction SilentlyContinue)
+      if ($hits.Count -gt 0) {
+        $n = [int]$hits[$hits.Count-1].Matches[0].Groups[1].Value
+        if ($n -gt 0) { return $n }
+      }
+    } catch { }
+  }
+  # (b) parent bundled fallback
+  $parent = Join-Path $rt 'docs/MEP/MEP_BUNDLE.md'
+  if (Test-Path $parent) {
+    $ph = @(Select-String -LiteralPath $parent -Pattern 'PR #(\d+)\s*\|\s*audit=OK,WB0000' -ErrorAction SilentlyContinue)
+    if ($ph.Count -gt 0) {
+      $m = [int]$ph[$ph.Count-1].Matches[0].Groups[1].Value
+      if ($m -gt 0) { return $m }
+    }
+  }
+  throw "pr_number=0 could not be resolved (evidence+parent bundled). Forbid PR #0 emission."
+}
+# param() 形状に依存せず、既知変数名を走査して 0→実PRへ置換
+try {
+  $varCandidates = @('pr_number','prNumber','pr','PR','PrNumber','PRNumber')
+  $bundleVarCandidates = @('evidence_bundle','evidenceBundle','bundlePath','evidenceBundlePath','EvidenceBundlePath')
+  $evidencePaths = @()
+  foreach ($bn in $bundleVarCandidates) {
+    $v = Get-Variable -Name $bn -ErrorAction SilentlyContinue
+    if ($v) { $evidencePaths += [string]$v.Value }
+  }
+  foreach ($pn in $varCandidates) {
+    $v = Get-Variable -Name $pn -ErrorAction SilentlyContinue
+    if ($v -and ($v.Value -is [int] -or $v.Value -is [string])) {
+      $cur = [int]$v.Value
+      if ($cur -eq 0) {
+        $resolved = Resolve-RealPrNumber_V2 -InputPr 0 -EvidenceBundleCandidates $evidencePaths
+        if ($resolved -le 0) { throw "Resolved PR invalid: $resolved" }
+        Set-Variable -Name $pn -Value $resolved -Scope Local
+      }
+    }
+  }
+} catch {
+  throw "PR0_GUARD_V2 failed: $($_.Exception.Message)"
+}
+### END PR0_GUARD_V2_FALLBACK (AUTO) ###
+
 param(
 
 

--- a/tools/mep_sync_evidence_to_parent.ps1
+++ b/tools/mep_sync_evidence_to_parent.ps1
@@ -7,6 +7,75 @@ param(
 
 Set-StrictMode -Version Latest
 
+### PR0_GUARD_V2_FALLBACK (AUTO) ###
+# Policy:
+# - "0" は内部表現（auto-latest）のみ。Bundled/Evidence へ "PR #0" を出力させない。
+# - 0 を受け取ったら、(a) Evidence bundle の最新 実PR (>0) を探す。
+#   見つからなければ、(b) 親Bundled（docs/MEP/MEP_BUNDLE.md）の最新 実PR (>0) にフォールバック。
+# - 両方で実PRが取れない場合のみ停止（=PR #0 を増殖させない）。
+function Resolve-RealPrNumber_V2 {
+  param([int]$InputPr, [string[]]$EvidenceBundleCandidates)
+  if ($InputPr -ne 0) { return $InputPr }
+  $rt = (git rev-parse --show-toplevel)
+  $cands = @()
+  foreach ($p in ($EvidenceBundleCandidates | Where-Object { $_ -and (Test-Path $_) })) {
+    try { $cands += (Resolve-Path $p).Path } catch { }
+  }
+  $preferred = Join-Path $rt 'docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md'
+  if (Test-Path $preferred) { try { $cands += (Resolve-Path $preferred).Path } catch { } }
+  try {
+    Get-ChildItem -Path (Join-Path $rt 'docs') -Recurse -File -Filter 'MEP_BUNDLE.md' -ErrorAction SilentlyContinue |
+      Where-Object { $_.FullName -match '\\MEP_SUB\\EVIDENCE\\' -or $_.FullName -match '\\EVIDENCE\\' } |
+      ForEach-Object { $cands += $_.FullName }
+  } catch { }
+  $cands = @($cands | Select-Object -Unique)
+  # (a) evidence bundles
+  foreach ($p in $cands) {
+    try {
+      $hits = @(Select-String -LiteralPath $p -Pattern 'PR #(\d+)\s*\|\s*audit=OK,WB0000' -ErrorAction SilentlyContinue)
+      if ($hits.Count -gt 0) {
+        $n = [int]$hits[$hits.Count-1].Matches[0].Groups[1].Value
+        if ($n -gt 0) { return $n }
+      }
+    } catch { }
+  }
+  # (b) parent bundled fallback
+  $parent = Join-Path $rt 'docs/MEP/MEP_BUNDLE.md'
+  if (Test-Path $parent) {
+    $ph = @(Select-String -LiteralPath $parent -Pattern 'PR #(\d+)\s*\|\s*audit=OK,WB0000' -ErrorAction SilentlyContinue)
+    if ($ph.Count -gt 0) {
+      $m = [int]$ph[$ph.Count-1].Matches[0].Groups[1].Value
+      if ($m -gt 0) { return $m }
+    }
+  }
+  throw "pr_number=0 could not be resolved (evidence+parent bundled). Forbid PR #0 emission."
+}
+# param() 形状に依存せず、既知変数名を走査して 0→実PRへ置換
+try {
+  $varCandidates = @('pr_number','prNumber','pr','PR','PrNumber','PRNumber')
+  $bundleVarCandidates = @('evidence_bundle','evidenceBundle','bundlePath','evidenceBundlePath','EvidenceBundlePath')
+  $evidencePaths = @()
+  foreach ($bn in $bundleVarCandidates) {
+    $v = Get-Variable -Name $bn -ErrorAction SilentlyContinue
+    if ($v) { $evidencePaths += [string]$v.Value }
+  }
+  foreach ($pn in $varCandidates) {
+    $v = Get-Variable -Name $pn -ErrorAction SilentlyContinue
+    if ($v -and ($v.Value -is [int] -or $v.Value -is [string])) {
+      $cur = [int]$v.Value
+      if ($cur -eq 0) {
+        $resolved = Resolve-RealPrNumber_V2 -InputPr 0 -EvidenceBundleCandidates $evidencePaths
+        if ($resolved -le 0) { throw "Resolved PR invalid: $resolved" }
+        Set-Variable -Name $pn -Value $resolved -Scope Local
+      }
+    }
+  }
+} catch {
+  throw "PR0_GUARD_V2 failed: $($_.Exception.Message)"
+}
+### END PR0_GUARD_V2_FALLBACK (AUTO) ###
+
+
 ### PR0_GUARD_RESOLVE_AND_FORBID (AUTO) ###
 # Policy:
 #   - "0" は内部表現（auto-latest）のみ。Bundled/Evidence へ "PR #0" を書くことを禁止。


### PR DESCRIPTION
Problem:
- Evidence bundle contains only "PR #0 | audit=OK,WB0000" so strict 0->realPR resolution can fail and break dispatch.
Fix:
- Inject PR0_GUARD_V2 that resolves pr_number=0 by:
  (a) evidence bundles latest real PR (>0), else
  (b) parent bundled latest real PR (>0).
- Keeps policy: forbid emitting "PR #0".