### PR TITLE
fix(mep): dedupe workflow_dispatch

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch.yml
@@ -15,7 +15,6 @@ name: MEP Writeback Bundle (Evidence)
         required: false
         type: string
         default: 'false'
-  workflow_dispatch:
     inputs:
       pr_number:
         description: 'PR number (0 = auto latest merged PR)'


### PR DESCRIPTION
Removes duplicate workflow_dispatch entries under on: in mep_writeback_bundle_dispatch.yml to fix YAML parse error.