### PR TITLE
fix(mep): rebuild dispatcher yaml header cleanly

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch.yml
@@ -1,4 +1,3 @@
-# PATCH_MARKER: restored-header
 name: MEP Writeback Bundle (Evidence)
 "on":
   workflow_dispatch:


### PR DESCRIPTION
Rebuilds mep_writeback_bundle_dispatch.yml with a clean header (name/on/permissions) while preserving jobs section, fixing YAML parse errors in called workflow.