### PR TITLE
fix(mep): PR0 guard v2 regex (resolve real PR)

### DIFF
--- a/tools/mep_append_evidence_line.ps1
+++ b/tools/mep_append_evidence_line.ps1
@@ -23,7 +23,7 @@ function Resolve-RealPrNumber_V2 {
   # (a) evidence bundles
   foreach ($p in $cands) {
     try {
-      $hits = @(Select-String -LiteralPath $p -Pattern 'PR #(\d+)\s*\|\s*audit=OK,WB0000' -ErrorAction SilentlyContinue)
+      $hits = @(Select-String -LiteralPath $p -Pattern 'PR #(\d+).*?\|\s*audit=OK,WB0000' -ErrorAction SilentlyContinue)
       if ($hits.Count -gt 0) {
         $n = [int]$hits[$hits.Count-1].Matches[0].Groups[1].Value
         if ($n -gt 0) { return $n }
@@ -33,7 +33,7 @@ function Resolve-RealPrNumber_V2 {
   # (b) parent bundled fallback
   $parent = Join-Path $rt 'docs/MEP/MEP_BUNDLE.md'
   if (Test-Path $parent) {
-    $ph = @(Select-String -LiteralPath $parent -Pattern 'PR #(\d+)\s*\|\s*audit=OK,WB0000' -ErrorAction SilentlyContinue)
+    $ph = @(Select-String -LiteralPath $parent -Pattern 'PR #(\d+).*?\|\s*audit=OK,WB0000' -ErrorAction SilentlyContinue)
     if ($ph.Count -gt 0) {
       $m = [int]$ph[$ph.Count-1].Matches[0].Groups[1].Value
       if ($m -gt 0) { return $m }
@@ -276,6 +276,7 @@ Add-Content -LiteralPath $abs -Value $line -Encoding utf8
 
 
 Ok ("appended={0}" -f $line)
+
 
 
 

--- a/tools/mep_sync_evidence_to_parent.ps1
+++ b/tools/mep_sync_evidence_to_parent.ps1
@@ -32,7 +32,7 @@ function Resolve-RealPrNumber_V2 {
   # (a) evidence bundles
   foreach ($p in $cands) {
     try {
-      $hits = @(Select-String -LiteralPath $p -Pattern 'PR #(\d+)\s*\|\s*audit=OK,WB0000' -ErrorAction SilentlyContinue)
+      $hits = @(Select-String -LiteralPath $p -Pattern 'PR #(\d+).*?\|\s*audit=OK,WB0000' -ErrorAction SilentlyContinue)
       if ($hits.Count -gt 0) {
         $n = [int]$hits[$hits.Count-1].Matches[0].Groups[1].Value
         if ($n -gt 0) { return $n }
@@ -42,7 +42,7 @@ function Resolve-RealPrNumber_V2 {
   # (b) parent bundled fallback
   $parent = Join-Path $rt 'docs/MEP/MEP_BUNDLE.md'
   if (Test-Path $parent) {
-    $ph = @(Select-String -LiteralPath $parent -Pattern 'PR #(\d+)\s*\|\s*audit=OK,WB0000' -ErrorAction SilentlyContinue)
+    $ph = @(Select-String -LiteralPath $parent -Pattern 'PR #(\d+).*?\|\s*audit=OK,WB0000' -ErrorAction SilentlyContinue)
     if ($ph.Count -gt 0) {
       $m = [int]$ph[$ph.Count-1].Matches[0].Groups[1].Value
       if ($m -gt 0) { return $m }
@@ -234,4 +234,5 @@ Set-Content -LiteralPath $ParentBundledPath -Value $parent -NoNewline -Encoding 
 
 Info "Appended: $line"
 exit 0
+
 


### PR DESCRIPTION
Problem:
- PR0_GUARD_V2 fails to resolve pr_number=0 because regex expects "PR #n | audit=OK,WB0000" with audit immediately after first pipe.
- Actual evidence/parent lines can be "PR #n | ... | audit=OK,WB0000".
Fix:
- Relax regex to: PR #(\d+).*?\|\s*audit=OK,WB0000