### PR TITLE
fix(mep): rebuild dispatcher yaml cleanly (v2)

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch.yml
@@ -27,32 +27,7 @@ permissions:
   contents: write
   pull-requests: write
 
-# PATCH_MARKER: gen-runstep 20260131_021740
-# PATCH_MARKER: generate-via-compiler 20260131_021532
-name: MEP Writeback Bundle (Evidence)
-""on"":
-  workflow_dispatch:
-    inputs:
-      pr_number:
-        description: ""0 = latest merged PR""
-        required: false
-        default: ""0""
-        type: string
-      write_handoff:
-        description: ""write HANDOFF_NEXT too (true/false)""
-        required: false
-        default: ""false""
-        type: string
-  workflow_call:
-    inputs:
-      pr_number:
-        required: false
-        type: string
-        default: ""0""
-      write_handoff:
-        required: false
-        type: string
-        default: ""false""jobs:
+jobs:
   writeback:
     runs-on: ubuntu-latest
     steps:
@@ -138,6 +113,7 @@ name: MEP Writeback Bundle (Evidence)
             git diff -- docs/MEP/MEP_BUNDLE.md || true
             exit 1
           fi
+
 
 
 


### PR DESCRIPTION
Rebuilds mep_writeback_bundle_dispatch.yml with a single clean header and extracts jobs: block robustly (handles glued '...jobs:'), fixing called-workflow YAML parse errors.