### PR TITLE
fix(mep): use github.token for GH_TOKEN

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch.yml
@@ -54,13 +54,13 @@ jobs:
       - name: Writeback evidence -> PR (full)
         shell: pwsh
         env:
-          GH_TOKEN: ${{ secrets.MEP_BOT_PAT }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           pwsh -NoProfile -File tools/mep_append_evidence_line_full.ps1 -PrNumber ${{ inputs.pr_number }}
       - name: Writeback evidence -> PR (slim)
         shell: pwsh
         env:
-          GH_TOKEN: ${{ secrets.MEP_BOT_PAT }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           $pr = '${{ inputs.pr_number }}'
           if ([string]::IsNullOrWhiteSpace($pr)) { $pr = '0' }
@@ -69,7 +69,7 @@ jobs:
       - name: Create PR for writeback branch
         shell: pwsh
         env:
-          GH_TOKEN: ${{ secrets.MEP_BOT_PAT }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           Set-StrictMode -Version Latest
           $ErrorActionPreference = 'Stop'
@@ -99,7 +99,7 @@ jobs:
         if: ${{ inputs.write_handoff == 'true' }}
         shell: pwsh
         env:
-          GH_TOKEN: ${{ secrets.MEP_BOT_PAT }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           pwsh -NoProfile -File tools/mep_writeback_handoff.ps1 -CI
 
@@ -113,6 +113,7 @@ jobs:
             git diff -- docs/MEP/MEP_BUNDLE.md || true
             exit 1
           fi
+
 
 
 


### PR DESCRIPTION
Replaces GH_TOKEN source from secrets.MEP_BOT_PAT to github.token in mep_writeback_bundle_dispatch.yml so reusable workflow always has a token and gh CLI works.