### PR TITLE
fix(mep): normalize PR0_GUARD_V2 single block

### DIFF
--- a/tools/mep_append_evidence_line.ps1
+++ b/tools/mep_append_evidence_line.ps1
@@ -1,74 +1,3 @@
-### PR0_GUARD_V2_FALLBACK (AUTO) ###
-# Policy:
-# - "0" は内部表現（auto-latest）のみ。Bundled/Evidence へ "PR #0" を出力させない（可能な限り解決）。
-# - 0 を受け取ったら、(a) Evidence bundle の最新 実PR (>0) を探す。
-#   見つからなければ、(b) 親Bundled（docs/MEP/MEP_BUNDLE.md）の最新 実PR (>0) にフォールバック。
-# - それでも実PRが取れない場合は「WARNして継続」（workflowを落とさない）。
-function Resolve-RealPrNumber_V2 {
-  param([int]$InputPr, [string[]]$EvidenceBundleCandidates)
-  if ($InputPr -ne 0) { return $InputPr }
-  $rt = (git rev-parse --show-toplevel)
-  $cands = @()
-  foreach ($p in ($EvidenceBundleCandidates | Where-Object { $_ -and (Test-Path $_) })) {
-    try { $cands += (Resolve-Path $p).Path } catch { }
-  }
-  $preferred = Join-Path $rt 'docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md'
-  if (Test-Path $preferred) { try { $cands += (Resolve-Path $preferred).Path } catch { } }
-  try {
-    Get-ChildItem -Path (Join-Path $rt 'docs') -Recurse -File -Filter 'MEP_BUNDLE.md' -ErrorAction SilentlyContinue |
-      Where-Object { $_.FullName -match '\\MEP_SUB\\EVIDENCE\\' -or $_.FullName -match '\\EVIDENCE\\' } |
-      ForEach-Object { $cands += $_.FullName }
-  } catch { }
-  $cands = @($cands | Select-Object -Unique)
-  # (a) evidence bundles: audit が後段にあっても拾う
-  foreach ($p in $cands) {
-    try {
-      $hits = @(Select-String -LiteralPath $p -Pattern 'PR #(\d+).*?\|\s*audit=OK,WB0000' -ErrorAction SilentlyContinue)
-      if ($hits.Count -gt 0) {
-        $n = [int]$hits[$hits.Count-1].Matches[0].Groups[1].Value
-        if ($n -gt 0) { return $n }
-      }
-    } catch { }
-  }
-  # (b) parent bundled fallback
-  $parent = Join-Path $rt 'docs/MEP/MEP_BUNDLE.md'
-  if (Test-Path $parent) {
-    try {
-      $ph = @(Select-String -LiteralPath $parent -Pattern 'PR #(\d+).*?\|\s*audit=OK,WB0000' -ErrorAction SilentlyContinue)
-      if ($ph.Count -gt 0) {
-        $m = [int]$ph[$ph.Count-1].Matches[0].Groups[1].Value
-        if ($m -gt 0) { return $m }
-      }
-    } catch { }
-  }
-  return 0
-}
-try {
-  $varCandidates = @('pr_number','prNumber','pr','PR','PrNumber','PRNumber')
-  $bundleVarCandidates = @('evidence_bundle','evidenceBundle','bundlePath','evidenceBundlePath','EvidenceBundlePath')
-  $evidencePaths = @()
-  foreach ($bn in $bundleVarCandidates) {
-    $v = Get-Variable -Name $bn -ErrorAction SilentlyContinue
-    if ($v) { $evidencePaths += [string]$v.Value }
-  }
-  foreach ($pn in $varCandidates) {
-    $v = Get-Variable -Name $pn -ErrorAction SilentlyContinue
-    if ($v -and ($v.Value -is [int] -or $v.Value -is [string])) {
-      $cur = [int]$v.Value
-      if ($cur -eq 0) {
-        $resolved = Resolve-RealPrNumber_V2 -InputPr 0 -EvidenceBundleCandidates $evidencePaths
-        if ($resolved -gt 0) {
-          Set-Variable -Name $pn -Value $resolved -Scope Local
-        } else {
-          Write-Host "[WARN] PR0_GUARD_V2: could not resolve pr_number=0 (soft-continue)" -ForegroundColor Yellow
-        }
-      }
-    }
-  }
-} catch {
-  Write-Host "[WARN] PR0_GUARD_V2: exception (soft-continue): $($_.Exception.Message)" -ForegroundColor Yellow
-}
-### END PR0_GUARD_V2_FALLBACK (AUTO) ###
 }
 ### END PR0_GUARD_V2_FALLBACK (AUTO) ###
 
@@ -282,6 +211,7 @@ Add-Content -LiteralPath $abs -Value $line -Encoding utf8
 
 
 Ok ("appended={0}" -f $line)
+
 
 
 

--- a/tools/mep_sync_evidence_to_parent.ps1
+++ b/tools/mep_sync_evidence_to_parent.ps1
@@ -7,77 +7,6 @@ param(
 
 Set-StrictMode -Version Latest
 
-### PR0_GUARD_V2_FALLBACK (AUTO) ###
-# Policy:
-# - "0" は内部表現（auto-latest）のみ。Bundled/Evidence へ "PR #0" を出力させない（可能な限り解決）。
-# - 0 を受け取ったら、(a) Evidence bundle の最新 実PR (>0) を探す。
-#   見つからなければ、(b) 親Bundled（docs/MEP/MEP_BUNDLE.md）の最新 実PR (>0) にフォールバック。
-# - それでも実PRが取れない場合は「WARNして継続」（workflowを落とさない）。
-function Resolve-RealPrNumber_V2 {
-  param([int]$InputPr, [string[]]$EvidenceBundleCandidates)
-  if ($InputPr -ne 0) { return $InputPr }
-  $rt = (git rev-parse --show-toplevel)
-  $cands = @()
-  foreach ($p in ($EvidenceBundleCandidates | Where-Object { $_ -and (Test-Path $_) })) {
-    try { $cands += (Resolve-Path $p).Path } catch { }
-  }
-  $preferred = Join-Path $rt 'docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md'
-  if (Test-Path $preferred) { try { $cands += (Resolve-Path $preferred).Path } catch { } }
-  try {
-    Get-ChildItem -Path (Join-Path $rt 'docs') -Recurse -File -Filter 'MEP_BUNDLE.md' -ErrorAction SilentlyContinue |
-      Where-Object { $_.FullName -match '\\MEP_SUB\\EVIDENCE\\' -or $_.FullName -match '\\EVIDENCE\\' } |
-      ForEach-Object { $cands += $_.FullName }
-  } catch { }
-  $cands = @($cands | Select-Object -Unique)
-  # (a) evidence bundles: audit が後段にあっても拾う
-  foreach ($p in $cands) {
-    try {
-      $hits = @(Select-String -LiteralPath $p -Pattern 'PR #(\d+).*?\|\s*audit=OK,WB0000' -ErrorAction SilentlyContinue)
-      if ($hits.Count -gt 0) {
-        $n = [int]$hits[$hits.Count-1].Matches[0].Groups[1].Value
-        if ($n -gt 0) { return $n }
-      }
-    } catch { }
-  }
-  # (b) parent bundled fallback
-  $parent = Join-Path $rt 'docs/MEP/MEP_BUNDLE.md'
-  if (Test-Path $parent) {
-    try {
-      $ph = @(Select-String -LiteralPath $parent -Pattern 'PR #(\d+).*?\|\s*audit=OK,WB0000' -ErrorAction SilentlyContinue)
-      if ($ph.Count -gt 0) {
-        $m = [int]$ph[$ph.Count-1].Matches[0].Groups[1].Value
-        if ($m -gt 0) { return $m }
-      }
-    } catch { }
-  }
-  return 0
-}
-try {
-  $varCandidates = @('pr_number','prNumber','pr','PR','PrNumber','PRNumber')
-  $bundleVarCandidates = @('evidence_bundle','evidenceBundle','bundlePath','evidenceBundlePath','EvidenceBundlePath')
-  $evidencePaths = @()
-  foreach ($bn in $bundleVarCandidates) {
-    $v = Get-Variable -Name $bn -ErrorAction SilentlyContinue
-    if ($v) { $evidencePaths += [string]$v.Value }
-  }
-  foreach ($pn in $varCandidates) {
-    $v = Get-Variable -Name $pn -ErrorAction SilentlyContinue
-    if ($v -and ($v.Value -is [int] -or $v.Value -is [string])) {
-      $cur = [int]$v.Value
-      if ($cur -eq 0) {
-        $resolved = Resolve-RealPrNumber_V2 -InputPr 0 -EvidenceBundleCandidates $evidencePaths
-        if ($resolved -gt 0) {
-          Set-Variable -Name $pn -Value $resolved -Scope Local
-        } else {
-          Write-Host "[WARN] PR0_GUARD_V2: could not resolve pr_number=0 (soft-continue)" -ForegroundColor Yellow
-        }
-      }
-    }
-  }
-} catch {
-  Write-Host "[WARN] PR0_GUARD_V2: exception (soft-continue): $($_.Exception.Message)" -ForegroundColor Yellow
-}
-### END PR0_GUARD_V2_FALLBACK (AUTO) ###
 }
 ### END PR0_GUARD_V2_FALLBACK (AUTO) ###
 
@@ -243,4 +172,71 @@ exit 0
 
 
 
+
+
+
+### PR0_GUARD_V2_FALLBACK (AUTO) ###
+function Resolve-RealPrNumber_V2 {
+  param([int]$InputPr, [string[]]$EvidenceBundleCandidates)
+  if ($InputPr -ne 0) { return $InputPr }
+  $rt = (git rev-parse --show-toplevel)
+  $cands = @()
+  foreach ($p in ($EvidenceBundleCandidates | Where-Object { $_ -and (Test-Path $_) })) {
+    try { $cands += (Resolve-Path $p).Path } catch { }
+  }
+  $preferred = Join-Path $rt 'docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md'
+  if (Test-Path $preferred) { try { $cands += (Resolve-Path $preferred).Path } catch { } }
+  try {
+    Get-ChildItem -Path (Join-Path $rt 'docs') -Recurse -File -Filter 'MEP_BUNDLE.md' -ErrorAction SilentlyContinue |
+      Where-Object { $_.FullName -match '\\MEP_SUB\\EVIDENCE\\' -or $_.FullName -match '\\EVIDENCE\\' } |
+      ForEach-Object { $cands += $_.FullName }
+  } catch { }
+  $cands = @($cands | Select-Object -Unique)
+  foreach ($p in $cands) {
+    try {
+      $hits = @(Select-String -LiteralPath $p -Pattern 'PR #(\d+).*?\|\s*audit=OK,WB0000' -ErrorAction SilentlyContinue)
+      if ($hits.Count -gt 0) {
+        $n = [int]$hits[$hits.Count-1].Matches[0].Groups[1].Value
+        if ($n -gt 0) { return $n }
+      }
+    } catch { }
+  }
+  $parent = Join-Path $rt 'docs/MEP/MEP_BUNDLE.md'
+  if (Test-Path $parent) {
+    try {
+      $ph = @(Select-String -LiteralPath $parent -Pattern 'PR #(\d+).*?\|\s*audit=OK,WB0000' -ErrorAction SilentlyContinue)
+      if ($ph.Count -gt 0) {
+        $m = [int]$ph[$ph.Count-1].Matches[0].Groups[1].Value
+        if ($m -gt 0) { return $m }
+      }
+    } catch { }
+  }
+  return 0
+}
+try {
+  $varCandidates = @('pr_number','prNumber','pr','PR','PrNumber','PRNumber')
+  $bundleVarCandidates = @('evidence_bundle','evidenceBundle','bundlePath','evidenceBundlePath','EvidenceBundlePath')
+  $evidencePaths = @()
+  foreach ($bn in $bundleVarCandidates) {
+    $v = Get-Variable -Name $bn -ErrorAction SilentlyContinue
+    if ($v) { $evidencePaths += [string]$v.Value }
+  }
+  foreach ($pn in $varCandidates) {
+    $v = Get-Variable -Name $pn -ErrorAction SilentlyContinue
+    if ($v -and ($v.Value -is [int] -or $v.Value -is [string])) {
+      $cur = [int]$v.Value
+      if ($cur -eq 0) {
+        $resolved = Resolve-RealPrNumber_V2 -InputPr 0 -EvidenceBundleCandidates $evidencePaths
+        if ($resolved -gt 0) {
+          Set-Variable -Name $pn -Value $resolved -Scope Local
+        } else {
+          Write-Host "[WARN] PR0_GUARD_V2: could not resolve pr_number=0 (soft-continue)" -ForegroundColor Yellow
+        }
+      }
+    }
+  }
+} catch {
+  Write-Host "[WARN] PR0_GUARD_V2: exception (soft-continue): $($_.Exception.Message)" -ForegroundColor Yellow
+}
+### END PR0_GUARD_V2_FALLBACK (AUTO) ###
 


### PR DESCRIPTION
Problem:
- Actions run fails with ParserError in tools/mep_sync_evidence_to_parent.ps1 (unexpected token / missing parens).
- Root cause is corrupted/duplicated PR0_GUARD_V2 block boundaries (multiple injections / leftover fragments).
Fix:
- Remove ALL existing PR0_GUARD_V2 blocks between markers (even if duplicated).
- Insert ONE canonical, syntax-safe PR0_GUARD_V2 block after Set-StrictMode.
- Apply to both tools/mep_sync_evidence_to_parent.ps1 and tools/mep_append_evidence_line.ps1.