### PR TITLE
fix(mep): remove stray brace (ParserError line 10)

### DIFF
--- a/tools/mep_sync_evidence_to_parent.ps1
+++ b/tools/mep_sync_evidence_to_parent.ps1
@@ -7,7 +7,6 @@ param(
 
 Set-StrictMode -Version Latest
 
-}
 ### END PR0_GUARD_V2_FALLBACK (AUTO) ###
 
 
@@ -26,7 +25,6 @@ function Resolve-RealPrNumber_FromEvidenceOrParent {
   $cands = @()
   foreach ($p in ($EvidenceBundleCandidates | Where-Object { $_ -and (Test-Path $_) })) {
     try { $cands += (Resolve-Path $p).Path } catch { }
-  }
   try {
     $rt = (git rev-parse --show-toplevel)
     $preferred = Join-Path $rt 'docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md'


### PR DESCRIPTION
Problem:
- Actions run fails with ParserError in tools/mep_sync_evidence_to_parent.ps1:10 (Unexpected token "}").
Fix:
- Remove stray standalone "}" line(s) near the top of the script (first 40 lines).