### PR TITLE
fix(ci): rebuild writeback dispatch workflow to restore workflow_dispatch

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch.yml
@@ -1,10 +1,126 @@
+name: MEP Writeback Bundle (Evidence)
+
 on:
   workflow_dispatch:
     inputs:
       pr_number:
-        description: 'PR number'
-        required: true
-        type: number
-on:   workflow_dispatch:     inputs:       pr_number:         description: 'PR number'         required: true         type: number on:   workflow_dispatch:     inputs:       pr_number:         description: 'PR number'         required: true         type: number on:   workflow_dispatch:     inputs:       pr_number:         description: 'PR number'         required: true         type: number name: MEP Writeback Bundle (Evidence) "on":   workflow_dispatch:     inputs:       pr_number:         description: "PR number (0 = auto latest merged PR)"         required: false         default: "0"         type: string       write_handoff:         description: "Generate+Guard+Writeback HANDOFF_NEXT into Bundled"         required: false         default: "false"         type: string   workflow_call:     inputs:       pr_number:         required: false         default: "0"         type: string       write_handoff:         required: false         default: "false"         type: string  permissions:   contents: write   pull-requests: write  jobs:   writeback:     runs-on: ubuntu-latest     steps:       - uses: actions/checkout@v4       - name: Export PR_NUMBER (resolve 0=latest merged) #         shell: bash #         env:           GH_TOKEN: ${{ github.token }} #         run: |           set -euo pipefail                  # Prefer reusable input. Empty -> 0           PR_IN="${{ inputs.pr_number }}"           if [ -z "${PR_IN}" ]; then PR_IN="0"; fi                  # Resolve 0 => latest merged PR into main           if [ "${PR_IN}" = "0" ]; then             echo "[export] inputs.pr_number=0 => resolve latest merged PR into base=main"             PR_IN="$(gh api "repos/${GITHUB_REPOSITORY}/pulls?state=closed&sort=updated&direction=desc&per_page=50" --jq '[.[] | select(.merged_at!=null and .base.ref=="main")][0].number')"           fi                  if [ -z "${PR_IN}" ] || [ "${PR_IN}" = "null" ]; then             echo "[NG] failed to resolve PR number."             exit 2           fi                  echo "PR_NUMBER=${PR_IN}" >> "${GITHUB_ENV}"           echo "[OK] PR_NUMBER=${PR_IN}"      - name: Guard: mergeable & leftover branches #         shell: bash #         env:           GH_TOKEN: ${{ github.token }} #         run: |           set -euo pipefail           echo "[guard] check leftover remote branches: auto/writeback-bundle_*"           if git ls-remote --heads origin "auto/writeback-bundle_*" | grep -q . ; then             echo "[NG] leftover remote branches exist (auto/writeback-bundle_*). Clean them before writeback."             git ls-remote --heads origin "auto/writeback-bundle_*" || true             exit 2           fi           echo "[OK] no leftover remote branches."           # PR number must be provided by earlier steps (export to env). We refuse to guess.           PR_NUMBER="${PR_NUMBER:-${pr_number:-${PR:-}}}"           if [ -z "${PR_NUMBER}" ]; then             echo "[NG] PR number is not available in env (PR_NUMBER/pr_number/PR). Ensure reusable workflow exports PR number before merge."             exit 2           fi           echo "[guard] polling mergeable state for PR #${PR_NUMBER}"           mergeable=""           mergeable_state=""           for i in $(seq 1 30); do             mergeable="$(gh api repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER} --jq '.mergeable' || true)"             mergeable_state="$(gh api repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER} --jq '.mergeable_state' || true)"             if [ "${mergeable}" != "null" ] && [ -n "${mergeable}" ]; then               break             fi             sleep 2           done           echo "[guard] mergeable=${mergeable} mergeable_state=${mergeable_state}"           if [ "${mergeable}" != "true" ] || [ "${mergeable_state}" != "clean" ]; then             echo "[NG] merge is not allowed by guard (mergeable must be true and mergeable_state must be clean)."             exit 2           fi           echo "[OK] mergeable guard passed." #         with:           fetch-depth: 0        - name: Configure git identity #         shell: bash #         run: |           git config user.name  "github-actions[bot]"           git config user.email "github-actions[bot]@users.noreply.github.com"       - name: Generate Bundled (update docs/MEP/MEP_BUNDLE.md) #         shell: pwsh #         run: |           Set-StrictMode -Version Latest           $ErrorActionPreference = "Stop"            # (re)generate Bundled so diff can exist BEFORE writeback           pwsh -NoProfile -File tools/mep_bump_bundle_version.ps1 -BundlePath "docs/MEP/MEP_BUNDLE.md"            # evidence (non-fatal)           git status --porcelain -- docs/MEP/MEP_BUNDLE.md || true       - name: Writeback evidence -> PR (full) #         shell: pwsh #         env:           GH_TOKEN: ${{ github.token }} #         run: |           pwsh -NoProfile -File tools/mep_append_evidence_line_full.ps1 -PrNumber ${{ inputs.pr_number }}       - name: Writeback evidence -> PR (slim) #         shell: pwsh #         env:           GH_TOKEN: ${{ github.token }} #         run: |           $pr = '${{ inputs.pr_number }}'           if ([string]::IsNullOrWhiteSpace($pr)) { $pr = '0' }           pwsh -NoProfile -File tools/mep_writeback_bundle.ps1 -Mode pr -PrNumber $pr -BundlePath "docs/MEP/MEP_BUNDLE.md" -BundleScope "parent"        - name: Create PR for writeback branch #         shell: pwsh #         env:           GH_TOKEN: ${{ github.token }} #         run: |           Set-StrictMode -Version Latest           $ErrorActionPreference = 'Stop'           function Info([string]$m){ Write-Host ('[INFO] {0}' -f $m) }           function Warn([string]$m){ Write-Host ('[WARN] {0}' -f $m) }                      # If current branch is auto/writeback-bundle_*, create PR (if not exists)           $head = (git rev-parse --abbrev-ref HEAD).Trim()           Info ('HEAD=' + $head)           if ($head -notlike 'auto/writeback-bundle_*') {             Warn 'Not on auto/writeback-bundle_* branch; skip PR create.'             exit 0           }                      # if PR already exists for this head, skip           $exists = gh pr list --state open --head $head --json number --jq '.[0].number' 2>$null           if ($exists) {             Info ('PR already exists for head ' + $head + ': #' + $exists)             exit 0           }                      $title = ('Writeback bundle evidence ({0})' -f $head)           $body  = ('Automated writeback: created from branch {0} (run_id=' + ${{ github.run_id }} + ')' -f $head)           $url = gh pr create --title $title --body $body --base 'main' --head $head           Info ('Created PR: ' + $url)       - name: Writeback HANDOFF_NEXT -> PR (slim)         if: ${{ inputs.write_handoff == 'true' }} #         shell: pwsh #         env:           GH_TOKEN: ${{ github.token }} #         run: |           pwsh -NoProfile -File tools/mep_writeback_handoff.ps1 -CI        - name: GUARD_NO_PARENT_BUNDLED_WRITE #         shell: bash #         run: |           set -euo pipefail           if git diff --name-only | grep -q '^docs/MEP/MEP_BUNDLE\.md$'; then             echo "ERROR: HANDOFF_NEXT must not modify docs/MEP/MEP_BUNDLE.md (parent Bundled)."             echo "This prevents writeback-order rollback. Write to docs/MEP/MEP_BUNDLE.md instead."             git diff -- docs/MEP/MEP_BUNDLE.md || true             exit 1           fi                    
+        description: "PR number (0 = auto latest merged PR)"
+        required: false
+        default: "0"
+        type: string
+      write_handoff:
+        description: "Generate+Guard+Writeback HANDOFF_NEXT into Bundled"
+        required: false
+        default: "false"
+        type: string
+  workflow_call:
+    inputs:
+      pr_number:
+        required: false
+        default: "0"
+        type: string
+      write_handoff:
+        required: false
+        default: "false"
+        type: string
 
+permissions:
+  contents: write
+  pull-requests: write
 
+jobs:
+  writeback:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Export PR_NUMBER (resolve 0=latest merged)
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          PR_IN="${{ inputs.pr_number }}"
+          if [ -z "${PR_IN}" ]; then PR_IN="0"; fi
+          if [ "${PR_IN}" = "0" ]; then
+            echo "[export] inputs.pr_number=0 => resolve latest merged PR into base=main"
+            PR_IN="$(gh api "repos/${GITHUB_REPOSITORY}/pullsstate=closed&sort=updated&direction=desc&per_page=50" --jq '[.[] | select(.merged_at!=null and .base.ref=="main")][0].number')"
+          fi
+          if [ -z "${PR_IN}" ] || [ "${PR_IN}" = "null" ]; then
+            echo "[NG] failed to resolve PR number."
+            exit 2
+          fi
+          echo "PR_NUMBER=${PR_IN}" >> "${GITHUB_ENV}"
+          echo "[OK] PR_NUMBER=${PR_IN}"
+
+      - name: Guard: leftover remote branches auto/writeback-bundle_*
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          echo "[guard] check leftover remote branches: auto/writeback-bundle_*"
+          if git ls-remote --heads origin "auto/writeback-bundle_*" | grep -q . ; then
+            echo "[NG] leftover remote branches exist (auto/writeback-bundle_*). Clean them before writeback."
+            git ls-remote --heads origin "auto/writeback-bundle_*" || true
+            exit 2
+          fi
+          echo "[OK] no leftover remote branches."
+
+      - name: Configure git identity
+        shell: bash
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Generate Bundled (update docs/MEP/MEP_BUNDLE.md)
+        shell: pwsh
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = "Stop"
+          pwsh -NoProfile -File tools/mep_bump_bundle_version.ps1 -BundlePath "docs/MEP/MEP_BUNDLE.md"
+          git status --porcelain -- docs/MEP/MEP_BUNDLE.md || true
+
+      - name: Writeback evidence -> PR (slim)
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $pr = '${{ inputs.pr_number }}'
+          if ([string]::IsNullOrWhiteSpace($pr)) { $pr = '0' }
+          pwsh -NoProfile -File tools/mep_writeback_bundle.ps1 -Mode pr -PrNumber $pr -BundlePath "docs/MEP/MEP_BUNDLE.md" -BundleScope "parent"
+
+      - name: Create PR for writeback branch (if on auto/writeback-bundle_*)
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+          function Info([string]$m){ Write-Host ('[INFO] {0}' -f $m) }
+          function Warn([string]$m){ Write-Host ('[WARN] {0}' -f $m) }
+          $head = (git rev-parse --abbrev-ref HEAD).Trim()
+          Info ('HEAD=' + $head)
+          if ($head -notlike 'auto/writeback-bundle_*') {
+            Warn 'Not on auto/writeback-bundle_* branch; skip PR create.'
+            exit 0
+          }
+          $exists = gh pr list --state open --head $head --json number --jq '.[0].number' 2>$null
+          if ($exists) {
+            Info ('PR already exists for head ' + $head + ': #' + $exists)
+            exit 0
+          }
+          $title = ('Writeback bundle evidence ({0})' -f $head)
+          $body  = ('Automated writeback: created from branch {0}' -f $head)
+          $url = gh pr create --title $title --body $body --base 'main' --head $head
+          Info ('Created PR: ' + $url)
+
+      - name: Writeback HANDOFF_NEXT -> PR (slim)
+        if: ${{ inputs.write_handoff == 'true' }}
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          pwsh -NoProfile -File tools/mep_writeback_handoff.ps1 -CI


### PR DESCRIPTION
mep_writeback_bundle_dispatch.yml is YAML-invalid (duplicate keys / collapsed lines), so GitHub cannot register workflow_dispatch and dispatch returns HTTP 422.
This PR replaces the file with a known-good minimal workflow that restores workflow_dispatch and preserves core writeback behavior.