### PR TITLE
fix(actions): force-enable workflow_dispatch for writeback

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch.yml
@@ -1,5 +1,6 @@
 name: MEP Writeback Bundle (Dispatch) (rereg 20260201_043933)
 on:
+  # rereg-onblock 20260201_050047
   workflow_dispatch:
     inputs:
       pr_number:


### PR DESCRIPTION
目的: mep_writeback_bundle_dispatch の workflow_dispatch が API 上で認識されず HTTP 422 になる事象を解消する。
内容: on: ブロック直下に workflow_dispatch を強制配置（不足時は追加、存在時は再パース用コメントを追加）。