### PR TITLE
fix(ci): quote on key to prevent yaml coercion

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch.yml
@@ -1,5 +1,5 @@
 name: MEP Writeback Bundle (Dispatch) (rereg 20260201_043933)
-on:
+"on":
   # rereg-onblock 20260201_050047
   workflow_dispatch:
     inputs:

--- a/.github/workflows/mep_writeback_bundle_dispatch_reborn.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch_reborn.yml
@@ -1,5 +1,5 @@
 name: MEP Writeback Bundle (Dispatch) REBORN 20260201_050222
-on:
+"on":
   # rereg-onblock 20260201_050047
   workflow_dispatch:
     inputs:

--- a/.github/workflows/mep_writeback_bundle_dispatch_v2_20260201_035903.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch_v2_20260201_035903.yml
@@ -1,4 +1,4 @@
-on:
+"on":
   workflow_dispatch:
     inputs:
       pr_number:

--- a/.github/workflows/mep_writeback_bundle_on_push.yml
+++ b/.github/workflows/mep_writeback_bundle_on_push.yml
@@ -1,6 +1,6 @@
 name: MEP Writeback Bundle (Push Caller)
 
-on:
+"on":
   push:
     branches: [ main ]
   workflow_dispatch:

--- a/.github/workflows/mep_writeback_bundle_on_push_temp.yml
+++ b/.github/workflows/mep_writeback_bundle_on_push_temp.yml
@@ -1,5 +1,5 @@
 name: MEP Writeback Bundle (PUSH TEMP PROBE) 20260201_052017
-on:
+"on":
   push:
     branches:
       - main


### PR DESCRIPTION
目的: workflow の 'on' キーが YAML 処理で boolean 化（true:) され、workflow_dispatch/push 等のトリガが消える事象を止める。
内容: top-level の on/true キーを ""on"": に正規化。
証跡: C:\Users\Syuichi\Desktop\MEP_LOGS\WF_DEBUG\evi_on_key_probe_20260201_052417.txt