### PR TITLE
chore(mep): unified entry uses guarded SCOPE_FILE (Scope-IN header aligned)

### DIFF
--- a/tools/mep_unified_entry.ps1
+++ b/tools/mep_unified_entry.ps1
@@ -42,8 +42,8 @@ foreach ($line in $diffRaw) {
     }
   }
 }
-$changedArr = $changed.ToArray() | Where-Object { $_ -and ($_ -notmatch '^\s*$') } | ForEach-Object { $_.Replace('\','/') } | Sort-Object -Unique
-if (-not $changedArr -or $changedArr.Count -eq 0) { Warn "No changed files detected vs $baseRef...HEAD. Scope-IN candidate will be empty." }
+$changedArr = @($changed.ToArray() | Where-Object { $_ -and ($_ -notmatch '^\s*$') } | ForEach-Object { $_.Replace('\','/') } | Sort-Object -Unique)
+if (-not $changedArr -or @($changedArr).Count -eq 0) { Warn "No changed files detected vs $baseRef...HEAD. Scope-IN candidate will be empty." }
 # ---- candidate (bullet-only) ----
 $candidate = New-Object System.Collections.Generic.List[string]
 foreach ($p in $changedArr) { $candidate.Add(("- {0}" -f $p)) }


### PR DESCRIPTION
目的:
- unified entry が更新する SCOPE_FILE / 見出しを、実際のガード（Scope Guard / Format Guard）が期待する形に合わせる
変更:
- tools/mep_unified_entry.ps1
  - ScopeFile 既定: platform/MEP/90_CHANGES/CURRENT_SCOPE.md
  - ScopeHeader 既定: ## 変更対象（Scope-IN）
  - Scope-INブロックは bullet-only / 空行なし