### PR TITLE
revert: undo direct pushes on main (range)

### DIFF
--- a/tools/mep_unified_entry.ps1
+++ b/tools/mep_unified_entry.ps1
@@ -1,19 +1,21 @@
 <#
-MEP 運転完成フェーズ（Unified Operation Entry） - STEP1 入口一本化（最小・StrictMode耐性）
-- diff取得 → Scope-IN候補生成 → 承認①（任意） → ScopeFile（CURRENT_SCOPE）更新
-- 意味判断/マスタ改変はしない（候補列挙のみ）
+MEP 運転完成フェーズ（Unified Operation Entry） - STEP1 Scope-IN 更新（ガード準拠）
+- diff取得 → Scope-IN候補生成 → 承認①（任意） → SCOPE_FILE更新 → commit/push
+- 重要: ガードが読む SCOPE_FILE / 見出し形式に合わせる（ここでは生成・改変はしない）
 #>
-param(
-  [switch]$Once,
-  [switch]$ApprovalYes,
-  [string]$ScopeFile = "platform/MEP/90_CHANGES/CURRENT_SCOPE.md",
-  [string]$BaseRef = "origin/main"
-)
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
 $OutputEncoding = [Console]::OutputEncoding
 $env:GIT_PAGER="cat"; $env:PAGER="cat"; $ProgressPreference="SilentlyContinue"
+param(
+  [switch]$Once,
+  [switch]$ApprovalYes,
+  # ガード準拠の既定（workflowログ根拠）
+  [string]$ScopeFile = "platform/MEP/90_CHANGES/CURRENT_SCOPE.md",
+  # ガード準拠（厳密一致）
+  [string]$ScopeHeader = "## 変更対象（Scope-IN）"
+)
 function Info([string]$m){ Write-Host "[INFO] $m" -ForegroundColor Cyan }
 function Warn([string]$m){ Write-Host "[WARN] $m" -ForegroundColor Yellow }
 function Fail([string]$m){ throw $m }
@@ -21,13 +23,11 @@ try { $repoRoot = (git rev-parse --show-toplevel 2>$null).Trim() } catch { Fail 
 if (-not $repoRoot) { Fail "repoRoot is empty." }
 Set-Location $repoRoot
 Info "repoRoot=$repoRoot"
-# baseRef verify/fallback
-$baseRef = $BaseRef
+# ---- base ref ----
+$baseRef = "origin/main"
 try { git rev-parse --verify $baseRef *> $null } catch { $baseRef = "main" }
 Info "baseRef=$baseRef"
-# Scope file absolute path
-$scopePath = Join-Path $repoRoot $ScopeFile
-# changed files (rename included)
+# ---- changed files (rename included) ----
 $changed = New-Object System.Collections.Generic.List[string]
 $diffRaw = (git diff --name-status "$baseRef...HEAD" 2>$null)
 foreach ($line in $diffRaw) {
@@ -42,15 +42,9 @@ foreach ($line in $diffRaw) {
     }
   }
 }
-# ALWAYS array
-$changedArr = @(
-  $changed.ToArray() |
-    Where-Object { $_ -and ($_ -notmatch '^\s*$') } |
-    ForEach-Object { $_.Replace('\','/') } |
-    Sort-Object -Unique
-)
-if ($changedArr.Count -eq 0) { Warn "No changed files detected vs $baseRef...HEAD. Scope-IN candidate will be empty." }
-# candidate bullets
+$changedArr = @($changed.ToArray() | Where-Object { $_ -and ($_ -notmatch '^\s*$') } | ForEach-Object { $_.Replace('\','/') } | Sort-Object -Unique)
+if (-not $changedArr -or @($changedArr).Count -eq 0) { Warn "No changed files detected vs $baseRef...HEAD. Scope-IN candidate will be empty." }
+# ---- candidate (bullet-only) ----
 $candidate = New-Object System.Collections.Generic.List[string]
 foreach ($p in $changedArr) { $candidate.Add(("- {0}" -f $p)) }
 Write-Host ""
@@ -58,40 +52,37 @@ Write-Host "===== Scope-IN Candidate (bullet-only) ====="
 if ($candidate.Count -gt 0) { $candidate | ForEach-Object { Write-Host $_ } } else { Write-Host "- (none)" }
 Write-Host "==========================================="
 Write-Host ""
-# approval①
+# ---- approval① ----
 if (-not $ApprovalYes) {
-  $ans = Read-Host "Approval① (type YES to apply to ScopeFile, otherwise abort)"
+  $ans = Read-Host "Approval① (type YES to apply to SCOPE_FILE, otherwise abort)"
   if ($ans -ne "YES") { Fail "Approval① denied (input was not YES)." }
 } else {
   Info "Approval① bypassed (-ApprovalYes)."
 }
-# ensure scope dir
-$scopeDir = Split-Path $scopePath -Parent
-if (!(Test-Path $scopeDir)) { New-Item -ItemType Directory -Path $scopeDir -Force | Out-Null }
-# create scope file if missing (minimal scaffold)
+# ---- SCOPE_FILE upsert + replace Scope-IN section ----
+$scopePath = Join-Path $repoRoot $ScopeFile
+$dir = Split-Path $scopePath -Parent
+if (-not (Test-Path $dir)) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
 if (!(Test-Path $scopePath)) {
-  Info "ScopeFile not found. Creating: $scopePath"
+  Info "SCOPE_FILE not found. Creating new file."
   @(
-    "# CURRENT_SCOPE（唯一の正：変更範囲の許可リスト）"
-    "## 変更対象（Scope-IN）"
+    "# CURRENT_SCOPE"
+    $ScopeHeader
     "- (none)"
-    "## 非対象（Scope-OUT｜明示）"
-    "- platform/MEP/01_CORE/**"
-    "- platform/MEP/00_GLOBAL/**"
   ) | Set-Content -Path $scopePath -Encoding UTF8 -NoNewline
 }
 $lines = Get-Content -Path $scopePath -Encoding UTF8
 if (-not $lines) { $lines = @() }
-# find "## 変更対象（Scope-IN）"
+# locate header (strict equality)
 $startIdx = -1
 for ($i=0; $i -lt $lines.Count; $i++) {
-  if ($lines[$i] -match '^\s*##\s*変更対象（Scope-IN）\s*$') { $startIdx = $i; break }
+  if ($lines[$i].Trim() -eq $ScopeHeader) { $startIdx = $i; break }
 }
-# end at next "## " or EOF
+# find end (next "## " or EOF)
 $endIdx = $lines.Count
 if ($startIdx -ge 0) {
   for ($j=$startIdx+1; $j -lt $lines.Count; $j++) {
-    if ($lines[$j] -match '^\s*##\s+') { $endIdx = $j; break }
+    if ($lines[$j].StartsWith("## ")) { $endIdx = $j; break }
   }
 }
 function Add-NonEmpty([System.Collections.Generic.List[string]]$list, [string]$s) {
@@ -100,21 +91,32 @@ function Add-NonEmpty([System.Collections.Generic.List[string]]$list, [string]$s
 $new = New-Object System.Collections.Generic.List[string]
 if ($startIdx -lt 0) {
   foreach($ln in $lines){ Add-NonEmpty $new $ln }
-  Add-NonEmpty $new "## 変更対象（Scope-IN）"
+  Add-NonEmpty $new $ScopeHeader
   if ($candidate.Count -gt 0) { foreach($c in $candidate){ Add-NonEmpty $new $c } } else { Add-NonEmpty $new "- (none)" }
 } else {
   for ($k=0; $k -le $startIdx; $k++) { Add-NonEmpty $new $lines[$k] }
   if ($candidate.Count -gt 0) { foreach($c in $candidate){ Add-NonEmpty $new $c } } else { Add-NonEmpty $new "- (none)" }
   for ($k=$endIdx; $k -lt $lines.Count; $k++) { Add-NonEmpty $new $lines[$k] }
 }
-# enforce: Scope-IN bullets only, and remove blank lines
+# enforce bullet-only inside Scope-IN block + remove blank lines
 $enforce = New-Object System.Collections.Generic.List[string]
 $inScope = $false
 foreach ($ln in $new) {
-  if ($ln -match '^\s*##\s*変更対象（Scope-IN）\s*$') { $inScope = $true; $enforce.Add($ln); continue }
-  if ($ln -match '^\s*##\s+' -and $ln -notmatch '^\s*##\s*変更対象（Scope-IN）\s*$') { $inScope = $false; $enforce.Add($ln); continue }
-  if ($inScope) { if ($ln -notmatch '^\s*-\s+') { Fail "Non-bullet line detected under Scope-IN: $ln" } }
-  $enforce.Add($ln)
+  if ($ln.Trim() -eq $ScopeHeader) { $inScope = $true; $enforce.Add($ln); continue }
+  if ($ln.StartsWith("## ") -and $ln.Trim() -ne $ScopeHeader) { $inScope = $false; $enforce.Add($ln); continue }
+  if ($inScope) {
+    if ($ln -notmatch '^\s*-\s+') { Fail "Non-bullet line detected under Scope-IN: $ln" }
+  }
+  if ($ln -ne "") { $enforce.Add($ln) }
 }
 $enforce.ToArray() | Set-Content -Path $scopePath -Encoding UTF8 -NoNewline
-Info "Updated ScopeFile: $scopePath"
+Info ("Updated SCOPE_FILE: " + $ScopeFile)
+# ---- git commit/push (scope update) ----
+$branchName = (git branch --show-current).Trim()
+if (-not $branchName) { Fail "Current branch name is empty." }
+git add $scopePath | Out-Null
+$ts2 = Get-Date -Format "yyyyMMdd_HHmmss"
+$commitMsg = "chore(mep): unified entry scope-in update ($ts2)"
+try { git commit -m $commitMsg | Out-Null } catch { Warn "git commit skipped (maybe no changes)." }
+try { git push -u origin $branchName | Out-Null } catch { Warn "git push failed (check auth/remote)." }
+Info "Unified entry run done."


### PR DESCRIPTION
Revert a contiguous range of direct-push commits on main (starting after c698c1356ac72e743283752cb1d338c3f32cf98d). This restores PR→main discipline before re-introducing changes via proper PRs (e.g., PR #1532).