### PR TITLE
revert: undo accidental direct push to main (f494c9db)

### DIFF
--- a/tools/mep_unified_entry.ps1
+++ b/tools/mep_unified_entry.ps1
@@ -14,19 +14,6 @@ param(
   [switch]$RunWriteback,
   [int]$WritebackPrNumber = 0
 )
-
-
-# === HARD_EARLY_RETURN: PRNUMBER_MODE ===
-try {
-  if ($PSBoundParameters.ContainsKey('PrNumber') -and ([int]$PrNumber) -ne 0) {
-    $repo = 'Osuu-ops/yorisoidou-system'
-    $tool = Join-Path $PSScriptRoot 'mep_scopein_candidates_from_pr.ps1'
-    if (-not (Test-Path $tool)) { throw "missing tool: $tool" }
-    & $tool -PrNumber ([int]$PrNumber) -Repo $repo
-    return
-  }
-} catch { throw }
-# === END HARD_EARLY_RETURN: PRNUMBER_MODE ===
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)


### PR DESCRIPTION
背景:
- mainへ直接pushが入ったため監査整合を回復する

内容:
- commit f494c9db をrevertし、PR経由でmainへ戻す
