### PR TITLE
feat(mep): draft lane + status snapshot + intent/blast cards

### DIFF
--- a/platform/MEP/01_CORE/cards/BLAST_RADIUS.md
+++ b/platform/MEP/01_CORE/cards/BLAST_RADIUS.md
@@ -1,0 +1,14 @@
+## CARD: BLAST_RADIUS (Change Boundary)
+
+### Purpose
+Declare what may change / must not change, to enforce "stop on unexpected change".
+
+### Template (minimum fields)
+- allowed_paths: glob/path prefixes allowed to change
+- forbidden_paths: glob/path prefixes forbidden to change
+- allowed_behaviors: allowed behavior changes
+- forbidden_behaviors: forbidden behavior changes
+- stop_condition: any diff outside allowed => fail gate
+
+### Enforcement (future)
+- diff classifier in CI to verify change boundary

--- a/platform/MEP/01_CORE/cards/INTENT_CARD.md
+++ b/platform/MEP/01_CORE/cards/INTENT_CARD.md
@@ -1,0 +1,15 @@
+## CARD: INTENT_CARD (Intent Declaration)
+
+### Purpose
+Freeze intent early to prevent scope drift and to make approval judgement stable.
+
+### Template (minimum fields)
+- purpose: what we are trying to achieve
+- non_goals: explicitly excluded outcomes
+- invariants: must-not-break points (truth sources, guard rails)
+- acceptance: conditions to accept
+- evidence: where truth is verified (Bundled, PR, commit, logs)
+
+### Storage
+- Draft: BUSINESS_UNIT/<unit>/DRAFT/INTENT.md
+- Master: BUSINESS_UNIT/<unit>/MASTER/INTENT.md (append-only sections)

--- a/platform/MEP/01_CORE/cards/STATUS_SNAPSHOT.md
+++ b/platform/MEP/01_CORE/cards/STATUS_SNAPSHOT.md
@@ -1,0 +1,19 @@
+## CARD: STATUS_SNAPSHOT (mep status / snapshot)
+
+### Purpose
+Provide a single command snapshot of "current truth" without relying on chat context.
+
+### Must Output (minimum)
+- repo: owner/name + current branch
+- HEAD commit
+- Bundled: docs/MEP/MEP_BUNDLE.md BUNDLE_VERSION
+- clean/dirty status
+- latest merged PR (best-effort via gh) and its mergeCommit/mergedAt
+- optional: last 20 commits summary (oneline)
+
+### Non-Goals
+- No mutation (read-only).
+- No inference beyond printed evidence.
+
+### Implementation
+- tools/mep_status_snapshot.ps1

--- a/platform/MEP/03_BUSINESS/BUSINESS_UNIT/_TEMPLATE/DRAFT/BLAST_RADIUS.md
+++ b/platform/MEP/03_BUSINESS/BUSINESS_UNIT/_TEMPLATE/DRAFT/BLAST_RADIUS.md
@@ -1,0 +1,16 @@
+# BLAST_RADIUS
+
+allowed_paths:
+- 
+
+forbidden_paths:
+- 
+
+allowed_behaviors:
+- 
+
+forbidden_behaviors:
+- 
+
+stop_condition:
+- any diff outside allowed_paths

--- a/platform/MEP/03_BUSINESS/BUSINESS_UNIT/_TEMPLATE/DRAFT/INTENT.md
+++ b/platform/MEP/03_BUSINESS/BUSINESS_UNIT/_TEMPLATE/DRAFT/INTENT.md
@@ -1,0 +1,11 @@
+# INTENT
+
+purpose:
+
+non_goals:
+
+invariants:
+
+acceptance:
+
+evidence:

--- a/platform/MEP/03_BUSINESS/INBOX_RAW/README.md
+++ b/platform/MEP/03_BUSINESS/INBOX_RAW/README.md
@@ -1,0 +1,22 @@
+# Draft Lane (INBOX_RAW -> DRAFT -> MASTER -> ARTIFACTS)
+
+## Purpose
+- Preserve pre-declaration fragments as **non-canonical** (INBOX_RAW).
+- Promote to structured draft (DRAFT) after declaration/templating.
+- Accumulate immutable master knowledge (MASTER) with append-only discipline.
+- Generate artifacts from MASTER into ARTIFACTS.
+
+## Structure
+- platform/MEP/03_BUSINESS/INBOX_RAW/
+  - Pre-declaration fragments (not truth; not adopted).
+- platform/MEP/03_BUSINESS/BUSINESS_UNIT/<unit>/
+  - DRAFT/      : templated draft for iteration
+  - MASTER/     : append-only canonicalized business knowledge
+  - ARTIFACTS/  : generated outputs from MASTER
+
+## Template
+- platform/MEP/03_BUSINESS/BUSINESS_UNIT/_TEMPLATE/{DRAFT,MASTER,ARTIFACTS}/
+
+## Operational Rule (minimal)
+- INBOX_RAW is isolation only (never treated as truth).
+- MASTER is append-only (history via Git).

--- a/tools/mep_status_snapshot.ps1
+++ b/tools/mep_status_snapshot.ps1
@@ -1,0 +1,52 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+$OutputEncoding = [Console]::OutputEncoding
+$env:GIT_PAGER="cat"; $env:PAGER="cat"
+
+function Out([string]$k,[string]$v){ "{0}: {1}" -f $k,$v }
+
+$root = (git rev-parse --show-toplevel 2>$null).Trim()
+if ([string]::IsNullOrWhiteSpace($root)) { throw "Not a git repo." }
+Set-Location $root
+
+$remote = (git remote get-url origin 2>$null).Trim()
+$slug = ""
+if ($remote -match 'github\.com[:/](<slug>[^/]+/[^/]+)(\.git)$') { $slug = $Matches['slug'] }
+
+$branch = (git rev-parse --abbrev-ref HEAD).Trim()
+$head   = (git rev-parse HEAD).Trim()
+$clean  = -not [bool](git status --porcelain)
+
+$bundled = Join-Path $root "docs/MEP/MEP_BUNDLE.md"
+$bv = ""
+if (Test-Path $bundled) {
+  $m = Select-String -Path $bundled -Pattern '^BUNDLE_VERSION\s*=' -ErrorAction SilentlyContinue | Select-Object -First 1
+  if ($m) { $bv = $m.Line.Trim() }
+}
+
+Write-Host (Out "repo"   (if ($slug) { $slug } else { $remote })) 
+Write-Host (Out "branch" $branch)
+Write-Host (Out "HEAD"   $head)
+Write-Host (Out "clean"  $clean)
+if ($bv) { Write-Host (Out "Bundled" $bv) } else { Write-Host (Out "Bundled" "missing or no BUNDLE_VERSION") }
+
+# best-effort: latest merged PR via gh (requires auth); never fails the snapshot if unavailable
+try {
+  $json = gh pr list --state merged --limit 1 --json number,mergedAt,mergeCommit,headRefName,title --repo $slug 2>$null | ConvertFrom-Json
+  if ($json -and $json.Count -ge 1) {
+    $pr = $json[0]
+    Write-Host (Out "latestMergedPR" ("#{0} {1}" -f $pr.number, $pr.title))
+    Write-Host (Out "mergedAt" $pr.mergedAt)
+    Write-Host (Out "mergeCommit" $pr.mergeCommit.oid)
+    Write-Host (Out "headRef" $pr.headRefName)
+  } else {
+    Write-Host (Out "latestMergedPR" "unavailable")
+  }
+} catch {
+  Write-Host (Out "latestMergedPR" "unavailable (gh not ready)")
+}
+
+Write-Host "recentCommits:"
+git log -n 20 --oneline


### PR DESCRIPTION
## What
- Add BUSINESS Draft Lane skeleton (INBOX_RAW -> DRAFT -> MASTER -> ARTIFACTS)
- Add STATUS_SNAPSHOT core card + read-only snapshot script (tools/mep_status_snapshot.ps1)
- Add INTENT_CARD + BLAST_RADIUS core cards
- Add BUSINESS_UNIT template files for INTENT/BLAST_RADIUS drafts
## Evidence / How to verify
- Run: pwsh -NoProfile -File tools/mep_status_snapshot.ps1