### PR TITLE
fix(ci): repair writeback reusable workflow (if boolean-safe)

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch.yml
@@ -57,7 +57,7 @@ jobs:
         run: |
           pwsh -NoProfile -File tools/mep_append_evidence_line_full.ps1 -PrNumber ${{ env.PR_NUMBER }} -BundlePath "docs/MEP/MEP_BUNDLE.md"
       - name: Optional: Writeback HANDOFF_NEXT (CI)
-        if: ${{ inputs.write_handoff == 'true' }}
+        if: ${{ inputs.write_handoff }}
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
@@ -87,3 +87,4 @@ jobs:
           $body  = ('Automated writeback: created from branch {0} (run_id={1})' -f $head, '${{ github.run_id }}')
           $url = gh pr create --title $title --body $body --base 'main' --head $head
           Info ('Created PR: ' + $url)
+


### PR DESCRIPTION
## What
- Make reusable workflow step condition boolean-safe:
  - if: ${{ inputs.write_handoff }}
## Why
- workflow_dispatch entry fails with HTTP 422 (failed to parse called workflow)
## Evidence
- gh workflow run of writeback entry should succeed after merge