### PR TITLE
fix(ci): repair writeback workflow yaml parse (remove optional step)

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch.yml
@@ -56,13 +56,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           pwsh -NoProfile -File tools/mep_append_evidence_line_full.ps1 -PrNumber ${{ env.PR_NUMBER }} -BundlePath "docs/MEP/MEP_BUNDLE.md"
-      - name: Optional: Writeback HANDOFF_NEXT (CI)
-        if: ${{ inputs.write_handoff }}
-        shell: pwsh
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          pwsh -NoProfile -File tools/mep_writeback_handoff.ps1 -CI
       - name: Create PR for writeback branch (if needed)
         shell: pwsh
         env:


### PR DESCRIPTION
## What
- Remove optional HANDOFF_NEXT step block that breaks YAML parsing in reusable workflow
- Remove any stray quote-only lines
## Why
- writeback entry dispatch fails with HTTP 422 (failed to parse called workflow)
## Evidence
- gh workflow run (entry) should succeed after merge