### PR TITLE
fix(ci): make writeback workflow reusable (workflow_call)

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch.yml
@@ -81,3 +81,4 @@ jobs:
           $url = gh pr create --title $title --body $body --base 'main' --head $head
           Info ('Created PR: ' + $url)
 
+


### PR DESCRIPTION
## What
- Add on.workflow_call to mep_writeback_bundle_dispatch.yml
- Provide inputs: pr_number (required), write_handoff (optional boolean)
## Why
- entry dispatch fails: workflow is not reusable as it is missing on.workflow_call