### PR TITLE
fix(ci): make writeback workflow reusable (on.workflow_call)

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch.yml
@@ -1,5 +1,5 @@
 name: MEP Writeback Bundle (Dispatch) (rereg 20260201_043933)
-"on":
+on:
   # rereg-onblock 20260201_050047
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## What
- Normalize "on": -> on:
- Add on.workflow_call with inputs: pr_number, write_handoff
## Why
- entry dispatch fails: called workflow is not reusable (missing on.workflow_call)