### PR TITLE
chore(mep): ratify tool-only policy via PR

### DIFF
--- a/docs/MEP/WORK_ITEMS/tool_only_pr_policy.md
+++ b/docs/MEP/WORK_ITEMS/tool_only_pr_policy.md
@@ -17,3 +17,5 @@ A **tool-only PR** is a change that:
 ## Audit Notes
 - When a PR is tool-only, evidence absence is not a defect.
 - If future requirements change, this policy must be revised via PR.
+## Change Control
+- This policy must be changed via PR (no direct edits on main).


### PR DESCRIPTION
Purpose:
- Create an auditable PR trail for the tool-only policy doc (ratification of the prior direct-main commit).
Notes:
- This PR makes a minimal, stable change only (no timestamps), and establishes PR-governed change control.