### PR TITLE
fix(mep): always create writeback PR

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch_reborn.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch_reborn.yml
@@ -75,8 +75,8 @@ jobs:
           $head = (git rev-parse --abbrev-ref HEAD).Trim()
           Info ('HEAD=' + $head)
           if ($head -notlike 'auto/writeback-bundle_*') {
-            Warn 'Not on auto/writeback-bundle_* branch; skip PR create.'
-            exit 0
+            Warn 'Override: always create PR (branch guard disabled).'
+# patched: removed early exit to ensure PR creation path executes
           }
           $exists = gh pr list --state open --head $head --json number --jq '.[0].number' 2>$null
           if ($exists) {
@@ -87,3 +87,4 @@ jobs:
           $body  = ('Automated writeback: created from branch {0} (run_id={1})' -f $head, '${{ github.run_id }}')
           $url = gh pr create --title $title --body $body --base 'main' --head $head
           Info ('Created PR: ' + $url)
+


### PR DESCRIPTION
Problem:
- Entry writeback can succeed but not update main because PR creation is skipped when not on auto/writeback-bundle_* branch.
Fix:
- Disable branch-name guard so writeback always creates a PR path (auditable) instead of silent no-op on main.