### PR TITLE
fix(mep): create writeback branch before PR create (run-scoped)

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch.yml
@@ -74,12 +74,34 @@ jobs:
           $ErrorActionPreference = "Stop"
           function Info([string]$m){ Write-Host ('[INFO] {0}' -f $m) }
           function Warn([string]$m){ Write-Host ('[WARN] {0}' -f $m) }
-          $head = (git rev-parse --abbrev-ref HEAD).Trim()
-          Info ('HEAD=' + $head)
-          if ($head -notlike 'auto/writeback-bundle_*') {
-            Warn 'Not on auto/writeback-bundle_* branch; skip PR create.'
-            exit 0
-          }
+          # === patched: if HEAD is main, create writeback branch, commit/push bundle, then create PR ===
+$head = (git rev-parse --abbrev-ref HEAD).Trim()
+Info ('HEAD=' + $head)
+# If we're not on auto/writeback-bundle_* , but we have changes, create a writeback branch and push it.
+if ($head -notlike 'auto/writeback-bundle_*') {
+  Warn 'Not on auto/writeback-bundle_* branch; creating writeback branch and PR.'
+  $dirty = (git status --porcelain).Trim()
+  if (-not $dirty) {
+    Info 'Working tree clean; nothing to write back.'
+    exit 0
+  }
+  $runId = $env:GITHUB_RUN_ID
+  if (-not $runId) { $runId = '0' }
+  $ts = (Get-Date -Format 'yyyyMMdd_HHmmss')
+  $newHead = ('auto/writeback-bundle_{0}_{1}_{2}' -f $runId, $env:PR_NUMBER, $ts)
+  Info ('Create branch: ' + $newHead)
+  git switch -c $newHead | Out-Null
+  # Commit only the bundle file (writeback content)
+  git add -- 'docs/MEP/MEP_BUNDLE.md' | Out-Null
+  if ((git status --porcelain).Trim()) {
+    $msg = ('chore(mep): writeback bundle evidence (PR #{0}) (run {1})' -f $env:PR_NUMBER, $runId)
+    git commit -m $msg | Out-Null
+    git push -u origin $newHead | Out-Null
+  }
+  $head = $newHead
+  Info ('HEAD=' + $head)
+}
+# ===========================================================
           $exists = gh pr list --state open --head $head --json number --jq '.[0].number' 2>$null
           if ($exists) {
             Info ('PR already exists for head ' + $head + ': #' + $exists)
@@ -89,6 +111,7 @@ jobs:
           $body  = ('Automated writeback: created from branch {0} (run_id={1})' -f $head, '${{ github.run_id }}')
           $url = gh pr create --title $title --body $body --base 'main' --head $head
           Info ('Created PR: ' + $url)
+
 
 
 

--- a/platform/MEP/90_CHANGES/CURRENT_SCOPE.md
+++ b/platform/MEP/90_CHANGES/CURRENT_SCOPE.md
@@ -3,6 +3,7 @@
 - platform/MEP/90_CHANGES/CURRENT_SCOPE.md
 - tools/mep_entry.ps1
 - tools/mep_append_evidence_line_full.ps1
+- .github/workflows/mep_writeback_bundle_dispatch.yml
 ## 非対象（Scope-OUT｜明示）
 - platform/MEP/01_CORE/**
 - platform/MEP/00_GLOBAL/**


### PR DESCRIPTION
Fix: writeback workflow skipped PR creation because HEAD=main. Now creates auto/writeback-bundle_<run>_<pr>_<ts> branch, commits bundle change, pushes, then creates PR. Also updates CURRENT_SCOPE Scope-IN for workflow file.