### PR TITLE
fix(mep): stable writeback PR creation via helper script

### DIFF
--- a/platform/MEP/90_CHANGES/CURRENT_SCOPE.md
+++ b/platform/MEP/90_CHANGES/CURRENT_SCOPE.md
@@ -4,6 +4,7 @@
 - tools/mep_entry.ps1
 - tools/mep_append_evidence_line_full.ps1
 - .github/workflows/mep_writeback_bundle_dispatch.yml
+- tools/mep_writeback_create_pr.ps1
 ## 非対象（Scope-OUT｜明示）
 - platform/MEP/01_CORE/**
 - platform/MEP/00_GLOBAL/**

--- a/tools/mep_writeback_create_pr.ps1
+++ b/tools/mep_writeback_create_pr.ps1
@@ -1,0 +1,47 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+param(
+  [Parameter(Mandatory=$true)][string]$BundlePath
+)
+function Info([string]$m){ Write-Host ("[INFO] {0}" -f $m) }
+function Warn([string]$m){ Write-Host ("[WARN] {0}" -f $m) }
+$head = (git rev-parse --abbrev-ref HEAD).Trim()
+Info ("HEAD=" + $head)
+# If we are already on a writeback branch, just create PR if needed
+function Ensure-PrForHead([string]$h){
+  $exists = $null
+  try { $exists = gh pr list --state open --head $h --json number --jq '.[0].number' 2>$null } catch {}
+  if ($exists) { Info ("PR already exists for head " + $h + ": #" + $exists); return }
+  $runId = $env:GITHUB_RUN_ID; if (-not $runId) { $runId = "0" }
+  $title = ("Writeback bundle evidence ({0})" -f $h)
+  $body  = ("Automated writeback: created from branch {0} (run_id={1})" -f $h, $runId)
+  $url = gh pr create --title $title --body $body --base "main" --head $h
+  Info ("Created PR: " + $url)
+}
+if ($head -like "auto/writeback-bundle_*") {
+  Ensure-PrForHead $head
+  exit 0
+}
+# If on main (or any non-writeback branch), create writeback branch if bundle file changed
+$dirty = (git status --porcelain).Trim()
+if (-not $dirty) {
+  Info "Working tree clean; nothing to write back."
+  exit 0
+}
+$runId = $env:GITHUB_RUN_ID; if (-not $runId) { $runId = "0" }
+$prNo  = $env:PR_NUMBER;    if (-not $prNo)  { $prNo  = "0" }
+$ts = (Get-Date -Format "yyyyMMdd_HHmmss")
+$newHead = ("auto/writeback-bundle_{0}_{1}_{2}" -f $runId, $prNo, $ts)
+Warn ("Not on auto/writeback-bundle_*; creating branch " + $newHead)
+git switch -c $newHead | Out-Null
+git add -- $BundlePath | Out-Null
+$dirty2 = (git status --porcelain).Trim()
+if ($dirty2) {
+  $msg = ("chore(mep): writeback bundle evidence (PR #{0}) (run {1})" -f $prNo, $runId)
+  git commit -m $msg | Out-Null
+  git push -u origin $newHead | Out-Null
+} else {
+  Info "No staged changes for bundle; skip push/PR."
+  exit 0
+}
+Ensure-PrForHead $newHead


### PR DESCRIPTION
Fix YAML parse regression and make writeback PR creation stable by calling tools/mep_writeback_create_pr.ps1 from workflow. Avoid complex inline scripts in YAML.