### PR TITLE
fix(ci): restore yaml indent for writeback workflow

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch.yml
@@ -75,33 +75,33 @@ jobs:
           function Info([string]$m){ Write-Host ('[INFO] {0}' -f $m) }
           function Warn([string]$m){ Write-Host ('[WARN] {0}' -f $m) }
           # === patched: if HEAD is main, create writeback branch, commit/push bundle, then create PR ===
-$head = (git rev-parse --abbrev-ref HEAD).Trim()
-Info ('HEAD=' + $head)
-# If we're not on auto/writeback-bundle_* , but we have changes, create a writeback branch and push it.
-if ($head -notlike 'auto/writeback-bundle_*') {
-  Warn 'Not on auto/writeback-bundle_* branch; creating writeback branch and PR.'
-  $dirty = (git status --porcelain).Trim()
-  if (-not $dirty) {
-    Info 'Working tree clean; nothing to write back.'
-    exit 0
-  }
-  $runId = $env:GITHUB_RUN_ID
-  if (-not $runId) { $runId = '0' }
-  $ts = (Get-Date -Format 'yyyyMMdd_HHmmss')
-  $newHead = ('auto/writeback-bundle_{0}_{1}_{2}' -f $runId, $env:PR_NUMBER, $ts)
-  Info ('Create branch: ' + $newHead)
-  git switch -c $newHead | Out-Null
-  # Commit only the bundle file (writeback content)
-  git add -- 'docs/MEP/MEP_BUNDLE.md' | Out-Null
-  if ((git status --porcelain).Trim()) {
-    $msg = ('chore(mep): writeback bundle evidence (PR #{0}) (run {1})' -f $env:PR_NUMBER, $runId)
-    git commit -m $msg | Out-Null
-    git push -u origin $newHead | Out-Null
-  }
-  $head = $newHead
-  Info ('HEAD=' + $head)
-}
-# ===========================================================
+          $head = (git rev-parse --abbrev-ref HEAD).Trim()
+          Info ('HEAD=' + $head)
+          # If we're not on auto/writeback-bundle_* , but we have changes, create a writeback branch and push it.
+          if ($head -notlike 'auto/writeback-bundle_*') {
+          Warn 'Not on auto/writeback-bundle_* branch; creating writeback branch and PR.'
+          $dirty = (git status --porcelain).Trim()
+          if (-not $dirty) {
+          Info 'Working tree clean; nothing to write back.'
+          exit 0
+          }
+          $runId = $env:GITHUB_RUN_ID
+          if (-not $runId) { $runId = '0' }
+          $ts = (Get-Date -Format 'yyyyMMdd_HHmmss')
+          $newHead = ('auto/writeback-bundle_{0}_{1}_{2}' -f $runId, $env:PR_NUMBER, $ts)
+          Info ('Create branch: ' + $newHead)
+          git switch -c $newHead | Out-Null
+          # Commit only the bundle file (writeback content)
+          git add -- 'docs/MEP/MEP_BUNDLE.md' | Out-Null
+          if ((git status --porcelain).Trim()) {
+          $msg = ('chore(mep): writeback bundle evidence (PR #{0}) (run {1})' -f $env:PR_NUMBER, $runId)
+          git commit -m $msg | Out-Null
+          git push -u origin $newHead | Out-Null
+          }
+          $head = $newHead
+          Info ('HEAD=' + $head)
+          }
+          # ===========================================================
           $exists = gh pr list --state open --head $head --json number --jq '.[0].number' 2>$null
           if ($exists) {
             Info ('PR already exists for head ' + $head + ': #' + $exists)


### PR DESCRIPTION
Problem:
- workflow_dispatch fails with HTTP 422 because .github/workflows/mep_writeback_bundle_dispatch.yml has a YAML syntax error (run: | block indent broken at line 78).
Fix:
- Re-indent the run: | script block under 'Create PR for writeback branch (if needed)' so YAML parses correctly.