### PR TITLE
chore(mep): quality - resolve mergeCommit for PR #1554

### DIFF
--- a/docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md
+++ b/docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md
@@ -47,3 +47,4 @@ PR #1507 | audit=OK,WB0000 | appended_at=2026-02-01T04:10:48.4072230+09:00 | via
 * - PR #1547 | mergedAt=02/01/2026 14:08:17 | mergeCommit=8ef23afd5cc256066c5b63783e0606e381a07a17 | BUNDLE_VERSION=v0.0.0+20260201_145322+main_135741d | audit=OK,WB0000 | https://github.com/Osuu-ops/yorisoidou-system/pull/1547
 PR #1547 | audit=OK,WB0000 | appended_at=2026-02-01T23:53:23.4181959+09:00 | via=mep_append_evidence_line_full.ps1
 
+PR #1554 | quality=MERGECOMMIT_RESOLVED | mergeCommit=fcc15e6ccf886aae6e5a0dd76e14fe0fab4c031b | resolved_at=2026-02-02T03:07:23.3408200+09:00 | via=mergecommit_fetch_no_profile.ps1


### PR DESCRIPTION
What: Append a quality evidence line resolving mergeCommit for merged PR #1554.
Why: Replace UNKNOWN_MERGECOMMIT quality gap with confirmed merge_commit_sha (fcc15e6ccf886aae6e5a0dd76e14fe0fab4c031b).
Scope: docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md (+1 line).