### PR TITLE
chore(mep): enforce BUNDLED_AT on evidence bundle + handoff shows it

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch_entry.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch_entry.yml
@@ -79,3 +79,4 @@ jobs:
           pwsh -NoProfile -File tools/mep_writeback_create_pr.ps1 -BundlePath "docs/MEP/MEP_BUNDLE.md"
 
 
+

--- a/tools/mep_handoff.ps1
+++ b/tools/mep_handoff.ps1
@@ -36,8 +36,9 @@ try {
   $parentBundledAt = if ($bundledAtLine) { (($bundledAtLine.Line -replace "\s+$","") -replace "^\s*BUNDLED_AT\s*=\s*","") } else { "(not found)" }
   $handoffFile = "docs/MEP_SUB/EVIDENCE/HANDOFF_VERIFIED_AT.txt"
   $handoffVerifiedAt = if (Test-Path -LiteralPath $handoffFile) { (Get-Content -LiteralPath $handoffFile -TotalCount 1) } else { "(not found)" }
+  $evidenceBundledAtLine = (Select-String -LiteralPath $evidencePath -Pattern "^BUNDLED_AT\s*=" -ErrorAction SilentlyContinue | Select-Object -First 1)
+  $evidenceBundledAt = if ($evidenceBundledAtLine) { (($evidenceBundledAtLine.Line -replace "\s+$","") -replace "^\s*BUNDLED_AT\s*=\s*","") } else { "(not found)" }
   # === TIME_MARKS_INLINE_OUT_END ===
-
   $evidencePath = "docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md"
   $evOk = Test-Path -LiteralPath $evidencePath
 
@@ -64,6 +65,7 @@ try {
   $out.Add("HANDOFF_VERIFIED_AT: " + $handoffVerifiedAt)
   $out.Add("GENERATED_AT: " + $handoffVerifiedAt)
   $out.Add("EVIDENCE_BUNDLE: " + $evidencePath)
+  $out.Add("EVIDENCE_BUNDLED_AT: " + $evidenceBundledAt)
   $out.Add("")
   $out.Add("完了（今回の確定点）")
   $out.Add("- Pre-Gate→AUTO（read-only suite）完走（stage=DONE）")


### PR DESCRIPTION
目的:
- writeback で親Bundledだけでなく EVIDENCE_BUNDLE も BUNDLED_AT を必須化（一次根拠を揃える）
- mep_handoff 出力に EVIDENCE_BUNDLED_AT を写経で表示（監査用の視認性）
変更:
- workflow: Stamp BUNDLED_AT step を git add/commit/push の直前へ移動（bundle生成後に刻む前提）
- tools/mep_handoff.ps1: EVIDENCE_BUNDLED_AT 行を追加（生成せず写経）