### PR TITLE
chore(mep): fix evidence BUNDLED_AT (stamp timing) + handoff bugfix

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch_entry.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch_entry.yml
@@ -1,3 +1,18 @@
+      - name: Stamp BUNDLED_AT
+        shell: bash
+        run: |
+          set -euo pipefail
+          ts=$(TZ=Asia/Tokyo date +"%Y-%m-%dT%H:%M:%S%z")
+          for f in docs/MEP/MEP_BUNDLE.md docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md; do
+            if [[ -f "$f" ]]; then
+              if grep -qE '^BUNDLED_AT\s*=' "$f"; then
+                sed -i -E "s/^BUNDLED_AT\s*=.*/BUNDLED_AT = $ts/" "$f"
+              else
+                awk -v ts="$ts" 'NR==1{print; print "BUNDLED_AT = " ts; next} {print}' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
+              fi
+            fi
+          done
+
 name: MEP Writeback Bundle (Entry)
 on:
   workflow_dispatch:
@@ -21,20 +36,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Stamp BUNDLED_AT
-        shell: bash
-        run: |
-          set -euo pipefail
-          ts=$(TZ=Asia/Tokyo date +"%Y-%m-%dT%H:%M:%S%z")
-          for f in docs/MEP/MEP_BUNDLE.md docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md; do
-            if [[ -f "$f" ]]; then
-              if grep -qE '^BUNDLED_AT\s*=' "$f"; then
-                sed -i -E "s/^BUNDLED_AT\s*=.*/BUNDLED_AT = $ts/" "$f"
-              else
-                awk -v ts="$ts" 'NR==1{print; print "BUNDLED_AT = " ts; next} {print}' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
-              fi
-            fi
-          done
       - name: Configure git identity
         shell: bash
         run: |
@@ -77,6 +78,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           pwsh -NoProfile -File tools/mep_writeback_create_pr.ps1 -BundlePath "docs/MEP/MEP_BUNDLE.md"
+
 
 
 


### PR DESCRIPTION
目的:
- EVIDENCE_BUNDLE にも BUNDLED_AT を確実に刻む（stamp を bundle生成後＝commit直前へ移動）
- mep_handoff の EVIDENCE_BUNDLED_AT が $evidencePath 未定義で落ちる不具合を修正
変更:
- workflow: Stamp BUNDLED_AT を git add/commit/push を含む step の直前へ移動
- tools/mep_handoff.ps1: evidenceBundledAt の算出を literal path に変更（未定義参照を排除）