### PR TITLE
chore(mep): business declare guard (non-interference)

### DIFF
--- a/.github/workflows/business_non_interference_guard.yml
+++ b/.github/workflows/business_non_interference_guard.yml
@@ -1,0 +1,97 @@
+name: business-non-interference-guard
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      business_declare:
+        description: "true = allow business path changes for this run"
+        required: false
+        default: "false"
+permissions:
+  contents: read
+jobs:
+  guard:
+    name: business-non-interference-guard
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full history for diff)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Determine refs (PR vs dispatch)
+        id: refs
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            echo "mode=pr" >> "$GITHUB_OUTPUT"
+            echo "base_ref=${{ github.base_ref }}" >> "$GITHUB_OUTPUT"
+            echo "head_ref=${{ github.head_ref }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "mode=dispatch" >> "$GITHUB_OUTPUT"
+            # Dispatch compares current ref against default branch
+            echo "base_ref=${{ github.event.repository.default_branch }}" >> "$GITHUB_OUTPUT"
+            echo "head_ref=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Fetch base/head
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --prune origin "+refs/heads/*:refs/remotes/origin/*"
+      - name: Compute changed files
+        id: diff
+        shell: bash
+        run: |
+          set -euo pipefail
+          BASE="origin/${{ steps.refs.outputs.base_ref }}"
+          HEAD="origin/${{ steps.refs.outputs.head_ref }}"
+          if ! git show-ref --verify --quiet "refs/remotes/${BASE#origin/}"; then
+            echo "BASE ref not found: $BASE" >&2
+            exit 2
+          fi
+          if ! git show-ref --verify --quiet "refs/remotes/${HEAD#origin/}"; then
+            echo "HEAD ref not found: $HEAD" >&2
+            exit 2
+          fi
+          git diff --name-only "${BASE}...${HEAD}" | sed '/^\s*$/d' > changed_files.txt
+          echo "changed_count=$(wc -l < changed_files.txt | tr -d ' ')" >> "$GITHUB_OUTPUT"
+      - name: Guard (business declare required to touch business paths)
+        shell: bash
+        env:
+          BUSINESS_DECLARE: ${{ inputs.business_declare }}
+        run: |
+          set -euo pipefail
+          # NOTE: declare is allowed only when explicitly set true.
+          DECLARE="${BUSINESS_DECLARE:-false}"
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            # For PR, allow override via label "business-declare:true" (optional)
+            # If the repo doesn't use labels, this has no effect.
+            :
+          fi
+          # Business paths to protect
+          # (adjust/add if you have additional business roots)
+          PATTERNS=(
+            "^platform/MEP/03_BUSINESS/"
+          )
+          HIT=0
+          while IFS= read -r f; do
+            for p in "${PATTERNS[@]}"; do
+              if [[ "$f" =~ $p ]]; then
+                HIT=1
+                break
+              fi
+            done
+            if [[ $HIT -eq 1 ]]; then break; fi
+          done < changed_files.txt
+          if [[ $HIT -eq 1 ]]; then
+            if [[ "$DECLARE" != "true" ]]; then
+              echo "::error::Business path change detected but BUSINESS_DECLARE=true is not set. Non-interference enforced."
+              echo "Detected business-path changes (first 200 lines):"
+              sed -n '1,200p' changed_files.txt
+              exit 1
+            fi
+            echo "Business path changes detected, but BUSINESS_DECLARE=true set -> allowed for this run."
+          else
+            echo "No business path changes detected -> OK."
+          fi

--- a/platform/MEP/01_CORE/cards/BUSINESS_DECLARE_GUARD.md
+++ b/platform/MEP/01_CORE/cards/BUSINESS_DECLARE_GUARD.md
@@ -1,0 +1,11 @@
+# CARD: BUSINESS_DECLARE_GUARD
+## Intent
+- Enforce strict non-interference: without explicit business declaration, CI must fail if any change touches business paths.
+- This makes "didn't touch business" irrelevant; the system guarantees "if touched -> stop".
+## Rule
+- If any changed file matches `platform/MEP/03_BUSINESS/**` and `BUSINESS_DECLARE=true` is not explicitly set, the guard fails.
+## Enforcement points
+- CI (pull_request + workflow_dispatch): `business-non-interference-guard` workflow
+- Optional entry/tool-side routing may exclude business paths when not declared; CI remains the source of truth.
+## Notes
+- Add/extend protected path patterns here if business roots expand.


### PR DESCRIPTION
目的（固定）
- システム更新がビジネスに影響（混入・改変）しないことを、運用ではなく仕組みで強制する。
変更
- CI Guard を追加：business パス差分が存在し、BUSINESS_DECLARE=true が無い場合は必ず FAIL。
- 最小カード（spec anchor）を追加：BUSINESS_DECLARE_GUARD。
期待
- 「触れなかった」ではなく「触れたら止まる」を恒久保証。