### PR TITLE
chore(evidence): child bundle add PR #1567 evidence line

### DIFF
--- a/docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md
+++ b/docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md
@@ -42,3 +42,7 @@ PR #1395 | audit=OK,WB0000 | appended_at=2026-01-31T05:15:56Z | via=mep_append_e
 PR #0 | audit=OK,WB0000 | appended_at=2026-01-31T14:42:08Z | via=mep_append_evidence_line.ps1
 
 BUNDLE_VERSION = v0.0.0+20260201_030804+main+c9e827e1f164c553713fafd3537221b460986ccf
+
+# appended_from_parent_bundle: PR #1567 | appended_at=2026-02-01T19:09:15Z
+* - PR #1567 | mergedAt=02/01/2026 17:51:55 | mergeCommit=7c478c619b64273ac49645fb49ccbea88d9ff7a7 | BUNDLE_VERSION=v0.0.0+20260201_182352+main_46ca524 | audit=OK,WB0000 | https://github.com/Osuu-ops/yorisoidou-system/pull/1567
+PR #1567 | audit=OK,WB0000 | appended_at=2026-02-01T18:23:56.2688033+00:00 | via=mep_append_evidence_line_full.ps1


### PR DESCRIPTION
目的:
- 子EVIDENCE_BUNDLE（docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md）に PR #1567 の証跡行が無く、監査用二重構造の「一次根拠（子）」が欠けているため
内容:
- 親Bundled（docs/MEP/MEP_BUNDLE.md）から PR #1567 の該当行を抽出し、子EVIDENCE_BUNDLEに同一行を追記
- 追記には appended_from_parent_bundle メタ行を付与（追跡用）