### PR TITLE
chore(mep): restore workflow_dispatch + fix handoff evidence_bundled_at

### DIFF
--- a/tools/mep_handoff.ps1
+++ b/tools/mep_handoff.ps1
@@ -59,6 +59,10 @@ try {
   $evidenceBundledAt = if ($evidenceBundledAtLine) { (($evidenceBundledAtLine.Line -replace "\s+$","") -replace "^\s*BUNDLED_AT\s*=\s*","") } else { "(not found)" }
   # === TIME_MARKS_INLINE_OUT_END ===
   $evidencePath = "docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md"
+  # === EVIDENCE_BUNDLED_AT_COMPUTE_BEGIN (transcribe-only) ===
+  $evidenceBundledAtLine = (Select-String -LiteralPath $evidencePath -Pattern "^BUNDLED_AT\s*=" -ErrorAction SilentlyContinue | Select-Object -First 1)
+  $evidenceBundledAt = if ($evidenceBundledAtLine) { (($evidenceBundledAtLine.Line -replace "\s+$","") -replace "^\s*BUNDLED_AT\s*=\s*","") } else { "(not found)" }
+  # === EVIDENCE_BUNDLED_AT_COMPUTE_END ===
   $evOk = Test-Path -LiteralPath $evidencePath
 
   # recent PR evidence anchors we touched in this session


### PR DESCRIPTION
目的:
- 422 (workflow_dispatch無し) を解消し、writeback workflow を再度 dispatch 可能に戻す
- mep_handoff.ps1 の $evidencePath 未定義クラッシュを根治し、EVIDENCE_BUNDLED_AT を写経で出す
変更:
- .github/workflows/mep_writeback_bundle_dispatch_entry.yml: workflow_dispatch を含む既知の過去版から復旧
- tools/mep_handoff.ps1: $evidencePath 定義後に evidenceBundledAt を計算し、出力に追加