### PR TITLE
fix(mep): clarify evidenceBundledAt when missing

### DIFF
--- a/tools/mep_handoff.ps1
+++ b/tools/mep_handoff.ps1
@@ -31,6 +31,12 @@ try {
   if (-not (Get-Variable evidencePath -Scope Local -ErrorAction SilentlyContinue)) { $evidencePath = "" }
 }
 # --- end guard ---
+# --- Evidence markers guard: derive evidenceBundledAt / latest evidence bundle version ---
+try {
+  if ((Get-Variable evidencePath -Scope Local -ErrorAction SilentlyContinue) -and $evidencePath -and (Test-Path $evidencePath)) {
+    $ev = Get-Content $evidencePath -Raw -ErrorAction SilentlyContinue
+    if ($ev) {
+      $bv = @([regex]::Matches($ev, '(?m)^BUNDLE_VERSION\s*=\s*(.+)
 $ErrorActionPreference = "Stop"
 $env:GIT_PAGER="cat"
 $env:PAGER="cat"
@@ -133,4 +139,506 @@ catch {
   Write-Error $_.Exception.Message
   exit 1
 }
+
+) | ForEach-Object { 
+function Get-BundledAtFromBundled([string]$bundledPath){
+  if (-not (Test-Path $bundledPath)) { return $null }
+  $m = Select-String -Path $bundledPath -Pattern '^\s*BUNDLED_AT\s*=\s*(.+)\s*$' -AllMatches -ErrorAction SilentlyContinue | Select-Object -First 1
+  if ($m) { return $m.Matches[0].Groups[1].Value.Trim() }
+  return $null
+}
+function Get-HandoffVerifiedAt([string]$evidenceFile){
+  if (-not (Test-Path $evidenceFile)) { return $null }
+  $v = (Get-Content -Path $evidenceFile -ErrorAction SilentlyContinue | Select-Object -First 1)
+  if ($v) { return $v.Trim() }
+  return $null
+}
+Set-StrictMode -Version Latest
+
+# --- StrictMode guard: ensure $evidencePath is always initialized (avoid unbound variable) ---
+try {
+  $repoRoot = (git rev-parse --show-toplevel 2>$null)
+  if ($repoRoot) {
+    $repoRoot = $repoRoot.Trim()
+    $cand = Join-Path $repoRoot "docs\MEP_SUB\EVIDENCE\MEP_BUNDLE.md"
+    if (Test-Path $cand) {
+      $evidencePath = $cand
+    } elseif (-not (Get-Variable evidencePath -Scope Local -ErrorAction SilentlyContinue)) {
+      $evidencePath = ""
+    }
+  } elseif (-not (Get-Variable evidencePath -Scope Local -ErrorAction SilentlyContinue)) {
+    $evidencePath = ""
+  }
+} catch {
+  if (-not (Get-Variable evidencePath -Scope Local -ErrorAction SilentlyContinue)) { $evidencePath = "" }
+}
+# --- end guard ---
+$ErrorActionPreference = "Stop"
+$env:GIT_PAGER="cat"
+$env:PAGER="cat"
+
+function Fail([string]$m){ throw $m }
+function Info([string]$m){ Write-Host $m -ForegroundColor Cyan }
+
+try {
+  if (!(Test-Path -LiteralPath ".git")) { Fail "Run at repo root (where .git exists)." }
+
+  $repoUrl = (git remote get-url origin 2>$null)
+  if (-not $repoUrl) { $repoUrl = "(origin not found)" }
+
+  $bundlePath = "docs/MEP/MEP_BUNDLE.md"
+  if (!(Test-Path -LiteralPath $bundlePath)) { Fail ("Missing: " + $bundlePath) }
+
+  $bvLine = (Select-String -LiteralPath $bundlePath -Pattern "^BUNDLE_VERSION\s*=" -ErrorAction SilentlyContinue | Select-Object -First 1)
+  $bundleVersion = if ($bvLine) { ($bvLine.Line -replace "\s+$","") } else { "BUNDLE_VERSION = (not found)" }
+
+  # === TIME_MARKS_INLINE_OUT_BEGIN (transcribe-only; do not generate) ===
+  $bundledAtLine = (Select-String -LiteralPath $bundlePath -Pattern "^BUNDLED_AT\s*=" -ErrorAction SilentlyContinue | Select-Object -First 1)
+  $parentBundledAt = if ($bundledAtLine) { (($bundledAtLine.Line -replace "\s+$","") -replace "^\s*BUNDLED_AT\s*=\s*","") } else { "(not found)" }
+  $handoffFile = "docs/MEP_SUB/EVIDENCE/HANDOFF_VERIFIED_AT.txt"
+  $handoffVerifiedAt = if (Test-Path -LiteralPath $handoffFile) { (Get-Content -LiteralPath $handoffFile -TotalCount 1) } else { "(not found)" }
+  $evidenceBundledAtLine = (Select-String -LiteralPath $evidencePath -Pattern "^BUNDLED_AT\s*=" -ErrorAction SilentlyContinue | Select-Object -First 1)
+  $evidenceBundledAt = if ($evidenceBundledAtLine) { (($evidenceBundledAtLine.Line -replace "\s+$","") -replace "^\s*BUNDLED_AT\s*=\s*","") } else { "(not found)" }
+  # === TIME_MARKS_INLINE_OUT_END ===
+  $evidencePath = "docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md"
+  # === EVIDENCE_BUNDLED_AT_COMPUTE_BEGIN (transcribe-only) ===
+  $evidenceBundledAtLine = (Select-String -LiteralPath $evidencePath -Pattern "^BUNDLED_AT\s*=" -ErrorAction SilentlyContinue | Select-Object -First 1)
+  $evidenceBundledAt = if ($evidenceBundledAtLine) { (($evidenceBundledAtLine.Line -replace "\s+$","") -replace "^\s*BUNDLED_AT\s*=\s*","") } else { "(not found)" }
+  # === EVIDENCE_BUNDLED_AT_COMPUTE_END ===
+  $evOk = Test-Path -LiteralPath $evidencePath
+
+  # recent PR evidence anchors we touched in this session
+  $targets = @(1204,1210,1214,1218,1220,1222,1224,1226,1233)
+  $evLines = @()
+  if ($evOk) {
+    foreach ($n in $targets) {
+      $hit = Select-String -LiteralPath $evidencePath -Pattern ("PR\s*#\s*" + $n) -ErrorAction SilentlyContinue | Select-Object -First 1
+      if ($hit) { $evLines += $hit.Line }
+    }
+  }
+
+  $head = (git rev-parse --short HEAD 2>$null)
+  if (-not $head) { $head = "(unknown)" }
+
+  $out = New-Object System.Collections.Generic.List[string]
+  $out.Add("【HANDOFF｜次チャット冒頭に貼る本文】")
+  $out.Add("")
+  $out.Add("REPO_ORIGIN: " + $repoUrl)
+  $out.Add("HEAD: " + $head)
+  $out.Add($bundleVersion)
+  $out.Add("PARENT_BUNDLED_AT: " + $parentBundledAt)
+  $out.Add("HANDOFF_VERIFIED_AT: " + $handoffVerifiedAt)
+  $out.Add("GENERATED_AT: " + $handoffVerifiedAt)
+  $out.Add("EVIDENCE_BUNDLE: " + $evidencePath)
+  $out.Add("EVIDENCE_BUNDLED_AT: " + $evidenceBundledAt)
+  $out.Add("")
+  $out.Add("完了（今回の確定点）")
+  $out.Add("- Pre-Gate→AUTO（read-only suite）完走（stage=DONE）")
+  $out.Add("- tools: entry/auto/stage を args-based に統一（StrictMode耐性）")
+  $out.Add("")
+  $out.Add("証跡（EVIDENCEより抜粋）")
+  if ($evOk -and $evLines.Count -gt 0) {
+    foreach ($l in $evLines) { $out.Add("- " + $l) }
+  } elseif ($evOk) {
+    # --- fallback excerpt (tail scan) ---
+try {
+  if (Test-Path $evidencePath) {
+    $tail = Get-Content -Path $evidencePath -Tail 300 -ErrorAction Stop
+    $hits = $tail | Select-String -Pattern '^PR #\d+ \| .*audit=OK,WB0000' -ErrorAction SilentlyContinue | Select-Object -Last 5
+    if ($hits -and $hits.Count -gt 0) {
+      foreach ($h in $hits) { $out.Add("- " + $h.Line.Trim()) }
+    } else {
+      $out.Add("- （EVIDENCE_BUNDLEは存在するが、対象PR行を未検出）")
+    }
+  } else {
+    $out.Add("- （EVIDENCE_BUNDLEが存在しない）")
+  }
+} catch {
+  $out.Add("- （EVIDENCE_BUNDLE抽出で例外）: " + $_.Exception.Message)
+}
+# --- /fallback excerpt ---
+  } else {
+    $out.Add("- （EVIDENCE_BUNDLEが存在しない）")
+  }
+  $out.Add("")
+  $out.Add("次から自動で回す入口")
+  $out.Add("- .\tools\mep_entry.ps1 -Once")
+  $out.Add("")
+  $out.Add("注記")
+  $out.Add("- 本文は Bundled/EVIDENCE の一次根拠のみを採用。会話ログは根拠にしない。")
+  $out.Add("")
+
+  Write-Host ($out -join "`n")
+  exit 0
+}
+catch {
+  Write-Error $_.Exception.Message
+  exit 1
+}
+
+.Groups[1].Value.Trim() })
+      if ($bv.Count -gt 0) { $evidenceBundleVersionLatest = ('BUNDLE_VERSION = ' + $bv[-1]) }
+      $ba = @([regex]::Matches($ev, '(?m)^BUNDLED_AT\s*=\s*(.+)
+$ErrorActionPreference = "Stop"
+$env:GIT_PAGER="cat"
+$env:PAGER="cat"
+
+function Fail([string]$m){ throw $m }
+function Info([string]$m){ Write-Host $m -ForegroundColor Cyan }
+
+try {
+  if (!(Test-Path -LiteralPath ".git")) { Fail "Run at repo root (where .git exists)." }
+
+  $repoUrl = (git remote get-url origin 2>$null)
+  if (-not $repoUrl) { $repoUrl = "(origin not found)" }
+
+  $bundlePath = "docs/MEP/MEP_BUNDLE.md"
+  if (!(Test-Path -LiteralPath $bundlePath)) { Fail ("Missing: " + $bundlePath) }
+
+  $bvLine = (Select-String -LiteralPath $bundlePath -Pattern "^BUNDLE_VERSION\s*=" -ErrorAction SilentlyContinue | Select-Object -First 1)
+  $bundleVersion = if ($bvLine) { ($bvLine.Line -replace "\s+$","") } else { "BUNDLE_VERSION = (not found)" }
+
+  # === TIME_MARKS_INLINE_OUT_BEGIN (transcribe-only; do not generate) ===
+  $bundledAtLine = (Select-String -LiteralPath $bundlePath -Pattern "^BUNDLED_AT\s*=" -ErrorAction SilentlyContinue | Select-Object -First 1)
+  $parentBundledAt = if ($bundledAtLine) { (($bundledAtLine.Line -replace "\s+$","") -replace "^\s*BUNDLED_AT\s*=\s*","") } else { "(not found)" }
+  $handoffFile = "docs/MEP_SUB/EVIDENCE/HANDOFF_VERIFIED_AT.txt"
+  $handoffVerifiedAt = if (Test-Path -LiteralPath $handoffFile) { (Get-Content -LiteralPath $handoffFile -TotalCount 1) } else { "(not found)" }
+  $evidenceBundledAtLine = (Select-String -LiteralPath $evidencePath -Pattern "^BUNDLED_AT\s*=" -ErrorAction SilentlyContinue | Select-Object -First 1)
+  $evidenceBundledAt = if ($evidenceBundledAtLine) { (($evidenceBundledAtLine.Line -replace "\s+$","") -replace "^\s*BUNDLED_AT\s*=\s*","") } else { "(not found)" }
+  # === TIME_MARKS_INLINE_OUT_END ===
+  $evidencePath = "docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md"
+  # === EVIDENCE_BUNDLED_AT_COMPUTE_BEGIN (transcribe-only) ===
+  $evidenceBundledAtLine = (Select-String -LiteralPath $evidencePath -Pattern "^BUNDLED_AT\s*=" -ErrorAction SilentlyContinue | Select-Object -First 1)
+  $evidenceBundledAt = if ($evidenceBundledAtLine) { (($evidenceBundledAtLine.Line -replace "\s+$","") -replace "^\s*BUNDLED_AT\s*=\s*","") } else { "(not found)" }
+  # === EVIDENCE_BUNDLED_AT_COMPUTE_END ===
+  $evOk = Test-Path -LiteralPath $evidencePath
+
+  # recent PR evidence anchors we touched in this session
+  $targets = @(1204,1210,1214,1218,1220,1222,1224,1226,1233)
+  $evLines = @()
+  if ($evOk) {
+    foreach ($n in $targets) {
+      $hit = Select-String -LiteralPath $evidencePath -Pattern ("PR\s*#\s*" + $n) -ErrorAction SilentlyContinue | Select-Object -First 1
+      if ($hit) { $evLines += $hit.Line }
+    }
+  }
+
+  $head = (git rev-parse --short HEAD 2>$null)
+  if (-not $head) { $head = "(unknown)" }
+
+  $out = New-Object System.Collections.Generic.List[string]
+  $out.Add("【HANDOFF｜次チャット冒頭に貼る本文】")
+  $out.Add("")
+  $out.Add("REPO_ORIGIN: " + $repoUrl)
+  $out.Add("HEAD: " + $head)
+  $out.Add($bundleVersion)
+  $out.Add("PARENT_BUNDLED_AT: " + $parentBundledAt)
+  $out.Add("HANDOFF_VERIFIED_AT: " + $handoffVerifiedAt)
+  $out.Add("GENERATED_AT: " + $handoffVerifiedAt)
+  $out.Add("EVIDENCE_BUNDLE: " + $evidencePath)
+  $out.Add("EVIDENCE_BUNDLED_AT: " + $evidenceBundledAt)
+  $out.Add("")
+  $out.Add("完了（今回の確定点）")
+  $out.Add("- Pre-Gate→AUTO（read-only suite）完走（stage=DONE）")
+  $out.Add("- tools: entry/auto/stage を args-based に統一（StrictMode耐性）")
+  $out.Add("")
+  $out.Add("証跡（EVIDENCEより抜粋）")
+  if ($evOk -and $evLines.Count -gt 0) {
+    foreach ($l in $evLines) { $out.Add("- " + $l) }
+  } elseif ($evOk) {
+    # --- fallback excerpt (tail scan) ---
+try {
+  if (Test-Path $evidencePath) {
+    $tail = Get-Content -Path $evidencePath -Tail 300 -ErrorAction Stop
+    $hits = $tail | Select-String -Pattern '^PR #\d+ \| .*audit=OK,WB0000' -ErrorAction SilentlyContinue | Select-Object -Last 5
+    if ($hits -and $hits.Count -gt 0) {
+      foreach ($h in $hits) { $out.Add("- " + $h.Line.Trim()) }
+    } else {
+      $out.Add("- （EVIDENCE_BUNDLEは存在するが、対象PR行を未検出）")
+    }
+  } else {
+    $out.Add("- （EVIDENCE_BUNDLEが存在しない）")
+  }
+} catch {
+  $out.Add("- （EVIDENCE_BUNDLE抽出で例外）: " + $_.Exception.Message)
+}
+# --- /fallback excerpt ---
+  } else {
+    $out.Add("- （EVIDENCE_BUNDLEが存在しない）")
+  }
+  $out.Add("")
+  $out.Add("次から自動で回す入口")
+  $out.Add("- .\tools\mep_entry.ps1 -Once")
+  $out.Add("")
+  $out.Add("注記")
+  $out.Add("- 本文は Bundled/EVIDENCE の一次根拠のみを採用。会話ログは根拠にしない。")
+  $out.Add("")
+
+  Write-Host ($out -join "`n")
+  exit 0
+}
+catch {
+  Write-Error $_.Exception.Message
+  exit 1
+}
+
+) | ForEach-Object { 
+function Get-BundledAtFromBundled([string]$bundledPath){
+  if (-not (Test-Path $bundledPath)) { return $null }
+  $m = Select-String -Path $bundledPath -Pattern '^\s*BUNDLED_AT\s*=\s*(.+)\s*$' -AllMatches -ErrorAction SilentlyContinue | Select-Object -First 1
+  if ($m) { return $m.Matches[0].Groups[1].Value.Trim() }
+  return $null
+}
+function Get-HandoffVerifiedAt([string]$evidenceFile){
+  if (-not (Test-Path $evidenceFile)) { return $null }
+  $v = (Get-Content -Path $evidenceFile -ErrorAction SilentlyContinue | Select-Object -First 1)
+  if ($v) { return $v.Trim() }
+  return $null
+}
+Set-StrictMode -Version Latest
+
+# --- StrictMode guard: ensure $evidencePath is always initialized (avoid unbound variable) ---
+try {
+  $repoRoot = (git rev-parse --show-toplevel 2>$null)
+  if ($repoRoot) {
+    $repoRoot = $repoRoot.Trim()
+    $cand = Join-Path $repoRoot "docs\MEP_SUB\EVIDENCE\MEP_BUNDLE.md"
+    if (Test-Path $cand) {
+      $evidencePath = $cand
+    } elseif (-not (Get-Variable evidencePath -Scope Local -ErrorAction SilentlyContinue)) {
+      $evidencePath = ""
+    }
+  } elseif (-not (Get-Variable evidencePath -Scope Local -ErrorAction SilentlyContinue)) {
+    $evidencePath = ""
+  }
+} catch {
+  if (-not (Get-Variable evidencePath -Scope Local -ErrorAction SilentlyContinue)) { $evidencePath = "" }
+}
+# --- end guard ---
+$ErrorActionPreference = "Stop"
+$env:GIT_PAGER="cat"
+$env:PAGER="cat"
+
+function Fail([string]$m){ throw $m }
+function Info([string]$m){ Write-Host $m -ForegroundColor Cyan }
+
+try {
+  if (!(Test-Path -LiteralPath ".git")) { Fail "Run at repo root (where .git exists)." }
+
+  $repoUrl = (git remote get-url origin 2>$null)
+  if (-not $repoUrl) { $repoUrl = "(origin not found)" }
+
+  $bundlePath = "docs/MEP/MEP_BUNDLE.md"
+  if (!(Test-Path -LiteralPath $bundlePath)) { Fail ("Missing: " + $bundlePath) }
+
+  $bvLine = (Select-String -LiteralPath $bundlePath -Pattern "^BUNDLE_VERSION\s*=" -ErrorAction SilentlyContinue | Select-Object -First 1)
+  $bundleVersion = if ($bvLine) { ($bvLine.Line -replace "\s+$","") } else { "BUNDLE_VERSION = (not found)" }
+
+  # === TIME_MARKS_INLINE_OUT_BEGIN (transcribe-only; do not generate) ===
+  $bundledAtLine = (Select-String -LiteralPath $bundlePath -Pattern "^BUNDLED_AT\s*=" -ErrorAction SilentlyContinue | Select-Object -First 1)
+  $parentBundledAt = if ($bundledAtLine) { (($bundledAtLine.Line -replace "\s+$","") -replace "^\s*BUNDLED_AT\s*=\s*","") } else { "(not found)" }
+  $handoffFile = "docs/MEP_SUB/EVIDENCE/HANDOFF_VERIFIED_AT.txt"
+  $handoffVerifiedAt = if (Test-Path -LiteralPath $handoffFile) { (Get-Content -LiteralPath $handoffFile -TotalCount 1) } else { "(not found)" }
+  $evidenceBundledAtLine = (Select-String -LiteralPath $evidencePath -Pattern "^BUNDLED_AT\s*=" -ErrorAction SilentlyContinue | Select-Object -First 1)
+  $evidenceBundledAt = if ($evidenceBundledAtLine) { (($evidenceBundledAtLine.Line -replace "\s+$","") -replace "^\s*BUNDLED_AT\s*=\s*","") } else { "(not found)" }
+  # === TIME_MARKS_INLINE_OUT_END ===
+  $evidencePath = "docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md"
+  # === EVIDENCE_BUNDLED_AT_COMPUTE_BEGIN (transcribe-only) ===
+  $evidenceBundledAtLine = (Select-String -LiteralPath $evidencePath -Pattern "^BUNDLED_AT\s*=" -ErrorAction SilentlyContinue | Select-Object -First 1)
+  $evidenceBundledAt = if ($evidenceBundledAtLine) { (($evidenceBundledAtLine.Line -replace "\s+$","") -replace "^\s*BUNDLED_AT\s*=\s*","") } else { "(not found)" }
+  # === EVIDENCE_BUNDLED_AT_COMPUTE_END ===
+  $evOk = Test-Path -LiteralPath $evidencePath
+
+  # recent PR evidence anchors we touched in this session
+  $targets = @(1204,1210,1214,1218,1220,1222,1224,1226,1233)
+  $evLines = @()
+  if ($evOk) {
+    foreach ($n in $targets) {
+      $hit = Select-String -LiteralPath $evidencePath -Pattern ("PR\s*#\s*" + $n) -ErrorAction SilentlyContinue | Select-Object -First 1
+      if ($hit) { $evLines += $hit.Line }
+    }
+  }
+
+  $head = (git rev-parse --short HEAD 2>$null)
+  if (-not $head) { $head = "(unknown)" }
+
+  $out = New-Object System.Collections.Generic.List[string]
+  $out.Add("【HANDOFF｜次チャット冒頭に貼る本文】")
+  $out.Add("")
+  $out.Add("REPO_ORIGIN: " + $repoUrl)
+  $out.Add("HEAD: " + $head)
+  $out.Add($bundleVersion)
+  $out.Add("PARENT_BUNDLED_AT: " + $parentBundledAt)
+  $out.Add("HANDOFF_VERIFIED_AT: " + $handoffVerifiedAt)
+  $out.Add("GENERATED_AT: " + $handoffVerifiedAt)
+  $out.Add("EVIDENCE_BUNDLE: " + $evidencePath)
+  $out.Add("EVIDENCE_BUNDLED_AT: " + $evidenceBundledAt)
+  $out.Add("")
+  $out.Add("完了（今回の確定点）")
+  $out.Add("- Pre-Gate→AUTO（read-only suite）完走（stage=DONE）")
+  $out.Add("- tools: entry/auto/stage を args-based に統一（StrictMode耐性）")
+  $out.Add("")
+  $out.Add("証跡（EVIDENCEより抜粋）")
+  if ($evOk -and $evLines.Count -gt 0) {
+    foreach ($l in $evLines) { $out.Add("- " + $l) }
+  } elseif ($evOk) {
+    # --- fallback excerpt (tail scan) ---
+try {
+  if (Test-Path $evidencePath) {
+    $tail = Get-Content -Path $evidencePath -Tail 300 -ErrorAction Stop
+    $hits = $tail | Select-String -Pattern '^PR #\d+ \| .*audit=OK,WB0000' -ErrorAction SilentlyContinue | Select-Object -Last 5
+    if ($hits -and $hits.Count -gt 0) {
+      foreach ($h in $hits) { $out.Add("- " + $h.Line.Trim()) }
+    } else {
+      $out.Add("- （EVIDENCE_BUNDLEは存在するが、対象PR行を未検出）")
+    }
+  } else {
+    $out.Add("- （EVIDENCE_BUNDLEが存在しない）")
+  }
+} catch {
+  $out.Add("- （EVIDENCE_BUNDLE抽出で例外）: " + $_.Exception.Message)
+}
+# --- /fallback excerpt ---
+  } else {
+    $out.Add("- （EVIDENCE_BUNDLEが存在しない）")
+  }
+  $out.Add("")
+  $out.Add("次から自動で回す入口")
+  $out.Add("- .\tools\mep_entry.ps1 -Once")
+  $out.Add("")
+  $out.Add("注記")
+  $out.Add("- 本文は Bundled/EVIDENCE の一次根拠のみを採用。会話ログは根拠にしない。")
+  $out.Add("")
+
+  Write-Host ($out -join "`n")
+  exit 0
+}
+catch {
+  Write-Error $_.Exception.Message
+  exit 1
+}
+
+.Groups[1].Value.Trim() })
+      if ($ba.Count -gt 0) {
+        $evidenceBundledAt = $ba[0]
+      } else {
+        if (-not (Get-Variable evidenceBundledAt -Scope Local -ErrorAction SilentlyContinue) -or -not $evidenceBundledAt) {
+          $evidenceBundledAt = "(not present in EVIDENCE_BUNDLE)"
+        }
+      }
+    }
+  } else {
+    if (-not (Get-Variable evidenceBundledAt -Scope Local -ErrorAction SilentlyContinue) -or -not $evidenceBundledAt) {
+      $evidenceBundledAt = "(not present in EVIDENCE_BUNDLE)"
+    }
+  }
+} catch {
+  if (-not (Get-Variable evidenceBundledAt -Scope Local -ErrorAction SilentlyContinue) -or -not $evidenceBundledAt) {
+    $evidenceBundledAt = "(not present in EVIDENCE_BUNDLE)"
+  }
+}
+# --- end evidence markers guard ---
+$ErrorActionPreference = "Stop"
+$env:GIT_PAGER="cat"
+$env:PAGER="cat"
+
+function Fail([string]$m){ throw $m }
+function Info([string]$m){ Write-Host $m -ForegroundColor Cyan }
+
+try {
+  if (!(Test-Path -LiteralPath ".git")) { Fail "Run at repo root (where .git exists)." }
+
+  $repoUrl = (git remote get-url origin 2>$null)
+  if (-not $repoUrl) { $repoUrl = "(origin not found)" }
+
+  $bundlePath = "docs/MEP/MEP_BUNDLE.md"
+  if (!(Test-Path -LiteralPath $bundlePath)) { Fail ("Missing: " + $bundlePath) }
+
+  $bvLine = (Select-String -LiteralPath $bundlePath -Pattern "^BUNDLE_VERSION\s*=" -ErrorAction SilentlyContinue | Select-Object -First 1)
+  $bundleVersion = if ($bvLine) { ($bvLine.Line -replace "\s+$","") } else { "BUNDLE_VERSION = (not found)" }
+
+  # === TIME_MARKS_INLINE_OUT_BEGIN (transcribe-only; do not generate) ===
+  $bundledAtLine = (Select-String -LiteralPath $bundlePath -Pattern "^BUNDLED_AT\s*=" -ErrorAction SilentlyContinue | Select-Object -First 1)
+  $parentBundledAt = if ($bundledAtLine) { (($bundledAtLine.Line -replace "\s+$","") -replace "^\s*BUNDLED_AT\s*=\s*","") } else { "(not found)" }
+  $handoffFile = "docs/MEP_SUB/EVIDENCE/HANDOFF_VERIFIED_AT.txt"
+  $handoffVerifiedAt = if (Test-Path -LiteralPath $handoffFile) { (Get-Content -LiteralPath $handoffFile -TotalCount 1) } else { "(not found)" }
+  $evidenceBundledAtLine = (Select-String -LiteralPath $evidencePath -Pattern "^BUNDLED_AT\s*=" -ErrorAction SilentlyContinue | Select-Object -First 1)
+  $evidenceBundledAt = if ($evidenceBundledAtLine) { (($evidenceBundledAtLine.Line -replace "\s+$","") -replace "^\s*BUNDLED_AT\s*=\s*","") } else { "(not found)" }
+  # === TIME_MARKS_INLINE_OUT_END ===
+  $evidencePath = "docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md"
+  # === EVIDENCE_BUNDLED_AT_COMPUTE_BEGIN (transcribe-only) ===
+  $evidenceBundledAtLine = (Select-String -LiteralPath $evidencePath -Pattern "^BUNDLED_AT\s*=" -ErrorAction SilentlyContinue | Select-Object -First 1)
+  $evidenceBundledAt = if ($evidenceBundledAtLine) { (($evidenceBundledAtLine.Line -replace "\s+$","") -replace "^\s*BUNDLED_AT\s*=\s*","") } else { "(not found)" }
+  # === EVIDENCE_BUNDLED_AT_COMPUTE_END ===
+  $evOk = Test-Path -LiteralPath $evidencePath
+
+  # recent PR evidence anchors we touched in this session
+  $targets = @(1204,1210,1214,1218,1220,1222,1224,1226,1233)
+  $evLines = @()
+  if ($evOk) {
+    foreach ($n in $targets) {
+      $hit = Select-String -LiteralPath $evidencePath -Pattern ("PR\s*#\s*" + $n) -ErrorAction SilentlyContinue | Select-Object -First 1
+      if ($hit) { $evLines += $hit.Line }
+    }
+  }
+
+  $head = (git rev-parse --short HEAD 2>$null)
+  if (-not $head) { $head = "(unknown)" }
+
+  $out = New-Object System.Collections.Generic.List[string]
+  $out.Add("【HANDOFF｜次チャット冒頭に貼る本文】")
+  $out.Add("")
+  $out.Add("REPO_ORIGIN: " + $repoUrl)
+  $out.Add("HEAD: " + $head)
+  $out.Add($bundleVersion)
+  $out.Add("PARENT_BUNDLED_AT: " + $parentBundledAt)
+  $out.Add("HANDOFF_VERIFIED_AT: " + $handoffVerifiedAt)
+  $out.Add("GENERATED_AT: " + $handoffVerifiedAt)
+  $out.Add("EVIDENCE_BUNDLE: " + $evidencePath)
+  $out.Add("EVIDENCE_BUNDLED_AT: " + $evidenceBundledAt)
+  $out.Add("")
+  $out.Add("完了（今回の確定点）")
+  $out.Add("- Pre-Gate→AUTO（read-only suite）完走（stage=DONE）")
+  $out.Add("- tools: entry/auto/stage を args-based に統一（StrictMode耐性）")
+  $out.Add("")
+  $out.Add("証跡（EVIDENCEより抜粋）")
+  if ($evOk -and $evLines.Count -gt 0) {
+    foreach ($l in $evLines) { $out.Add("- " + $l) }
+  } elseif ($evOk) {
+    # --- fallback excerpt (tail scan) ---
+try {
+  if (Test-Path $evidencePath) {
+    $tail = Get-Content -Path $evidencePath -Tail 300 -ErrorAction Stop
+    $hits = $tail | Select-String -Pattern '^PR #\d+ \| .*audit=OK,WB0000' -ErrorAction SilentlyContinue | Select-Object -Last 5
+    if ($hits -and $hits.Count -gt 0) {
+      foreach ($h in $hits) { $out.Add("- " + $h.Line.Trim()) }
+    } else {
+      $out.Add("- （EVIDENCE_BUNDLEは存在するが、対象PR行を未検出）")
+    }
+  } else {
+    $out.Add("- （EVIDENCE_BUNDLEが存在しない）")
+  }
+} catch {
+  $out.Add("- （EVIDENCE_BUNDLE抽出で例外）: " + $_.Exception.Message)
+}
+# --- /fallback excerpt ---
+  } else {
+    $out.Add("- （EVIDENCE_BUNDLEが存在しない）")
+  }
+  $out.Add("")
+  $out.Add("次から自動で回す入口")
+  $out.Add("- .\tools\mep_entry.ps1 -Once")
+  $out.Add("")
+  $out.Add("注記")
+  $out.Add("- 本文は Bundled/EVIDENCE の一次根拠のみを採用。会話ログは根拠にしない。")
+  $out.Add("")
+
+  Write-Host ($out -join "`n")
+  exit 0
+}
+catch {
+  Write-Error $_.Exception.Message
+  exit 1
+}
+
 


### PR DESCRIPTION
EVIDENCE_BUNDLE has no BUNDLED_AT line; clarify as '(not present in EVIDENCE_BUNDLE)' and derive latest evidence bundle version safely.