### PR TITLE
fix(mep): entry -Once reads WORK_ID master (no actions)

### DIFF
--- a/tools/mep_entry.ps1
+++ b/tools/mep_entry.ps1
@@ -1,19 +1,32 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
-
 function Fail([string]$m){ throw $m }
 function Info([string]$m){ Write-Host "[ENTRY] $m" -ForegroundColor Cyan }
-
 $root = (Get-Location).Path
 if (!(Test-Path -LiteralPath (Join-Path $root ".git"))) { Fail "Not a git repo root: $root" }
-
-$auto = Join-Path $root "tools/mep_auto.ps1"
-if (!(Test-Path -LiteralPath $auto)) { Fail "Missing: tools/mep_auto.ps1" }
-
 # StrictMode-safe: detect -Once in $args (no param)
 $onceFlag = $false
 if ($args -and ($args -contains "-Once")) { $onceFlag = $true }
-
+function Read-WorkItemsMaster([string]$path) {
+  if (!(Test-Path -LiteralPath $path)) { Fail "WORK_ID master not found: $path" }
+  $ids = @()
+  foreach ($line in (Get-Content -LiteralPath $path -ErrorAction Stop)) {
+    if ($line -match '^\s*###\s*(WIP-\d+)\b') {
+      $ids += $Matches[1]
+    }
+  }
+  return $ids
+}
+if ($onceFlag) {
+  $workPath = Join-Path $root "docs/MEP/WORK_ITEMS/mep_entry_work_items_master.md"
+  $ids = Read-WorkItemsMaster -path $workPath
+  Info ("WORK_ITEMS_COUNT=" + $ids.Count)
+  Info ("WORK_ITEMS_IDS=" + ($ids -join ","))
+  exit 2  # UNDETERMINED: only read stage (no actions yet)
+}
+# default behavior (non-Once): delegate to auto (unchanged)
+$auto = Join-Path $root "tools/mep_auto.ps1"
+if (!(Test-Path -LiteralPath $auto)) { Fail "Missing: tools/mep_auto.ps1" }
 Info ("Delegating to tools/mep_auto.ps1 (Once=" + $onceFlag + ")")
-if ($onceFlag) { & $auto -Once } else { & $auto }
+& $auto
 exit $LASTEXITCODE


### PR DESCRIPTION
Purpose: Start Step 2 by adding a read-only footing to mep_entry -Once.
Behavior: When -Once, read WORK_ID master and print IDs; no actions are executed.
Exit: 2 (UNDETERMINED) to prevent false success.
Non-Once behavior: unchanged (delegates to mep_auto.ps1).