### PR TITLE
fix(actions): writeback workflow parse error

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch.yml
@@ -56,6 +56,7 @@ jobs:
         run: |
           pwsh -NoProfile -File tools/mep_append_evidence_line_full.ps1 -PrNumber ${{ env.PR_NUMBER }} -BundlePath "docs/MEP/MEP_BUNDLE.md"
       - name: Create PR for writeback branch (if needed)
+        run: echo 'noop: fix workflow schema (auto)';
           pwsh -NoProfile -File tools/mep_append_evidence_line_full.ps1 -PrNumber ${{ env.PR_NUMBER }} -BundlePath "docs/MEP/MEP_BUNDLE.md"
       - name: Ensure writeback PR (helper)
         shell: pwsh


### PR DESCRIPTION
目的: writeback系workflowがHTTP 422(パースエラー)でdispatch不能になっており、Bundled証跡(writeback)が進められない。
最小修正: malformed step（run/uses無し）にnoop runを追加してworkflow schemaを満たす（ロジック変更なし）。
次: このPRをmerge後、writeback(pr_number=1619)を再実行し、docs/MEP/MEP_BUNDLE.mdに証跡が入ることを確認する。