### PR TITLE
fix(entry): avoid StrictMode crash when LASTEXITCODE undefined

### DIFF
--- a/tools/mep_entry.ps1
+++ b/tools/mep_entry.ps1
@@ -16,4 +16,5 @@ if ($args -and ($args -contains "-Once")) { $onceFlag = $true }
 
 Info ("Delegating to tools/mep_auto.ps1 (Once=" + $onceFlag + ")")
 if ($onceFlag) { & $auto -Once } else { & $auto }
-exit $LASTEXITCODE
+if (Test-Path variable:LASTEXITCODE) { exit $LASTEXITCODE } else { exit 0 }
+


### PR DESCRIPTION
現象:
- tools/mep_entry.ps1 -Once 実行後、StrictMode 下で $LASTEXITCODE 未定義により例外で終了していた
対応:
- exit 前に Test-Path variable:LASTEXITCODE で存在確認し、未定義なら 0 を返す