### PR TITLE
fix(handoff): fallback extract by audit marker

### DIFF
--- a/tools/mep_handoff.ps1
+++ b/tools/mep_handoff.ps1
@@ -137,7 +137,7 @@ try {
 try {
   if (Test-Path $evidencePath) {
     $tail = Get-Content -Path $evidencePath -Tail 300 -ErrorAction Stop
-    $hits = $tail | Select-String -Pattern '^\s*\*?\s*-?\s*PR #\d+ \| .*audit=OK,WB0000' -ErrorAction SilentlyContinue | Select-Object -Last 5
+    $hits = $tail | Select-String -Pattern 'audit=OK,WB0000' -ErrorAction SilentlyContinue | Select-Object -Last 5
     if ($hits -and $hits.Count -gt 0) {
       foreach ($h in $hits) { $out.Add("- " + $h.Line.Trim()) }
     } else {
@@ -168,6 +168,7 @@ catch {
   Write-Error $_.Exception.Message
   exit 1
 }
+
 
 
 


### PR DESCRIPTION
現象:
- tools/mep_handoff.ps1 が EVIDENCE の末尾抽出で「未検出」になることがある
- EVIDENCE には audit=OK,WB0000 行が存在する（PR #1567 等）
対応（最小・確実）:
- fallback 抽出条件を 'audit=OK,WB0000' を含む行の末尾5件取得に変更
  （'* - PR #1567 | ...audit=OK,WB0000' / 'PR #1567 | audit=OK,WB0000 | ...' 両方確実に拾える）