### PR TITLE
cosmetic: handoff prints EVIDENCE_BUNDLE as relative path

### DIFF
--- a/tools/mep_handoff.ps1
+++ b/tools/mep_handoff.ps1
@@ -139,7 +139,7 @@ try {
   $out.Add("PARENT_BUNDLED_AT: " + $parentBundledAt)
   $out.Add("HANDOFF_VERIFIED_AT: " + $handoffVerifiedAt)
   $out.Add("GENERATED_AT: " + $handoffVerifiedAt)
-  $out.Add("EVIDENCE_BUNDLE: " + $evidencePath)
+$out.Add("EVIDENCE_BUNDLE: docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md")
   $out.Add("EVIDENCE_BUNDLED_AT: " + $evidenceBundledAt)
   $out.Add("")
   $out.Add("完了（今回の確定点）")
@@ -173,6 +173,7 @@ catch {
   Write-Error $_.Exception.Message
   exit 1
 }
+
 
 
 


### PR DESCRIPTION
目的:
- HANDOFF出力の EVIDENCE_BUNDLE 表示を絶対パスから相対パスへ固定し、文字化け/環境依存を除去する
変更:
- tools/mep_handoff.ps1 の EVIDENCE_BUNDLE 表示行を "docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md" 固定に変更
影響:
- 表示のみ（抽出ロジックや監査根拠には影響なし）