### PR TITLE
Audit: self-heal 401 Bad credentials (primary evidence report)

### DIFF
--- a/docs/MEP/90_CHANGES/self_heal_401_audit_report_20260202_222016.md
+++ b/docs/MEP/90_CHANGES/self_heal_401_audit_report_20260202_222016.md
@@ -1,0 +1,19 @@
+# self-heal 401 (Bad credentials) Audit Report
+
+- generated_at: 2026-02-02T22:20:17+09:00
+- branch: auto/audit_self-heal-401_20260202_222016
+- head: 19360be04a33f03400e46a87835391b300b24fd9
+
+## Repo-side candidate workflows (.github/workflows)
+- chat_packet_self_heal.yml
+- mep_self_heal_min5.yml
+- self_heal_auto_prs.yml
+
+## Actions-side failed run hits (primary evidence)
+- (no hits in last 30 failed runs on main, or logs not accessible)
+
+## Next required evidence keys (to proceed to fix)
+- Map workflow name -> exact yml filename (primary evidence)
+- Pinpoint the failing step and which token it uses (GITHUB_TOKEN / GH_TOKEN / secret)
+- Decide: treat as Completion-B scope (ENTRY_EXIT=1/2) or SKIP (noise outside B)
+


### PR DESCRIPTION
Purpose:
- Move the unfinished self-heal 401 investigation forward without guessing.
What:
- Add a report under docs/MEP/90_CHANGES/ with:
  - repo-side candidate workflows
  - actions-side failure run hits containing "Bad credentials" / "HTTP 401" (when accessible)
Next:
- Use run_id/workflow evidence to pinpoint the exact workflow+token and implement the fix.