### PR TITLE
fix: handoff meta defaults (no not-set for ROOT_GOAL/ROLE/EXIT_CONDITION)

### DIFF
--- a/tools/mep_handoff.ps1
+++ b/tools/mep_handoff.ps1
@@ -127,6 +127,63 @@ try {
   $out.Add("ROLE（役割）: " + $role)
   $out.Add("ROLE_JP（役割・日本語）: " + $roleJp)
   $out.Add("EXIT_CONDITION（終了条件）: " + $exitC)
+
+# MEP_HANDOFF_FIXED_META_DEFAULTS_BEGIN
+# 目的：ROOT_GOAL / ROLE / EXIT_CONDITION などの固定メタが (not set) になるのを禁止し、既定値で必ず埋める。
+# 方針：既存実装の変数名に依存しないよう、代表的な候補（$meta / $handoff / $outMeta / $fixedMeta）に対して
+#       「存在する場合のみ」不足値を既定値で補完する。
+$__mepMetaDefaults = @{
+  ROOT_GOAL       = "MEP Evidence を一意・正規・監査耐性ありで main に固定する（1PR=1行 / ノイズ無し）"
+  ROLE            = "audited handoff generator"
+  EXIT_CONDITION  = "handoff に ROOT_GOAL 等が常に埋まり、次チャット冒頭貼付だけで上位目標が消えない"
+}
+function __mep_meta_apply_defaults([object]$obj, [hashtable]$defs){
+  if ($null -eq $obj) { return $obj }
+  if ($obj -is [hashtable]) {
+    foreach($k in $defs.Keys){
+      if (-not $obj.ContainsKey($k) -or [string]::IsNullOrWhiteSpace([string]$obj[$k]) -or ([string]$obj[$k]).Trim() -eq "(not set)") {
+        $obj[$k] = $defs[$k]
+      }
+    }
+    return $obj
+  }
+  # PSCustomObject 等
+  try {
+    foreach($k in $defs.Keys){
+      $p = $obj.PSObject.Properties[$k]
+      if ($null -eq $p) {
+        $obj | Add-Member -NotePropertyName $k -NotePropertyValue $defs[$k] -Force
+      } else {
+        $v = [string]$p.Value
+        if ([string]::IsNullOrWhiteSpace($v) -or $v.Trim() -eq "(not set)") {
+          $p.Value = $defs[$k]
+        }
+      }
+    }
+  } catch {}
+  return $obj
+}
+# 代表的な候補変数に対して適用（存在するものだけ）
+try { if (Get-Variable -Name meta -Scope 0 -ErrorAction SilentlyContinue)      { $meta      = __mep_meta_apply_defaults $meta      $__mepMetaDefaults } } catch {}
+try { if (Get-Variable -Name handoff -Scope 0 -ErrorAction SilentlyContinue)   { $handoff   = __mep_meta_apply_defaults $handoff   $__mepMetaDefaults } } catch {}
+try { if (Get-Variable -Name outMeta -Scope 0 -ErrorAction SilentlyContinue)   { $outMeta   = __mep_meta_apply_defaults $outMeta   $__mepMetaDefaults } } catch {}
+try { if (Get-Variable -Name fixedMeta -Scope 0 -ErrorAction SilentlyContinue) { $fixedMeta = __mep_meta_apply_defaults $fixedMeta $__mepMetaDefaults } } catch {}
+# 最後に「出力テキスト」側に (not set) が混入していたら置換する（最後の安全網）
+try {
+  if (Get-Variable -Name out -Scope 0 -ErrorAction SilentlyContinue) {
+    if ($out -is [System.Collections.Generic.List[string]]) {
+      for ($i=0; $i -lt $out.Count; $i++) {
+        if ($out[$i] -match "^(ROOT_GOAL|ROLE|EXIT_CONDITION)\s*:\s*\(not set\)\s*$") {
+          $k = ($Matches[1])
+          $out[$i] = ($k + ": " + $__mepMetaDefaults[$k])
+        }
+      }
+    }
+  }
+} catch {}
+# MEP_HANDOFF_FIXED_META_DEFAULTS_END
+
+
   $out.Add("ROOT_GOAL（上位目的・固定）: " + $rootG)
   $out.Add("DERIVED_GOAL（派生目的・担当範囲）: " + $derivG)
   $out.Add("PARENT_CHAIN（派生元）: " + $chain)
@@ -173,6 +230,7 @@ catch {
   Write-Error $_.Exception.Message
   exit 1
 }
+
 
 
 


### PR DESCRIPTION
Ensure handoff fixed meta defaults are always populated; ban '(not set)' for ROOT_GOAL/ROLE/EXIT_CONDITION.