### PR TITLE
fix(mep): ALL_DONE progress must be G10/10 when stage=DONE

### DIFF
--- a/tools/mep_auto_loop.ps1
+++ b/tools/mep_auto_loop.ps1
@@ -57,6 +57,9 @@ if ($stageVal -eq "DONE" -and $ec -eq 0) {
   $gm=@{}; for($i=0;$i -le $GateMax;$i++){ $gm[$i]="OK" }
   Write-MepRun -Source DRAFT -PreGateResult OK -PreGateReason "" -GateMax $GateMax -GateOkUpto $GateMax -GateStopAt 0 -ExitCode 0 -StopReason "ALL_DONE" -GateMatrix $gm
   exit 0
+}; for($i=0;$i -le $GateMax;$i++){ $gm[$i]="OK" }
+  Write-MepRun -Source DRAFT -PreGateResult OK -PreGateReason "" -GateMax $GateMax -GateOkUpto $GateMax -GateStopAt 0 -ExitCode 0 -StopReason "ALL_DONE" -GateMatrix $gm
+  exit 0
 }
 Write-MepRun -Source DRAFT -PreGateResult OK -PreGateReason "" -GateMax $GateMax -GateOkUpto 0 -GateStopAt 0 -ExitCode $ec -StopReason ("STAGE_" + $stageVal) -GateMatrix @{0="STOP"}
 exit $ec


### PR DESCRIPTION
症状:
- CURRENT_STAGE=DONE なのに Progress が G0/10 になり、G1..G10 が PENDING のまま表示される
修正:
- stageVal を Trim() して比較の揺れを除去
- stage=DONE & exit=0 の canonical ルートで GateOkUpto=GateMax を渡し、ALL_DONE (G10/10) を確定表示