### PR TITLE
debug(mep): print stageVal/ec to diagnose ALL_DONE mismatch

### DIFF
--- a/tools/mep_auto_loop.ps1
+++ b/tools/mep_auto_loop.ps1
@@ -1,5 +1,3 @@
-Write-Host ("[DEBUG] stageVal=''{0}'' ec={1}" -f $stageVal,$ec)
-
 exit $ec
 Set-StrictMode -Version Latest
 $ErrorActionPreference="Stop"


### PR DESCRIPTION
目的:
- CURRENT_STAGE=DONE なのに Progress が G0/10 になる原因を一次根拠で確定する
- stageVal と ec を m ep_auto_loop の実行時に必ず表示する