### PR TITLE
fix(mep): stage truth priority (DONE forces ec=0 for ALL_DONE display)

### DIFF
--- a/tools/mep_auto_loop.ps1
+++ b/tools/mep_auto_loop.ps1
@@ -1,8 +1,4 @@
 Set-StrictMode -Version Latest
-if ($stageVal -eq "DONE") {
-  # stage truth source priority: DONE means we must present ALL_DONE
-  $ec = 0
-}
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference="Stop"
@@ -66,3 +62,13 @@ if ($stageVal -eq "DONE" -and $ec -eq 0) {
 }
 Write-MepRun -Source DRAFT -PreGateResult OK -PreGateReason "" -GateMax $GateMax -GateOkUpto 0 -GateStopAt 0 -ExitCode $ec -StopReason ("STAGE_" + $stageVal) -GateMatrix @{0="STOP"}
 $stageVal = (Read-StageValue).Trim()
+if ([string]::IsNullOrWhiteSpace($stageVal)) {
+  $sf = Join-Path $root ".mep\CURRENT_STAGE.txt"
+  if (Test-Path -LiteralPath $sf) {
+    $tmp = (Get-Content -LiteralPath $sf -ErrorAction SilentlyContinue | Select-Object -First 1)
+    if ($tmp) { $stageVal = $tmp.Trim() }
+  }
+}
+if ($stageVal -eq "DONE") {
+  $ec = 0
+}


### PR DESCRIPTION
症状:
- CURRENT_STAGE=DONE なのに Progress が STOP/exit=2 になり ALL_DONE 表示に入らない
原因:
- stage表示と判定に使う stageVal/ec が不整合（stageVal空/別経路で ec=2 のまま）
修正:
- .mep/CURRENT_STAGE.txt を唯一の stage 真実源とし、stageVal=DONE なら ec=0 に上書きして ALL_DONE 表示へ確定