### PR TITLE
fix(mep): remove undefined stageFile var in mep_auto_loop

### DIFF
--- a/tools/mep_auto_loop.ps1
+++ b/tools/mep_auto_loop.ps1
@@ -28,7 +28,8 @@ Set-Location $root
 
 # Stage truth source: .mep/CURRENT_STAGE.txt
 function Read-StageValue {
-  if (Test-Path -LiteralPath $stageFile) {
+  $sf = Join-Path $root ".mep\CURRENT_STAGE.txt"
+  if (Test-Path -LiteralPath $sf) {
     $v = (Get-Content -LiteralPath $stageFile -ErrorAction SilentlyContinue | Select-Object -First 1)
     if ($v) { return $v.Trim() }
   }


### PR DESCRIPTION
症状:
- mep_auto_loop 実行で $stageFile 未定義（StrictMode）によりクラッシュする
修正:
- Test-Path の参照を $stageFile から $sf（Join-Path $root ".mep\CURRENT_STAGE.txt"）へ置換
- stage truth source を直接参照し、未定義変数を排除