### PR TITLE
fix(mep): fully remove undefined stageFile var in mep_auto_loop

### DIFF
--- a/tools/mep_auto_loop.ps1
+++ b/tools/mep_auto_loop.ps1
@@ -30,7 +30,7 @@ Set-Location $root
 function Read-StageValue {
   $sf = Join-Path $root ".mep\CURRENT_STAGE.txt"
   if (Test-Path -LiteralPath $sf) {
-    $v = (Get-Content -LiteralPath $stageFile -ErrorAction SilentlyContinue | Select-Object -First 1)
+    $v = (Get-Content -LiteralPath $sf -ErrorAction SilentlyContinue | Select-Object -First 1)
     if ($v) { return $v.Trim() }
   }
   return ""


### PR DESCRIPTION
症状:
- mep_auto_loop が $stageFile 未定義（StrictMode）でクラッシュする（Get-Content側が残存）
修正:
- stage file path を $sf（Join-Path $root ".mep\CURRENT_STAGE.txt"）に統一
- Test-Path と Get-Content の両方で $sf を使用し、$stageFile を完全排除