### PR TITLE
fix(mep): observe stageVal and force DONE route to ALL_DONE

### DIFF
--- a/tools/mep_auto_loop.ps1
+++ b/tools/mep_auto_loop.ps1
@@ -73,6 +73,9 @@ if ($stageVal -eq "DONE" -and $ec -eq 0) {
 }
 Write-MepRun -Source DRAFT -PreGateResult OK -PreGateReason "" -GateMax $GateMax -GateOkUpto 0 -GateStopAt 0 -ExitCode $ec -StopReason ("STAGE_" + $stageVal) -GateMatrix @{0="STOP"}
 $stageVal = (Read-StageValue).Trim()
+Write-Host ("[STAGEVAL] stageVal=''{0}'' ec={1}" -f $stageVal,$ec)
+if ($stageVal -eq "DONE") { $ec = 0 }
+
 if ([string]::IsNullOrWhiteSpace($stageVal)) {
   $sf = Join-Path $root ".mep\CURRENT_STAGE.txt"
   if (Test-Path -LiteralPath $sf) {


### PR DESCRIPTION
目的:
- CURRENT_STAGE=DONE なのに STOP@G0 (exit=2) へ落ちる不整合を解消
- stageVal を可視化し、stageVal=DONE のとき ec=0 に正規化して ALL_DONE 分岐に確実に入れる