### PR TITLE
fix(mep): mep_handoff ParserError fix + include PR #1676 evidence

### DIFF
--- a/tools/mep_handoff.ps1
+++ b/tools/mep_handoff.ps1
@@ -484,7 +484,7 @@ try {
   $rulesetHits = __MEP_GrepLines -Lines $bundledLines -Regex '(?i)RULESET_|Required\s*checks|merge\s*block|MERGE_BLOCK' -Max 300
   __MEP_PrintSection -Title "Bundled Ruleset/Checks Evidence (raw lines)" -Lines $rulesetHits
   # PR evidence: match 1669/1671/1673 even if formatting differs
-  $prHits = __MEP_GrepLines -Lines $bundledLines -Regex '(?i)(PR\s*#\s*(1669|1671|1673)\b|pull/(1669|1671|1673)\b|\b(1669|1671|1673)\b)' -Max 200
+  $prHits = __MEP_GrepLines -Lines $bundledLines -Regex '(?i)(PR\s*#\s*(1669|1671|1673|1676)\b|pull/(1669|1671|1673|1676)\b|\b(1669|1671|1673|1676)\b)' -Max 200
   __MEP_PrintSection -Title "Bundled PR Evidence (1669/1671/1673 raw lines)" -Lines $prHits
   # --- EVIDENCE_BUNDLE (fallback / supplement) ---
   $evidenceLines = __MEP_ReadTextLines -Path $evidencePath


### PR DESCRIPTION
Base (Bundled): BUNDLE_VERSION=v0.0.0+20260203_054702+main_fb7ee4a
- Fix tools/mep_handoff.ps1 ParserError at prHits assignment
- Extend PR evidence matcher to include PR #1676
Acceptance:
- Script parses under StrictMode
- Script output contains BUNDLE_VERSION=v0.0.0+20260203_054702+main_fb7ee4a and includes '1676'