### PR TITLE
fix(mep): repair mep_handoff parser/quoting (deterministic)

### DIFF
--- a/tools/mep_handoff.ps1
+++ b/tools/mep_handoff.ps1
@@ -19,11 +19,11 @@ function __ReadBundledEvidence {
   param([string]$RepoRoot)
   $p = Join-Path $RepoRoot "docs/MEP/MEP_BUNDLE.md"
   if (!(Test-Path $p)) { return @{ ok=$false; err="Bundled missing: $p" } }
-  $bundleVersion = (Select-String -Path $p -Pattern '^BUNDLE_VERSION\s*=' -List).Line
+  $bundleVersion = ($bundledLines | Select-String -Pattern "^\s*BUNDLE_VERSION\s*=" -List -ErrorAction SilentlyContinue).Line
   if (-not $bundleVersion) { $bundleVersion = "<BUNDLE_VERSION_NOT_FOUND>" }
   # Extract: CARD headings + key evidence tokens + recent PR evidence lines (best-effort)
   $lines = Get-Content -Path $p -Encoding UTF8
-  $cards = @()
+  $cards = __MEP_GrepLines -Lines $bundledLines -Regex "^\s*##\s*CARD:\s*.+$" -Max 500
   foreach ($m in ($lines | Select-String -Pattern '^\s*##\s*CARD:\s*.+
 # --- StrictMode guard: ensure $evidencePath is always initialized (avoid unbound variable) ---
 try {
@@ -62,7 +62,7 @@ function Get-MepEvidenceAuditMarkers {
     throw "EVIDENCE_BUNDLE not found: $EvidenceRel"
   }
   $lines = Get-Content -LiteralPath $evidenceAbs -Encoding UTF8 -Tail $Tail
-  $picked = $lines | Where-Object { $_ -match 'audit=OK,WB0000' } | Select-Object -Last $Take
+  $picked = $lines | Where-Object { $_ -match "audit=OK,WB0000" } | Select-Object -Last $Take
   return ,$picked
 }
 function Info([string]$m){ Write-Host $m -ForegroundColor Cyan }
@@ -205,7 +205,7 @@ catch {
     foreach ($m in ($lines | Select-String -SimpleMatch $k)) { $keyHits += $m.Line.Trim() }
   }
   $prs = @("PR #1669","PR #1671","PR #1673")
-  $prHits = @()
+  $prHits = __MEP_GrepLines -Lines $bundledLines -Regex "(?i)(PR\s*#\s*(1669|1671|1673|1676)\b|pull/(1669|1671|1673|1676)\b|\b(1669|1671|1673|1676)\b)" -Max 200
   foreach ($pr in $prs) {
     foreach ($m in ($lines | Select-String -SimpleMatch $pr)) { $prHits += $m.Line.Trim() }
   }
@@ -257,7 +257,7 @@ function Get-MepEvidenceAuditMarkers {
     throw "EVIDENCE_BUNDLE not found: $EvidenceRel"
   }
   $lines = Get-Content -LiteralPath $evidenceAbs -Encoding UTF8 -Tail $Tail
-  $picked = $lines | Where-Object { $_ -match 'audit=OK,WB0000' } | Select-Object -Last $Take
+  $picked = $lines | Where-Object { $_ -match "audit=OK,WB0000" } | Select-Object -Last $Take
   return ,$picked
 }
 function Info([string]$m){ Write-Host $m -ForegroundColor Cyan }
@@ -481,7 +481,7 @@ try {
   $cards = __MEP_GrepLines -Lines $bundledLines -Regex '^\s*##\s*CARD:\s*.+$' -Max 500
   __MEP_PrintSection -Title "Bundled Cards" -Lines $cards
   # Ruleset evidence: match broadly (token names may differ)
-  $rulesetHits = __MEP_GrepLines -Lines $bundledLines -Regex '(?i)RULESET_|Required\s*checks|merge\s*block|MERGE_BLOCK' -Max 300
+  $rulesetHits = __MEP_GrepLines -Lines $bundledLines -Regex "(?i)RULESET_|Required\s*checks|merge\s*block|MERGE_BLOCK" -Max 300
   __MEP_PrintSection -Title "Bundled Ruleset/Checks Evidence (raw lines)" -Lines $rulesetHits
   # PR evidence: match 1669/1671/1673 even if formatting differs
   $prHits = __MEP_GrepLines -Lines $bundledLines -Regex '(?i)(PR\s*#\s*(1669|1671|1673|1676)\b|pull/(1669|1671|1673|1676)\b|\b(1669|1671|1673|1676)\b)' -Max 200
@@ -491,11 +491,11 @@ try {
   Write-Output ""
   Write-Output "=== [EVIDENCE_BUNDLE Baseline] ==="
   Write-Output ("EVIDENCE_BUNDLE Path: " + $evidencePath)
-  $evVersion = ($evidenceLines | Select-String -Pattern '^\s*BUNDLE_VERSION\s*=' -List -ErrorAction SilentlyContinue).Line
+  $evVersion     = ($evidenceLines | Select-String -Pattern "^\s*BUNDLE_VERSION\s*=" -List -ErrorAction SilentlyContinue).Line
   if ($evVersion) { Write-Output ("EVIDENCE_BUNDLE " + $evVersion) }
-  $evRulesetHits = __MEP_GrepLines -Lines $evidenceLines -Regex '(?i)RULESET_|Required\s*checks|merge\s*block|MERGE_BLOCK' -Max 300
+  $evRulesetHits = __MEP_GrepLines -Lines $evidenceLines -Regex "(?i)RULESET_|Required\s*checks|merge\s*block|MERGE_BLOCK" -Max 300
   __MEP_PrintSection -Title "EVIDENCE_BUNDLE Ruleset/Checks Evidence (raw lines)" -Lines $evRulesetHits
-  $evPrHits = __MEP_GrepLines -Lines $evidenceLines -Regex '(?i)(PR\s*#\s*(1669|1671|1673)\b|pull/(1669|1671|1673)\b|\b(1669|1671|1673)\b)' -Max 200
+  $evPrHits = __MEP_GrepLines -Lines $evidenceLines -Regex "(?i)(PR\s*#\s*(1669|1671|1673|1676)\b|pull/(1669|1671|1673|1676)\b|\b(1669|1671|1673|1676)\b)" -Max 200
   __MEP_PrintSection -Title "EVIDENCE_BUNDLE PR Evidence (1669/1671/1673 raw lines)" -Lines $evPrHits
   # --- mep_entry evidence (logs) ---
   $entryDir = Join-Path $env:USERPROFILE "Desktop\MEP_LOGS\ENTRY_AUDIT"
@@ -512,7 +512,7 @@ try {
     Write-Output ("Latest Log: " + $latest.FullName)
     $logLines = __MEP_ReadTextLines -Path $latest.FullName
     # pull the key tokens aggressively
-    $entryHits = __MEP_GrepLines -Lines $logLines -Regex '(?i)(ENTRY_EXIT|STOP_REASON|ALL_DONE|Progress|Gate\s*\d+/\d+|mep_entry\.ps1)' -Max 200
+    $entryHits = __MEP_GrepLines -Lines $logLines -Regex "(?i)(ENTRY_EXIT|STOP_REASON|ALL_DONE|Progress|Gate\s*\d+/\d+|mep_entry\.ps1)" -Max 200
     __MEP_PrintSection -Title "ENTRY_AUDIT Key Lines (raw)" -Lines $entryHits
   } else {
     Write-Output "(no log file found)"


### PR DESCRIPTION
- Repair ParserError sources by normalizing quoting for:
  - BUNDLE_VERSION pattern reads (bundleVersion / evVersion)
  - cards / ruleset / PR evidence greps
  - entry audit greps
  - audit filter (-match audit=OK,WB0000)
Acceptance:
- tools/mep_handoff.ps1 parses under StrictMode
- script executes end-to-end