### PR TITLE
fix(mep): G0 sync uses fetch+reset (avoid ff-only pull error)

### DIFF
--- a/tools/gates/G0.ps1
+++ b/tools/gates/G0.ps1
@@ -11,6 +11,7 @@ $st=@(git status --porcelain)
 if($st.Count -gt 0){ FailGate "Working tree dirty (must be clean)" }
 git fetch origin 1>$null
 git checkout main 1>$null
-git pull --ff-only origin main 1>$null
+git reset --hard origin/main 1>$null
 OkGate "Pre-Gate OK (origin/clean/main-sync)"
 exit 0
+


### PR DESCRIPTION
Fix G0: replace 'git pull --ff-only origin main' (can error: Cannot fast-forward to multiple branches) with deterministic fetch+reset to origin/main.