### PR TITLE
docs(mep): OP-3 日本語監査テンプレ一次根拠ブロック + CURRENT_SCOPE 最小復帰手順

### DIFF
--- a/docs/MEP/MEP_BUNDLE.md
+++ b/docs/MEP/MEP_BUNDLE.md
@@ -985,3 +985,30 @@ MERGED_AT=2026-02-03T20:43:56+09:00
 - EVIDENCE_BUNDLE_VERSION bumped by commit 84af90e0..
 - Child MEP follow ref: PR#1709 mergeCommit 99b1a5bc..
 
+<!-- appended: OP-3 jp audit template 2026-02-04T06:44:52+09:00 -->
+## OP-3 日本語監査テンプレ（一次根拠ブロック）
+【監査用引継ぎ（一次根拠のみ／確定事項）｜OP-3】
+REPO_ORIGIN
+https://github.com/Osuu-ops/yorisoidou-system.git
+基準ブランチ
+main
+HEAD（main）
+38061eb492c4fc4c08321bad000f0d1768bc210a
+PARENT_BUNDLED
+docs/MEP/MEP_BUNDLE.md
+EVIDENCE_BUNDLE
+docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md
+PARENT_BUNDLE_VERSION
+v0.0.0+20260203_194633+main_cfbd3c5
+確定（証跡）
+- 上記はすべて main ブランチおよび gh / git の一次出力に基づく
+目的（OP-3）
+- Scope Guard / 非干渉ガードにより、ログ・zip・想定外ファイル混入を自動排除する
+- docs/MEP の運用を一次根拠として固定し、追随台帳として消えない形で維持する
+一次根拠（このファイル内の参照点）
+- 「## OP-3 PARENT_BUNDLED FOLLOW LEDGER」節の存在
+- 「CURRENT_SCOPE_OPS」固定方針の記載
+- 追随行（PR / commit / BUNDLE_VERSION 更新）の台帳
+備考
+- 本ブロックは “監査テンプレ形式” の固定。外部事情・会話文脈は一次根拠に含めない。
+

--- a/platform/MEP/90_CHANGES/CURRENT_SCOPE.md
+++ b/platform/MEP/90_CHANGES/CURRENT_SCOPE.md
@@ -9,3 +9,26 @@
 - docs/MEP/MEP_BUNDLE.md
 - docs/MEP_SUB/CARDS/**
 
+<!-- appended: scope recovery min 2026-02-04T06:44:52+09:00 -->
+## CURRENT_SCOPE 運用（最小復帰手順／一次根拠採取点）
+目的
+- 事故時に CURRENT_SCOPE を「確実に復帰」し、一次根拠（PR/commit/追随行）を採取できる状態を最小で保証する
+復帰の最小手順（ローカル）
+1) main を同期（ff-only）
+   - git fetch origin --prune
+   - git checkout main
+   - git pull --ff-only origin main
+2) CURRENT_SCOPE の参照点を確認
+   - platform/MEP/90_CHANGES/CURRENT_SCOPE.md を確認（運用方針・固定点）
+   - docs/MEP/MEP_BUNDLE.md の「OP-3 PARENT_BUNDLED FOLLOW LEDGER」を確認（追随行）
+3) 一次根拠採取点（監査で必須となる最小セット）
+   - main HEAD（git rev-parse HEAD）
+   - 対象PR URL / mergedAt / mergeCommit（gh pr view）
+   - PARENT_BUNDLE_VERSION（docs/MEP/MEP_BUNDLE.md 先頭の BUNDLE_VERSION 行）
+   - EVIDENCE_BUNDLE_VERSION（docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md 先頭の BUNDLE_VERSION 行）
+4) 追随が崩れている場合（最小復旧）
+   - docs/MEP 側の ledger に「追随行（PR/commit）」を追記し、PR→auto-merge→main で一次根拠化する
+   - zip/log 等の混入は Scope Guard / 非干渉ガードの対象（docs-only で収束させる）
+注意
+- 一次根拠は “main と gh/git の一次出力” のみ。会話文脈・推測は入れない。
+


### PR DESCRIPTION
目的（OP-3）
- Scope Guard / 非干渉ガードの一次根拠を「日本語監査テンプレ形式」で docs/MEP/MEP_BUNDLE.md に固定
- CURRENT_SCOPE 運用の“最小復帰手順”を、採取点（PR/commit/追随行）まで最小で明文化
変更
- docs/MEP/MEP_BUNDLE.md: 「## OP-3 日本語監査テンプレ（一次根拠ブロック）」追記（HEAD/BUNDLE_VERSION を実値で差し込み）
- platform/MEP/90_CHANGES/CURRENT_SCOPE.md: 「## CURRENT_SCOPE 運用（最小復帰手順／一次根拠採取点）」追記
一次根拠採取（作成時点）
- origin/main HEAD: 38061eb492c4fc4c08321bad000f0d1768bc210a
- parent bundle version (from file): v0.0.0+20260203_194633+main_cfbd3c5
- head branch: fix/op3-jp-audit-template_20260204_064452
