### PR TITLE
docs(mep): OP-3 テンプレ一次根拠（PR/mergedAt/commit）をmain実態に整合

### DIFF
--- a/docs/MEP/MEP_BUNDLE.md
+++ b/docs/MEP/MEP_BUNDLE.md
@@ -1,7 +1,7 @@
 PARENT_BUNDLE_VERSION
 v0.0.0+20260204_042728+main_34b5a6e0
 
-BUNDLE_VERSION = v0.0.0+20260203_194633+main_cfbd3c5
+BUNDLE_VERSION = v0.0.0+20260204_042728+main_34b5a6e0
 BUNDLED_AT = 2026-02-02T04:05:55+0900
 OPS: Bundled writeback is executed via workflow_dispatch (mep_writeback_bundle_dispatch); local runs are for debugging only.
 # MEP_BUNDLE
@@ -993,18 +993,18 @@ https://github.com/Osuu-ops/yorisoidou-system.git
 基準ブランチ
 main
 HEAD（main）
-35fbdeb093fbf301b9e19ec2bb34926e7cf586a5
+bd336142762dbc9c061aceb9fd6e9307d726e717
 PARENT_BUNDLED
 docs/MEP/MEP_BUNDLE.md
 EVIDENCE_BUNDLE
 docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md
 PARENT_BUNDLE_VERSION
-v0.0.0+20260203_194633+main_cfbd3c5
+v0.0.0+20260204_042728+main_34b5a6e0
 EVIDENCE_BUNDLE_VERSION
 v0.0.0+20260204_035621+main+evidence-child
 確定（証跡）
-PR #
-mergedAt: 
-mergeCommit: 35fbdeb093fbf301b9e19ec2bb34926e7cf586a5
+PR #1740
+mergedAt: 2026-02-03T22:04:24Z
+mergeCommit: bd336142762dbc9c061aceb9fd6e9307d726e717
 ※上記はすべて main ブランチおよび gh / git の一次出力に基づく。
 


### PR DESCRIPTION
目的（OP-3 監査テンプレの確定）
- docs/MEP/MEP_BUNDLE.md の OP-3 日本語監査テンプレ節に、PR/mergedAt/mergeCommit/HEAD/PARENT/EVIDENCE の一次値を埋めて確定
- BUNDLE_VERSION = を PARENT_BUNDLE_VERSION(top) と一致させ、参照点の齟齬を除去
一次根拠（gh/git）
- PR URL: https://github.com/Osuu-ops/yorisoidou-system/pull/1740
- PR mergedAt: 2026-02-03T22:04:24Z
- PR mergeCommit: bd336142762dbc9c061aceb9fd6e9307d726e717
- HEAD(main): bd336142762dbc9c061aceb9fd6e9307d726e717
- PARENT_BUNDLE_VERSION(top): v0.0.0+20260204_042728+main_34b5a6e0
- EVIDENCE_BUNDLE_VERSION(child): v0.0.0+20260204_035621+main+evidence-child
