### PR TITLE
fix(handoff): add OP-0 wrapper + declare Scope-IN

### DIFF
--- a/platform/MEP/90_CHANGES/CURRENT_SCOPE.md
+++ b/platform/MEP/90_CHANGES/CURRENT_SCOPE.md
@@ -2,6 +2,8 @@
 - CURRENT_SCOPE.md
 - platform/MEP/90_CHANGES/CURRENT_SCOPE.md
 - tools/mep_handoff_op0.ps1
+- tools/mep_handoff.ps1
+- tools/mep_handoff_min.ps1
 ## CURRENT_SCOPE 運用（最小復帰手順／一次根拠採取点）
 目的
 - 事故時に CURRENT_SCOPE を「確実に復帰」し、一次根拠（PR/commit/追随行）を採取できる状態を最小で保証する

--- a/tools/mep_handoff_op0.ps1
+++ b/tools/mep_handoff_op0.ps1
@@ -1,41 +1,57 @@
-# PowerShell is @' '@ safe (wrapper; OP-0 embedded as base64; NO baseOut capture)
+# PowerShell is @' '@ safe (OP-0 wrapper)
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 $ProgressPreference = 'SilentlyContinue'
 try { [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false) } catch {}
 try { $OutputEncoding = [Console]::OutputEncoding } catch {}
 $env:GIT_PAGER="cat"; $env:PAGER="cat"; $env:GH_PAGER="cat"
-
 function Fail($msg) { Write-Host "[FATAL] $msg" -ForegroundColor Red; exit 2 }
-
 # repo root: tools\.. (no git invocation needed)
 $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
 Set-Location $repoRoot
-
 # base generator (prefer min)
 $baseMin  = Join-Path $PSScriptRoot "mep_handoff_min.ps1"
 $baseMain = Join-Path $PSScriptRoot "mep_handoff.ps1"
-if (Test-Path $baseMin) { $base = $baseMin } elseif (Test-Path $baseMain) { $base = $baseMain } else { Fail "base handoff generator not found under tools" }
-
-# OP-0 excerpt decode
-$op0_b64 = @'
-U09VUkNFX01EOiBDOlxVc2Vyc1xTeXVpY2hpXERlc2t0b3BcTUVQX0xPR1NcT1AwX0VWSURFTkNFX0VYVFJBQ1Rcb3AwX2V2aWRlbmNlX3NlbGVjdF8yMDI2MDIwNF8wNjIxNDUubWQKRVhUUkFDVF9BVDogMjAyNi0wMi0wNFQwNjo1ODo0NCswOTowMApIRUFEKHByLWJyYW5jaCk6IDczNDQ1MmI5NzBhMWIyYjhiZjg1NWM4ZjQ1YmU5MGI2YTU5NGExMjMKIyBPUC0wIEV2aWRlbmNlIFNlbGVjdCAocGFzdGUtcmVhZHkpCgpJTlBVVF9FWFRSQUNUOiBDOlxVc2Vyc1xTeXVpY2hpXERlc2t0b3BcTUVQX0xPR1NcT1AwX0VWSURFTkNFX0VYVFJBQ1Rcb3AwX2V2aWRlbmNlX2V4dHJhY3RfMjAyNjAyMDRfMDYxNTE0Lm1kClJFUE9fUk9PVDogQzovVXNlcnMvU3l1aWNoaS9PbmVEcml2ZS/jg4njgq3jg6Xjg6Hjg7Pjg4gvR2l0SHViL3lvcmlzb2lkb3Utc3lzdGVtCkhFQUQobWFpbik6IDAwYWZmYzgxMTg4NTQ3Mjc5OTBmYTAzNzE4NzQ5NzhhMTNlOTBiMWUKR0VORVJBVEVEX0FUOiAyMDI2LTAyLTA0VDA2OjIxOjQ1KzA5OjAwCgpXQVJOSU5HOiBIRUFEIGRyaWZ0IHZzIEhBTkRPRkZfSEVBRAotIEhBTkRPRkZfSEVBRDogN2JmMDZmY2NkNGMxNzEwMTNjNTBlZjBkMGY3ZjQzMjUwNWZiNWU1NAotIENVUlJFTlRfSEVBRDogMDBhZmZjODExODg1NDcyNzk5MGZhMDM3MTg3NDk3OGExM2U5MGIxZQoKIyMg55uj5p+755So5byV57aZ44GO44G46L+96KiY44GZ44KL44CO5LiA5qyh5qC55oug77yI5oqc57KL77yJ44CP5YCZ6KOc77yI5LiK5L2N5oq95Ye644O76YeN6KSHL+WBj+OCiuaKkeWItu+8iQoKIyMjIE9QLTAgUk9PVF9FVklERU5DRSAxIChzY29yZT0zODApClNPVVJDRTogQzpcVXNlcnNcU3l1aWNoaVxPbmVEcml2ZVzjg4njgq3jg6Xjg6Hjg7Pjg4hcR2l0SHViXHlvcmlzb2lkb3Utc3lzdGVtXGRvY3NcTUVQXE1FUF9CVU5ETEUubWQKUkFOR0UgOiBMMDg4Ni1MMDg5MCAoaGl0PUwwODg4KQoKYGBgdGV4dApMMDg4NjogLSByZXF1aXJlZCBjb250ZXh0cyAoYXMgcmVxdWlyZWQgY2hlY2tzKTogKG5vbmUgZGV0ZWN0ZWQgdmlhIGJyYW5jaCBwcm90ZWN0aW9uIEFQSSkKTDA4ODc6ICMjIyBFdmlkZW5jZSBCOiBSdWxlc2V0cyAoYmVzdC1lZmZvcnQgZGlzY292ZXJ5KQpMMDg4ODogLSBpZD0xMTUyNTUwNSBuYW1lPW1haW4tcmVxdWlyZWQtY2hlY2tzIHRhcmdldD1icmFuY2ggZW5mb3JjZW1lbnQ9YWN0aXZlIHJlcXVpcmVkX2NoZWNrcz1TY29wZSBHdWFyZCAoUFIpIHwgYnVzaW5lc3Mtbm9uLWludGVyZmVyZW5jZS1ndWFyZApMMDg4OTogIyMjIEV2aWRlbmNlIEM6IE9ic2VydmVkIGNoZWNrcyBvbiBtZXJnZWQgUFIgKHNuYXBzaG90KQpMMDg5MDogLSBzb3VyY2VQUjogIzE2NjkKYGBgCgojIyMgT1AtMCBST09UX0VWSURFTkNFIDIgKHNjb3JlPTM4MCkKU09VUkNFOiBDOlxVc2Vyc1xTeXVpY2hpXE9uZURyaXZlXOODieOCreODpeODoeODs+ODiFxHaXRIdWJceW9yaXNvaWRvdS1zeXN0ZW1cZG9jc1xNRVBcTUVQX0JVTkRMRS5tZApSQU5HRSA6IEwwODg1LUwwODg5IChoaXQ9TDA4ODcpCgpgYGB0ZXh0CkwwODg1OiAtIHJlcXVpcmVkX3N0YXR1c19jaGVja3Muc3RyaWN0OiAKTDA4ODY6IC0gcmVxdWlyZWQgY29udGV4dHMgKGFzIHJlcXVpcmVkIGNoZWNrcyk6IChub25lIGRldGVjdGVkIHZpYSBicmFuY2ggcHJvdGVjdGlvbiBBUEkpCkwwODg3OiAjIyMgRXZpZGVuY2UgQjogUnVsZXNldHMgKGJlc3QtZWZmb3J0IGRpc2NvdmVyeSkKTDA4ODg6IC0gaWQ9MTE1MjU1MDUgbmFtZT1tYWluLXJlcXVpcmVkLWNoZWNrcyB0YXJnZXQ9YnJhbmNoIGVuZm9yY2VtZW50PWFjdGl2ZSByZXF1aXJlZF9jaGVja3M9U2NvcGUgR3VhcmQgKFBSKSB8IGJ1c2luZXNzLW5vbi1pbnRlcmZlcmVuY2UtZ3VhcmQKTDA4ODk6ICMjIyBFdmlkZW5jZSBDOiBPYnNlcnZlZCBjaGVja3Mgb24gbWVyZ2VkIFBSIChzbmFwc2hvdCkKYGBgCgojIyMgT1AtMCBST09UX0VWSURFTkNFIDMgKHNjb3JlPTM4MCkKU09VUkNFOiBDOlxVc2Vyc1xTeXVpY2hpXE9uZURyaXZlXOODieOCreODpeODoeODs+ODiFxHaXRIdWJceW9yaXNvaWRvdS1zeXN0ZW1cZG9jc1xNRVBcTUVQX0JVTkRMRS5tZApSQU5HRSA6IEwwODg0LUwwODg4IChoaXQ9TDA4ODYpCgpgYGB0ZXh0CkwwODg0OiAtIHByb3RlY3Rpb25FbmFibGVkOiBUcnVlCkwwODg1OiAtIHJlcXVpcmVkX3N0YXR1c19jaGVja3Muc3RyaWN0OiAKTDA4ODY6IC0gcmVxdWlyZWQgY29udGV4dHMgKGFzIHJlcXVpcmVkIGNoZWNrcyk6IChub25lIGRldGVjdGVkIHZpYSBicmFuY2ggcHJvdGVjdGlvbiBBUEkpCkwwODg3OiAjIyMgRXZpZGVuY2UgQjogUnVsZXNldHMgKGJlc3QtZWZmb3J0IGRpc2NvdmVyeSkKTDA4ODg6IC0gaWQ9MTE1MjU1MDUgbmFtZT1tYWluLXJlcXVpcmVkLWNoZWNrcyB0YXJnZXQ9YnJhbmNoIGVuZm9yY2VtZW50PWFjdGl2ZSByZXF1aXJlZF9jaGVja3M9U2NvcGUgR3VhcmQgKFBSKSB8IGJ1c2luZXNzLW5vbi1pbnRlcmZlcmVuY2UtZ3VhcmQKYGBgCgojIyMgT1AtMCBST09UX0VWSURFTkNFIDQgKHNjb3JlPTM4MCkKU09VUkNFOiBDOlxVc2Vyc1xTeXVpY2hpXE9uZURyaXZlXOODieOCreODpeODoeODs+ODiFxHaXRIdWJceW9yaXNvaWRvdS1zeXN0ZW1cZG9jc1xNRVBcTUVQX0JVTkRMRS5tZApSQU5HRSA6IEwwODM3LUwwODQxIChoaXQ9TDA4MzkpCgpgYGB0ZXh0CkwwODM3OiAqIC0gUFIgIzE2MTkgfCBtZXJnZWRBdD0wMi8wMS8yMDI2IDIxOjA5OjAwIHwgbWVyZ2VDb21taXQ9ZTg2ZmI5NTFlNTk4NjA5YTZjOTg5OTc2YjNkYWVmNzQ5ZTkzMzM4NCB8IEJVTkRMRV9WRVJTSU9OPXYwLjAuMCsyMDI2MDIwMl8wODQ5MDIrbWFpbl82MzU3NjBjIHwgYXVkaXQ9T0ssV0IwMDAwIHwgaHR0cHM6Ly9naXRodWIuY29tL09zdXUtb3BzL3lvcmlzb2lkb3Utc3lzdGVtL3B1bGwvMTYxOQpMMDgzODogUFIgIzE2MTkgfCBhdWRpdD1PSyxXQjAwMDAgfCBhcHBlbmRlZF9hdD0yMDI2LTAyLTAyVDA4OjQ5OjEzLjU5ODQwNTkrMDA6MDAgfCB2aWE9bWVwX2FwcGVuZF9ldmlkZW5jZV9saW5lX2Z1bGwucHMxCkwwODM5OiAqIFJVTEVTRVRfTEVER0VSIHwgbWFpbi1yZXF1aXJlZC1jaGVja3MoaWQ9MTE1MjU1MDUpIGVuZm9yY2VtZW50PWFjdGl2ZSByZXF1aXJlZF9jaGVja3M9W2J1c2luZXNzLW5vbi1pbnRlcmZlcmVuY2UtZ3VhcmQsIFNjb3BlIEd1YXJkIChQUildIHZlcmlmaWVkX21lcmdlX2Jsb2NrPVBSIzE2MzMgYmFzZS1icmFuY2gtcG9saWN5LXByb2hpYml0cy1tZXJnZSBvYnNlcnZlZF9hdD0yMDI2LTAyLTAyVDEyOjExOjA5WgpMMDg0MDogCkwwODQxOiAKYGBgCgojIyMgT1AtMCBST09UX0VWSURFTkNFIDUgKHNjb3JlPTM1NSkKU09VUkNFOiBDOlxVc2Vyc1xTeXVpY2hpXE9uZURyaXZlXOODieOCreODpeODoeODs+ODiFxHaXRIdWJceW9yaXNvaWRvdS1zeXN0ZW1cZG9jc1xNRVBcTUVQX0JVTkRMRS5tZApSQU5HRSA6IEwwOTE4LUwwOTIyIChoaXQ9TDA5MjApCgpgYGB0ZXh0CkwwOTE4OiAtIGlkOiAxMTUyNTUwNQpMMDkxOTogLSBlbmZvcmNlbWVudDogYWN0aXZlCkwwOTIwOiAtIHJlcXVpcmVkIGNoZWNrcyAoY29udGV4dHMpOiBidXNpbmVzcy1ub24taW50ZXJmZXJlbmNlLWd1YXJkIHwgU2NvcGUgR3VhcmQgKFBSKQpMMDkyMTogIyMjIEJsb2NrIGV2aWRlbmNlIChpbnRlbnRpb25hbCBQUjsgRE8gTk9UIE1FUkdFKQpMMDkyMjogLSBwcjogIzE2NzIKYGBg
-'@
-$op0 = [System.Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($op0_b64))
-
+if (Test-Path $baseMin) { $base = $baseMin }
+elseif (Test-Path $baseMain) { $base = $baseMain }
+else { Fail "base handoff generator not found under tools (mep_handoff_min.ps1 / mep_handoff.ps1)" }
+# --- find SOURCE_MD (latest op0_evidence_select_*.md) ---
+$sourceMd = Join-Path $env:USERPROFILE "Desktop\MEP_LOGS\OP0_EVIDENCE_EXTRACT\op0_evidence_select_20260204_062145.md"
+if (-not (Test-Path $sourceMd)) {
+  $dir = Join-Path $env:USERPROFILE "Desktop\MEP_LOGS\OP0_EVIDENCE_EXTRACT"
+  if (Test-Path $dir) {
+    $latest = Get-ChildItem -Path $dir -Filter "op0_evidence_select_*.md" -File | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+    if ($latest) { $sourceMd = $latest.FullName }
+  }
+}
+$head = $null
+try { $head = (git rev-parse HEAD 2>$null).Trim() } catch { $head = "" }
+if (-not (Test-Path $sourceMd)) {
+  $op0Text = @"
+SOURCE_MD: (not found)
+EXTRACT_AT: $(Get-Date -Format "yyyy-MM-ddTHH:mm:ssK")
+HEAD(local): $head
+（OP-0抜粋未生成：Desktop\MEP_LOGS\OP0_EVIDENCE_EXTRACT\op0_evidence_select_*.md が見つかりません）
+"@
+} else {
+  $op0Text = @"
+SOURCE_MD: $sourceMd
+EXTRACT_AT: $(Get-Date -Format "yyyy-MM-ddTHH:mm:ssK")
+HEAD(local): $head
+$(Get-Content -LiteralPath $sourceMd -Raw -Encoding UTF8)
+"@
+}
+# base64 encode excerpt (avoid here-string edge cases)
+$op0B64 = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($op0Text))
+$op0 = [System.Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($op0B64))
 $stamp = Get-Date -Format "yyyy-MM-ddTHH:mm:ssK"
 $append = @"
 【OP-0 一次根拠追記（監査用：抜粋）】
 APPENDED_AT: $stamp
-
 $op0
 "@
-
-# run base generator (it may use Write-Host). do not capture.
+# run base generator (may use Write-Host); do not capture
 & $base
-
-# then print append as pipeline output (handoff text tail)
-Write-Output "
-
-"
+# append as pipeline output tail
+Write-Output "`r`n`r`n"
 Write-Output $append


### PR DESCRIPTION
目的:
- OP-0（非干渉/Scope Guard/business保護）の一次根拠（抜粋）を HANDOFF へ追記するための tools/mep_handoff_op0.ps1 を追加
- CURRENT_SCOPE.md の Scope-IN に tools/mep_handoff_op0.ps1 を宣言（bullet-only/空行ゼロ/不正文字ゼロ）
変更:
- tools/mep_handoff_op0.ps1 (new)
- platform/MEP/90_CHANGES/CURRENT_SCOPE.md (Scope-IN追加)
注記:
- 旧PR(#1737)はチェック不整合が発生していたため、mainからの最小差分PRとして作り直し。