### PR TITLE
fix(mep): parent bundle version follows HEAD(main)

### DIFF
--- a/docs/MEP/MEP_BUNDLE.md
+++ b/docs/MEP/MEP_BUNDLE.md
@@ -1,7 +1,7 @@
 PARENT_BUNDLE_VERSION
 v0.0.0+20260204_042728+main_34b5a6e0
 
-BUNDLE_VERSION = v0.0.0+20260204_010354+main_dca633e
+BUNDLE_VERSION = v0.0.0+20260204_193735+main_8f9f7b3
 BUNDLED_AT = 2026-02-02T04:05:55+0900
 OPS: Bundled writeback is executed via workflow_dispatch (mep_writeback_bundle_dispatch); local runs are for debugging only.
 # MEP_BUNDLE


### PR DESCRIPTION
目的:
- docs/MEP/MEP_BUNDLE.md の BUNDLE_VERSION が古い main_* で固定され、HEAD(main) と不一致になる問題を解消する
変更:
- docs/MEP/MEP_BUNDLE.md の BUNDLE_VERSION を「現在の HEAD(main) 短縮hash」に追随する値へ更新
備考:
- 0承認が来るまでマージしない