### PR TITLE
fix(mep): parent bundle version follows current HEAD(main)

### DIFF
--- a/docs/MEP/MEP_BUNDLE.md
+++ b/docs/MEP/MEP_BUNDLE.md
@@ -1,7 +1,7 @@
 PARENT_BUNDLE_VERSION
 v0.0.0+20260204_042728+main_34b5a6e0
 
-BUNDLE_VERSION = v0.0.0+20260204_194252+main_eff19f7
+BUNDLE_VERSION = v0.0.0+20260204_205145+main_a1b8f65
 BUNDLED_AT = 2026-02-02T04:05:55+0900
 OPS: Bundled writeback is executed via workflow_dispatch (mep_writeback_bundle_dispatch); local runs are for debugging only.
 # MEP_BUNDLE


### PR DESCRIPTION
目的:
- docs/MEP/MEP_BUNDLE.md の BUNDLE_VERSION(main_*) を「現時点のHEAD(main)」へ追随させる
備考:
- 0承認が来るまでマージしない