### PR TITLE
ci: make writeback commit-status stamping provable

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch.yml
@@ -108,11 +108,16 @@ jobs:
           $repo = $env:GITHUB_REPOSITORY
           $runUrl = ("{0}/{1}/actions/runs/{2}" -f $env:GITHUB_SERVER_URL, $repo, $env:GITHUB_RUN_ID)
           function SetStatus([string]$context){
-            gh api ("repos/{0}/statuses/{1}" -f $repo, $sha) `
+            $out = & gh api ("repos/{0}/statuses/{1}" -f $repo, $sha) `
               -f state="success" `
               -f context=$context `
               -f description=("writeback ok (run {0})" -f $env:GITHUB_RUN_ID) `
-              -f target_url=$runUrl | Out-Null
+              -f target_url=$runUrl 2>&1
+            if($LASTEXITCODE -ne 0){
+              throw ("gh api failed (exit={0}) context={1} output={2}" -f $LASTEXITCODE,$context,($out -join " "))
+            }
+            $json = $out | ConvertFrom-Json
+            Info ("set status OK: " + $context + " state=" + $json.state + " url=" + $json.url)
             Info ("set status: " + $context)
           }
           # contexts must match ruleset main-required-checks


### PR DESCRIPTION
目的:
- writeback workflow の commit status 付与を「成功/失敗が一次根拠で判定できる」形にする（失敗は即停止 + 出力、成功は state/url を出す）。
変更:
- .github/workflows/mep_writeback_bundle_dispatch.yml : permissions に statuses: write を確実に含める / SetStatus の gh api を capture + exitcode検査 + JSONログ化
- platform/MEP/90_CHANGES/CURRENT_SCOPE.md : Scope-IN に .github/workflows/mep_writeback_bundle_dispatch.yml を含める（未記載なら追加）