### PR TITLE
ci: fix writeback status stamping (gh api -X POST)

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch.yml
@@ -108,7 +108,7 @@ jobs:
           $repo = $env:GITHUB_REPOSITORY
           $runUrl = ("{0}/{1}/actions/runs/{2}" -f $env:GITHUB_SERVER_URL, $repo, $env:GITHUB_RUN_ID)
           function SetStatus([string]$context){
-            $out = & gh api ("repos/{0}/statuses/{1}" -f $repo, $sha) `
+            $out = & gh api -X POST ("repos/{0}/statuses/{1}" -f $repo, $sha) `
               -f state="success" `
               -f context=$context `
               -f description=("writeback ok (run {0})" -f $env:GITHUB_RUN_ID) `


### PR DESCRIPTION
目的:
- writeback workflow の status 付与が 'accepts 1 arg(s)' で失敗する問題を解消する。
一次根拠:
- run log: gh api failed ... output=accepts 1 arg(s) ...
変更:
- .github/workflows/mep_writeback_bundle_dispatch.yml : SetStatus の gh api を -X POST + endpoint 1引数固定にする