### PR TITLE
ci: fix writeback status stamping (define ep endpoint)

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch.yml
@@ -106,6 +106,7 @@ jobs:
           $sha = (git rev-parse HEAD).Trim()
           Info ('writeback head sha=' + $sha)
           $repo = $env:GITHUB_REPOSITORY
+          [string]$ep = "repos/$repo/statuses/$sha"
           $runUrl = ("{0}/{1}/actions/runs/{2}" -f $env:GITHUB_SERVER_URL, $repo, $env:GITHUB_RUN_ID)
           function SetStatus([string]$context){
             $out = & gh api -X POST "$ep" `


### PR DESCRIPTION
目的:
- writeback workflow の SetStatus が repos/Osuu-ops/yorisoidou-system/statuses/66c5cda0a441943618087845e8b8b67977f62eb5 未定義で失敗するのを修正し、commit status(context) を確実に付与する。
一次根拠:
- workflow内 SetStatus が gh api -X POST "repos/Osuu-ops/yorisoidou-system/statuses/66c5cda0a441943618087845e8b8b67977f62eb5" だが repos/Osuu-ops/yorisoidou-system/statuses/66c5cda0a441943618087845e8b8b67977f62eb5 が未定義で、run log に 'accepts 1 arg(s), received 2' が出て writeback が failure。
変更:
- SetStatus の前で [string]$ep = "repos/$repo/statuses/$sha" を定義
- gh api 呼び出しは gh api -X POST "$ep" を維持（手動成功パターンと一致）