### PR TITLE
fix(workflow): define ep before setting status

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch.yml
@@ -106,7 +106,6 @@ jobs:
           $sha = (git rev-parse HEAD).Trim()
           Info ('writeback head sha=' + $sha)
           $repo = $env:GITHUB_REPOSITORY
-          [string]$ep = "repos/$repo/statuses/$sha"
           $runUrl = ("{0}/{1}/actions/runs/{2}" -f $env:GITHUB_SERVER_URL, $repo, $env:GITHUB_RUN_ID)
           function SetStatus([string]$context){
             $out = & gh api -X POST "$ep" `


### PR DESCRIPTION
Fixes mep_writeback_bundle_dispatch failure:
- Ensure writeback PR (helper) / SetStatus used "$ep" but never set $ep
- Define $ep = [string]::Format("repos/{0}/statuses/{1}", repo, sha) before gh api -X POST "$ep"
This should allow the workflow_dispatch writeback loop to complete and generate the writeback PR.