### PR TITLE
ci: repair SetStatus fully (single endpoint; provable logs)

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch.yml
@@ -111,10 +111,20 @@ jobs:
             try {
               [string]$ep = "repos/$repo/statuses/$sha"
               Info ("status endpoint=" + $ep + " type=" + $ep.GetType().FullName)
-          # contexts must match ruleset main-required-checks
-          SetStatus "Scope Guard (PR)"
-          SetStatus "business-non-interference-guard"
-          # =====================================================================
+              $out = & gh api -X POST "$ep" `
+                -f state="success" `
+                -f context="$context" `
+                -f description=("writeback ok (run {0})" -f $env:GITHUB_RUN_ID) `
+                -f target_url=$runUrl 2>&1
+              if($LASTEXITCODE -ne 0){
+                throw ("gh api failed (exit={0}) context={1} output={2}" -f $LASTEXITCODE,$context,($out -join " "))
+              }
+              $json = $out | ConvertFrom-Json
+              Info ("set status OK: " + $context + " state=" + $json.state + " url=" + $json.url)
+            } catch {
+              Warn ("set status FAILED: " + $context)
+              throw
+            }
           }
           $head = $newHead
           Info ('HEAD=' + $head)


### PR DESCRIPTION
目的:
- PR#1789 の実行中 ParserError 由来で SetStatus が半壊した可能性があるため、SetStatus を安全に全置換して復旧する。
一次根拠:
- writeback run log: 'accepts 1 arg(s), received 2' が発生して commit status total_count=0 が継続。
- 手動では gh api -X POST "repos/<owner>/<repo>/statuses/<sha>" が成功。
変更:
- SetStatus を「丸ごと」置換:
  - [string]$ep = "repos/$repo/statuses/$sha"
  - gh api -X POST "$ep" に固定
  - endpoint/type と set status OK をログ化
  - 失敗時は throw で run を止める