### PR TITLE
ci: fix SetStatus endpoint arg-splitting (single string + single-line gh api)

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch.yml
@@ -108,11 +108,20 @@ jobs:
           Info ("writeback head sha=" + $sha)
           $ep = ("repos/{0}/statuses/{1}" -f $repo, $sha)
           function SetStatus([string]$context){
-            $desc = ("writeback ok (run {0})" -f $env:GITHUB_RUN_ID)
-            $out = & gh api -X POST $ep -f "state=success" -f ("context=$context") -f ("description=$desc") -f ("target_url=$runUrl") 2>&1
-            if($LASTEXITCODE -ne 0){ throw ("gh api failed (exit={0}) context={1} output={2}" -f $LASTEXITCODE,$context,($out -join " ")) }
-            $json = $out | ConvertFrom-Json
-            Info ("set status OK: " + $context + " state=" + $json.state + " url=" + $json.url)
+            try {
+              [string]$ep = ("repos/{0}/statuses/{1}" -f $repo, $sha)
+              Info ("status endpoint=" + $ep + " type=" + $ep.GetType().FullName)
+              $desc = ("writeback ok (run {0})" -f $env:GITHUB_RUN_ID)
+              $out = & gh api -X POST "$ep" -f "state=success" -f ("context=" + $context) -f ("description=" + $desc) -f ("target_url=" + $runUrl) 2>&1
+              if($LASTEXITCODE -ne 0){
+                throw ("gh api failed (exit={0}) context={1} output={2}" -f $LASTEXITCODE,$context,($out -join " "))
+              }
+              $json = $out | ConvertFrom-Json
+              Info ("set status OK: " + $context + " state=" + $json.state + " url=" + $json.url)
+            } catch {
+              Warn ("set status FAILED: " + $context)
+              throw
+            }
           }
           SetStatus "Scope Guard (PR)"
           SetStatus "business-non-interference-guard"


### PR DESCRIPTION
目的:
- writeback workflow の commit status 付与が 'accepts 1 arg(s), received 2' で失敗する問題を解消する。
一次根拠:
- 手動成功: gh api -X POST "repos/<owner>/<repo>/statuses/<sha>" (1本の文字列) は exit=0。
- 失敗run log: accepts 1 arg(s), received 2 (endpoint が分割されている)。
変更:
- Ensure writeback PR (helper) 内 SetStatus を置換
  - endpoint を [string] に固定: ("repos/{0}/statuses/{1}" -f $repo, $sha)
  - gh api 呼び出しはバッククォート無しの単一行 (arg-splitting根絶)
  - 失敗は throw、成功は state/url をログに残す