### PR TITLE
ci(evidence): persist child bundle from evidence dispatch

### DIFF
--- a/.github/workflows/mep_writeback_bundle_evidence_dispatch.yml
+++ b/.github/workflows/mep_writeback_bundle_evidence_dispatch.yml
@@ -40,3 +40,30 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           pwsh -NoProfile -File tools/mep_append_evidence_line_full.ps1 -PrNumber ${{ env.PR_NUMBER }} -BundlePath "docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md"
+
+      - name: Create PR for EVIDENCE writeback branch
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          CHILD="docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md"
+          if [ ! -f "${CHILD}" ]; then echo "[NG] missing ${CHILD}"; exit 2; fi
+          if git status --porcelain -- "${CHILD}" | grep -q . ; then
+            BR="auto/writeback-evidence_${{ github.run_id }}_${{ env.PR_NUMBER }}_$(date +%Y%m%d_%H%M%S)"
+            echo "[INFO] create branch: ${BR}"
+            git switch -c "${BR}"
+            git add -- "${CHILD}"
+            git commit -m "chore(evidence): writeback child bundle (PR #${{ env.PR_NUMBER }}) (run ${{ github.run_id }})"
+            git push -u origin "${BR}"
+            EXIST="$(gh pr list --state open --head "${BR}" --json number --jq '.[0].number' 2>/dev/null || true)"
+            if [ -n "${EXIST}" ]; then echo "[INFO] PR already exists: #${EXIST}"; exit 0; fi
+            TITLE="Evidence writeback (${BR})"
+            BODY="Automated evidence writeback: ${BR} (run_id=${{ github.run_id }})"
+            URL="$(gh pr create --title "${TITLE}" --body "${BODY}" --base "main" --head "${BR}")"
+            echo "[OK] Created PR: ${URL}"
+          else
+            echo "[INFO] child bundle not changed; skip PR create"
+          fi


### PR DESCRIPTION
目的:
- evidence dispatch が child bundle を更新しても main に反映されない（commit/push/PR無し）問題を解消。
一次根拠:
- workflow_dispatch run success でも、run以降に child bundle を変更した merged PR が存在しない。
変更:
- jobs.writeback_evidence.steps 末尾に、childがdirtyなら auto/writeback-evidence_* を commit/push して PR 作成する step を追加。