### PR TITLE
fix(scope): allow OP-3 workflow path for PR #1800

### DIFF
--- a/CURRENT_SCOPE.md
+++ b/CURRENT_SCOPE.md
@@ -4,3 +4,5 @@
 - docs/MEP/**
 - docs/MEP_SUB/**
 - START_HERE.md
+.github/workflows/mep_writeback_bundle_on_push.yml
+


### PR DESCRIPTION
Scope Guard is blocking PR #1800 because .github/workflows/mep_writeback_bundle_on_push.yml is out-of-scope. This PR updates the Scope-IN allowlist to permit that path.