### PR TITLE
fix(scope): allow OP-3 workflow path in platform CURRENT_SCOPE for PR #1800

### DIFF
--- a/platform/MEP/90_CHANGES/CURRENT_SCOPE.md
+++ b/platform/MEP/90_CHANGES/CURRENT_SCOPE.md
@@ -30,3 +30,5 @@
    - zip/log 等の混入は Scope Guard / 非干渉ガードの対象（docs-only で収束させる）
 注意
 - 一次根拠は “main と gh/git の一次出力” のみ。会話文脈・推測は入れない。
+.github/workflows/mep_writeback_bundle_on_push.yml
+


### PR DESCRIPTION
Scope Guard still blocks PR #1800 as out-of-scope for .github/workflows/mep_writeback_bundle_on_push.yml. This PR updates platform/MEP/90_CHANGES/CURRENT_SCOPE.md (the Scope Guard reference) to allow that path.