### PR TITLE
chore(mep): SSOT WIP-020 workflow_fixed (evidence writeback)

### DIFF
--- a/docs/MEP/SSOT/WORK_ID_SSOT.json
+++ b/docs/MEP/SSOT/WORK_ID_SSOT.json
@@ -4,7 +4,7 @@
   "repo_origin": "https://github.com/Osuu-ops/yorisoidou-system.git",
   "owner_repo": "Osuu-ops/yorisoidou-system",
   "baseline_branch": "main",
-  "generated_at_utc": "2026-02-05T11:14:06.2233726Z",
+  "generated_at_utc": "2026-02-05T20:51:04.7043377Z",
   "enums": {
     "action_type": [
       "REPO_ORIGIN_OK",
@@ -164,7 +164,14 @@
         "params": {
           "pr_number": 0,
           "ref": "main",
-          "workflow_fixed": null
+          "workflow_fixed": {
+            "workflow_path": ".github/workflows/mep_writeback_bundle_evidence_dispatch.yml",
+            "workflow_id": "225692127",
+            "ref": "main",
+            "pr_number": 0,
+            "dispatch_inputs": {},
+            "note": "Fixed: child-evidence writeback dispatch (no inputs detected; pr_number kept as contract=0)"
+          }
         }
       },
       "done": {


### PR DESCRIPTION
目的:
- WIP-020 (writeback dispatch) の action.params.workflow_fixed を探索禁止の確定値に固定する。
- 子EVIDENCE更新に使う workflow を workflow_path/workflow_id/ref/pr_number=0 でSSOT化する。
内容:
- docs/MEP/SSOT/WORK_ID_SSOT.json の WIP-020.action.params.workflow_fixed を確定値オブジェクトに更新
- workflow_path=.github/workflows/mep_writeback_bundle_evidence_dispatch.yml
- workflow_id=225692127
- ref=main
- pr_number=0（inputsなしでも契約値として固定）