### PR TITLE
fix(entry): avoid $k: parser error in entry report

### DIFF
--- a/.github/scripts/mep_entry_ssot_report.ps1
+++ b/.github/scripts/mep_entry_ssot_report.ps1
@@ -97,7 +97,7 @@ $lines += "## WORK_ID Results (SSOT-driven)"
 $lines += ""
 foreach($k in @("WIP-020","WIP-025","WIP-026")){
   $x = $report.work.$k
-  $lines += "- $k: " + ($(if($x.ok){ "OK" } else { "NG" })) + " — " + $x.purpose
+  $lines += "- ${k}: " + ($(if($x.ok){ "OK" } else { "NG" })) + " — " + $x.purpose
 }
 $lines += ""
 $lines += "## Notes"


### PR DESCRIPTION
目的:
- .github/scripts/mep_entry_ssot_report.ps1 の ParserError ($k:) を修正し、ENTRYレポート生成を実行可能に戻す。
内容:
- "- $k: " を "- ${k}: " に変更（PowerShellの変数解釈を安全化）
一次根拠:
- 実行時エラー: Variable reference is not valid. ':' was not followed by a valid variable name character