### PR TITLE
fix(actions): quote "on" to enable workflow_dispatch (handoff)

### DIFF
--- a/.github/workflows/mep_handoff_dispatch_manual.yml
+++ b/.github/workflows/mep_handoff_dispatch_manual.yml
@@ -1,5 +1,5 @@
 name: MEP Handoff Dispatch (Manual)
-on:
+"on":
   workflow_dispatch:
     inputs:
       pr_number:


### PR DESCRIPTION
Fix GitHub Actions YAML parsing edge-case where `on:` may not be recognized properly, causing HTTP 422 "Workflow does not have workflow_dispatch trigger".
Change:
- .github/workflows/mep_handoff_dispatch_manual.yml : on: -> "on":