### PR TITLE
feat(actions): add v4b workflow_dispatch smoke (force new workflow_id)

### DIFF
--- a/.github/workflows/mep_handoff_dispatch_manual_v4b.yml
+++ b/.github/workflows/mep_handoff_dispatch_manual_v4b.yml
@@ -1,0 +1,22 @@
+name: MEP Handoff Dispatch (Manual v4b)
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Target PR number (0=auto-resolve mode)."
+        required: true
+        default: "0"
+permissions:
+  contents: write
+  pull-requests: write
+concurrency:
+  group: mep-handoff-dispatch-manual-v4b
+  cancel-in-progress: false
+jobs:
+  handoff:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Echo (smoke)
+        run: |
+          echo "OK: workflow_dispatch is alive"
+          echo "pr_number=${{ inputs.pr_number }}"

--- a/platform/MEP/90_CHANGES/CURRENT_SCOPE.md
+++ b/platform/MEP/90_CHANGES/CURRENT_SCOPE.md
@@ -7,3 +7,4 @@
 - .github/workflows/mep_handoff_dispatch_manual_v3.yml
 - .github/workflows/mep_handoff_dispatch_manual_v4.yml
 - docs/MEP/HANDOFF.md
+- .github/workflows/mep_handoff_dispatch_manual_v4b.yml


### PR DESCRIPTION
Adds a minimal workflow_dispatch-only workflow to verify dispatchability and force a fresh workflow_id registration.
Also appends it to CURRENT_SCOPE.