### PR TITLE
fix(actions): v5 handoff workflow add push trigger (dispatch 422 workaround)

### DIFF
--- a/.github/workflows/mep_handoff_dispatch_manual_v5.yml
+++ b/.github/workflows/mep_handoff_dispatch_manual_v5.yml
@@ -1,6 +1,12 @@
 name: MEP Handoff Dispatch (Manual v5)
 "on":
   workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/mep_handoff_dispatch_manual_v5.yml
+
     inputs:
       pr_number:
         description: "Target PR number (0=auto-resolve mode)."
@@ -32,6 +38,7 @@ jobs:
           RUN_ID="${{ github.run_id }}"
           TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           PR_NUMBER="${{ inputs.pr_number }}"
+          if [[ -z "$PR_NUMBER" ]]; then PR_NUMBER="0"; fi
           REPO="${{ github.repository }}"
           BASE_BRANCH="main"
           HEAD_SHA="$(git rev-parse HEAD)"


### PR DESCRIPTION
Adds push trigger to v5 handoff workflow so it can run on main merge even when workflow_dispatch is broken (HTTP 422).
Also sets PR_NUMBER fallback to 0 for push events.