### PR TITLE
Stabilize HANDOFF.md to prevent endless auto PRs

### DIFF
--- a/docs/MEP/HANDOFF.md
+++ b/docs/MEP/HANDOFF.md
@@ -1,12 +1,10 @@
-HANDOFF (dual-layer, machine-generated)
+HANDOFF (stable, machine-generated)
 
 [AUDIT]
 REPO_ORIGIN
 https://github.com/Osuu-ops/yorisoidou-system.git
 BASE_BRANCH
 main
-HEAD
-eeb11fe1
 PARENT_BUNDLED
 docs/MEP/MEP_BUNDLE.md
 EVIDENCE_BUNDLE
@@ -15,9 +13,6 @@ PARENT_BUNDLE_VERSION
 v0.0.0+20260206_191703+main_f733f7c
 EVIDENCE_BUNDLE_VERSION
 v0.0.0+20260204_035621+main+evidence-child
-EVIDENCE_BUNDLE_LAST_COMMIT
-eeb11fe125fd1ca8bb602652c942dba1bfcdf607 2026-02-07T10:19:23+09:00
-fix(scope): comply with Scope Guard for PR #1907
 
 PR
 number=1898 mergedAt=2026-02-06T22:42:45Z mergeCommit=e569fa490ef10efdc587c055715515cf4a8ba3ff
@@ -29,4 +24,4 @@ OP-1: ensure EVIDENCE follows main
 OP-2: keep minimal recovery loop for handoff
 OP-3: scope guard blocks unexpected files
 
-PROOF_HIT parent=e569fa490ef10efdc587c055715515cf4a8ba3ff evidence=e569fa490ef10efdc587c055715515cf4a8ba3ff
+PROOF_HIT parent=e569fa490ef10efdc587c055715515cf4a8ba3ff evidence=

--- a/docs/MEP/HANDOFF_LATEST.txt
+++ b/docs/MEP/HANDOFF_LATEST.txt
@@ -1,0 +1,3 @@
+HEAD=5c9bee60
+LAST_COMMIT=5c9bee601c5654a19335536070c6750840fc7334 2026-02-07T10:48:39+09:00
+Merge pull request #1913 from Osuu-ops/fix/handoff-dispatch-dedupe_20260207_104820


### PR DESCRIPTION
Moves volatile fields (HEAD/time/last commit) to docs/MEP/HANDOFF_LATEST.txt; keeps docs/MEP/HANDOFF.md stable for auto-PR loop.