### PR TITLE
fix(auto): auto-approve ENTER prompts (MEP_AUTO_APPROVE=1)

### DIFF
--- a/tools/mep_auto_loop.ps1
+++ b/tools/mep_auto_loop.ps1
@@ -86,7 +86,7 @@ if ($stageVal -eq "DONE") { $ec = 0 }
 
   Write-MepRun -Source DRAFT -PreGateResult FAIL -PreGateReason $reason -GateMax $GateMax -GateOkUpto 0 -GateStopAt 0 -ExitCode $exitCode -StopReason $reason -GateMatrix @{}
   if ($exitCode -eq 2) {
-    [void](Read-Host "ENTER（承認）で続行")
+    if ($env:MEP_AUTO_APPROVE -eq '1') { } else { [void](Read-Host "ENTER（承認）で続行") }
   } else {
     exit 1
   }


### PR DESCRIPTION
目的:
- PREGATE_NG / G0 exit=2 の ENTER承認が Read-Host(コンソール直結) で自動化できず、完全ループが前進できない。
- env:MEP_AUTO_APPROVE=1 のとき Read-Host を自動ENTERに置換して、ループを止めない。
変更:
- tools/mep_auto_loop.ps1 の Read-Host 行を、MEP_AUTO_APPROVE=1 なら '' を返すラッパに置換。
- 通常運用(環境変数未設定)の挙動は不変。
確認:
- PR上で Required checks が通ったら merge（Ruleset正）→ main で MEP_AUTO_APPROVE=1 を付けて -Once 実行。