### PR TITLE
fix(v1.12): audit helper path + null-safe proofline snapshot

### DIFF
--- a/tools/mep_audit_writeback_v112.ps1
+++ b/tools/mep_audit_writeback_v112.ps1
@@ -1,7 +1,7 @@
 # v1.12 writeback audit (minimal): WIP-025/026 judge by canonical merge line only
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
-. "\mep_ssot_v112_lib.ps1"
+. "$PSScriptRoot\mep_ssot_v112_lib.ps1"
 param(
   [Parameter(Mandatory=$true)][int]$PrNumber
 )

--- a/tools/mep_snapshot_proofline_v112.ps1
+++ b/tools/mep_snapshot_proofline_v112.ps1
@@ -1,0 +1,22 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+param(
+  [Parameter(Mandatory=$true)][int]$PrNumber
+)
+$repoRoot = (git rev-parse --show-toplevel 2>$null).Trim()
+if (-not $repoRoot) { throw "Not a git repo" }
+$bundled = Join-Path $repoRoot "docs/MEP/MEP_BUNDLE.md"
+$evid    = Join-Path $repoRoot "docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md"
+$mergeSha = (gh pr view $PrNumber --json mergeCommit --jq '.mergeCommit.oid' 2>$null).Trim()
+if (-not $mergeSha) { throw "mergeCommit not found for PR #$PrNumber" }
+$rx = ('^{0}\s+Merge pull request #{1}\b' -f $mergeSha, $PrNumber)
+Write-Host ("MERGE_COMMIT_SHA " + $mergeSha)
+Write-Host ("PROOF_REGEX " + $rx)
+function FirstMatchLine([string]$path, [string]$pattern){
+  if (-not (Test-Path $path)) { return "<missing>" }
+  $m = Select-String -LiteralPath $path -Pattern $pattern | Select-Object -First 1
+  if ($null -eq $m) { return "<none>" }
+  return $m.Line
+}
+Write-Host ("PARENT_BUNDLED_MATCH " + (FirstMatchLine $bundled $rx))
+Write-Host ("EVIDENCE_BUNDLE_MATCH " + (FirstMatchLine $evid $rx))


### PR DESCRIPTION
背景:
- tools/mep_audit_writeback_v112.ps1 が . ""\mep_ssot_v112_lib.ps1"" を dot-source しており、実行時にルート相対として失敗。
- 証跡行の可視化（Select-String）も、マッチ0件時に .Line 参照で例外化していた。
修正:
- audit helper の dot-source を $PSScriptRoot 起点へ固定。
- マッチ0件でも落ちない proofline snapshot ユーティリティを追加（v1.12: ^<MERGE_COMMIT_SHA>\\s+Merge pull request #<PR_NUMBER>\\b）。