### PR TITLE
fix(audit): make mep_audit_writeback_v112 param() valid (move to top)

### DIFF
--- a/tools/mep_audit_writeback_v112.ps1
+++ b/tools/mep_audit_writeback_v112.ps1
@@ -1,10 +1,11 @@
+param(
+  [Parameter(Mandatory=$true)][int]$PrNumber
+)
+
 # v1.12 writeback audit (minimal): WIP-025/026 judge by canonical merge line only
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 . "$PSScriptRoot\mep_ssot_v112_lib.ps1"
-param(
-  [Parameter(Mandatory=$true)][int]$PrNumber
-)
 $repoRoot = (git rev-parse --show-toplevel 2>$null).Trim()
 if (-not $repoRoot){ throw 'Not a git repo' }
 $parent = Join-Path $repoRoot 'docs/MEP/MEP_BUNDLE.md'


### PR DESCRIPTION
目的:
- Pre-Gate が mep_audit_writeback_v112.ps1 実行で "param is not recognized" になり、PREGATE_FAIL_1 で AUTO が停止する。
原因:
- PowerShell の param(...) は「スクリプト先頭（コメントの直後）」に無いとキーワード扱いされず、コマンド扱いとなる。
対応:
- tools/mep_audit_writeback_v112.ps1 の param(...) ブロックを、先頭（先頭コメントの直後）へ移動してキーワードとして成立させる。
確認:
- tools/pre_gate.ps1 が exit 0 になる
- tools/mep_auto_loop.ps1 -Once が PREGATE_FAIL_1 で止まらない