### PR TITLE
fix(v1.12): param() must be top of script (audit/snapshot)

### DIFF
--- a/tools/mep_audit_writeback_v112.ps1
+++ b/tools/mep_audit_writeback_v112.ps1
@@ -1,10 +1,10 @@
 # v1.12 writeback audit (minimal): WIP-025/026 judge by canonical merge line only
-Set-StrictMode -Version Latest
-$ErrorActionPreference = 'Stop'
-. "$PSScriptRoot\mep_ssot_v112_lib.ps1"
 param(
   [Parameter(Mandatory=$true)][int]$PrNumber
 )
+# lib load (robust): do NOT rely on $PSScriptRoot
+$__scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+. (Join-Path $__scriptDir 'mep_ssot_v112_lib.ps1')
 $repoRoot = (git rev-parse --show-toplevel 2>$null).Trim()
 if (-not $repoRoot){ throw 'Not a git repo' }
 $parent = Join-Path $repoRoot 'docs/MEP/MEP_BUNDLE.md'

--- a/tools/mep_snapshot_proofline_v112.ps1
+++ b/tools/mep_snapshot_proofline_v112.ps1
@@ -1,5 +1,4 @@
-Set-StrictMode -Version Latest
-$ErrorActionPreference = 'Stop'
+
 param(
   [Parameter(Mandatory=$true)][int]$PrNumber
 )


### PR DESCRIPTION
原因:
- PowerShell の仕様で param() はスクリプト先頭（コメント/#requires以外の前）でないと無効。
- その結果 -PrNumber がバインドされず StrictMode で ' not set' になっていた。
修正:
- tools/mep_audit_writeback_v112.ps1 / tools/mep_snapshot_proofline_v112.ps1 を param() 最上段に正規化。
- audit 側 dot-source を $PSScriptRoot 起点に固定（再確認）。