### PR TITLE
fix(pregate): repair pre_gate pipeline corruption (unblock auto_loop)

### DIFF
--- a/tools/pre_gate.ps1
+++ b/tools/pre_gate.ps1
@@ -79,8 +79,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
   Where-Object {
     <#
 MEP Pre-Gate (入口の手前)
@@ -142,8 +140,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_pr_audit_merge.ps1' })
@@ -230,8 +226,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   }
@@ -316,8 +310,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   }
@@ -429,8 +421,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
   Where-Object {
     <#
 MEP Pre-Gate (入口の手前)
@@ -492,8 +482,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_pr_audit_merge.ps1' })
@@ -580,8 +568,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   }
@@ -666,8 +652,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   }
@@ -779,8 +763,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
   Where-Object {
     <#
 MEP Pre-Gate (入口の手前)
@@ -842,8 +824,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_pr_audit_merge.ps1' })
@@ -930,8 +910,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   }
@@ -1016,8 +994,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   }
@@ -1129,8 +1105,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
   Where-Object {
     <#
 MEP Pre-Gate (入口の手前)
@@ -1192,8 +1166,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_pr_audit_merge.ps1' })
@@ -1280,8 +1252,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   }
@@ -1366,8 +1336,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   }
@@ -1469,8 +1437,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
   Where-Object {
     <#
 MEP Pre-Gate (入口の手前)
@@ -1553,8 +1519,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
   Where-Object {
     <#
 MEP Pre-Gate (入口の手前)
@@ -1616,8 +1580,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_pr_audit_merge.ps1' })
@@ -1704,8 +1666,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   }
@@ -1790,8 +1750,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   }
@@ -1903,8 +1861,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
   Where-Object {
     <#
 MEP Pre-Gate (入口の手前)
@@ -1966,8 +1922,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_pr_audit_merge.ps1' })
@@ -2054,8 +2008,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   }
@@ -2140,8 +2092,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   }
@@ -2253,8 +2203,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
   Where-Object {
     <#
 MEP Pre-Gate (入口の手前)
@@ -2316,8 +2264,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_pr_audit_merge.ps1' })
@@ -2404,8 +2350,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   }
@@ -2490,8 +2434,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   }
@@ -2603,8 +2545,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
   Where-Object {
     <#
 MEP Pre-Gate (入口の手前)
@@ -2666,8 +2606,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_pr_audit_merge.ps1' })
@@ -2754,8 +2692,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   }
@@ -2840,8 +2776,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   }
@@ -2943,8 +2877,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_pr_audit_merge.ps1' })
@@ -3052,8 +2984,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
   Where-Object {
     <#
 MEP Pre-Gate (入口の手前)
@@ -3115,8 +3045,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_pr_audit_merge.ps1' })
@@ -3203,8 +3131,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   }
@@ -3289,8 +3215,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   }
@@ -3402,8 +3326,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
   Where-Object {
     <#
 MEP Pre-Gate (入口の手前)
@@ -3465,8 +3387,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_pr_audit_merge.ps1' })
@@ -3553,8 +3473,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   }
@@ -3639,8 +3557,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   }
@@ -3752,8 +3668,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
   Where-Object {
     <#
 MEP Pre-Gate (入口の手前)
@@ -3815,8 +3729,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_pr_audit_merge.ps1' })
@@ -3903,8 +3815,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   }
@@ -3989,8 +3899,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   }
@@ -4102,8 +4010,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
   Where-Object {
     <#
 MEP Pre-Gate (入口の手前)
@@ -4165,8 +4071,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_pr_audit_merge.ps1' })
@@ -4253,8 +4157,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   }
@@ -4339,8 +4241,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   }
@@ -4442,8 +4342,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   }
@@ -4549,8 +4447,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
   Where-Object {
     <#
 MEP Pre-Gate (入口の手前)
@@ -4612,8 +4508,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_pr_audit_merge.ps1' })
@@ -4700,8 +4594,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   }
@@ -4786,8 +4678,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   }
@@ -4899,8 +4789,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
   Where-Object {
     <#
 MEP Pre-Gate (入口の手前)
@@ -4962,8 +4850,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_pr_audit_merge.ps1' })
@@ -5050,8 +4936,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   }
@@ -5136,8 +5020,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   }
@@ -5249,8 +5131,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
   Where-Object {
     <#
 MEP Pre-Gate (入口の手前)
@@ -5312,8 +5192,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_pr_audit_merge.ps1' })
@@ -5400,8 +5278,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   }
@@ -5486,8 +5362,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   }
@@ -5599,8 +5473,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
   Where-Object {
     <#
 MEP Pre-Gate (入口の手前)
@@ -5662,8 +5534,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_pr_audit_merge.ps1' })
@@ -5750,8 +5620,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   }
@@ -5836,8 +5704,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   }
@@ -5939,8 +5805,6 @@ Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
   $candidates = @()
   if (Test-Path $toolsDir) {
     $candidates += Get-ChildItem -Path $toolsDir -File -Filter "*.ps1" |
-      # TEMP: exclude dispatch audit to unblock PREGATE_FAIL_1 (workflow_dispatch entrypoints drift is handled separately)
-  $candidates = @($candidates | Where-Object { $_.Name -ne 'mep_dispatch_audit.ps1' })
       Where-Object { $_.Name -match "mep_.*(audit|readonly)" -and $_.Name -notmatch "entry|pregate" } |
       Sort-Object Name
   }
@@ -5989,6 +5853,7 @@ if ($LASTEXITCODE -ne 0) {
 catch {
   Boom $_.Exception.Message
 }
+
 
 
 


### PR DESCRIPTION
目的:
- tools/pre_gate.ps1 が ParserError で壊れており、mep_auto_loop が PREGATE_FAIL_1 で停止するのを解消する。
原因（一次出力）:
- pipeline の途中に "$candidates = @($candidates | Where-Object ...)" が注入され、
  "Expressions are only allowed as the first element of a pipeline." で構文エラー。
対応:
- 壊れた注入行（および関連TEMPコメント）を全削除。
- 監査の一時除外（dispatch/writeback）は「パイプ外」の安全な位置（Sort-Object の直後）で適用。
注:
- dispatch/writeback 監査の“本修正”は別途（SSOT化/非対話化）で行う。