### PR TITLE
fix(pregate): repair pre_gate syntax corruption

### DIFF
--- a/tools/pre_gate.ps1
+++ b/tools/pre_gate.ps1
@@ -95,7 +95,7 @@ catch {
 }
 .Name -ne 'mep_audit_writeback_v112.ps1'not entry/pregate
   $candidates = @(Get-ChildItem -Path $tools -File -Filter *.ps1 |
-    Where-Object { $_.Name -match 'mep_.*(audit|readonly)' -a -and # MEP Pre-Gate (入口の手前) - minimal stable
+    Where-Object { $_.Name -match 'mep_.*(audit|readonly)' -and # MEP Pre-Gate (入口の手前) - minimal stable
 # exit 0: OK
 # exit 1: FAIL (tooling/bug)
 # exit 2: NG (state not suitable; approval / fixing required)
@@ -205,4 +205,5 @@ catch {
   Fail ("Boom: " + $_.Exception.Message)
   exit 1
 }
+
 


### PR DESCRIPTION
目的:
- tools/pre_gate.ps1 が構文エラー（Unexpected token '-a'）で実行不能になり、mep_auto_loop が PREGATE_FAIL_1 で停止するのを解消する。
対応:
- pre_gate.ps1 内に混入した壊れたトークン "-a -and" を "-and" に復旧し、PowerShell のパースが通る状態へ戻す。
確認:
- tools/pre_gate.ps1 が ParserError を出さずに実行できる
- main 反映後に tools/mep_auto_loop.ps1 -Once を再実行できる