### PR TITLE
feat(op1): canonical evidence/writeback dispatch entry

### DIFF
--- a/.github/workflows/mep_evidence_writeback_dispatch_entry.yml
+++ b/.github/workflows/mep_evidence_writeback_dispatch_entry.yml
@@ -1,0 +1,18 @@
+name: OP-1 Evidence Writeback (Dispatch Entry)
+on:
+  workflow_dispatch:
+permissions:
+  actions: write
+  contents: read
+jobs:
+  trigger_op1_target:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Trigger OP-1 target workflow
+        env:
+          GH_TOKEN: $${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          echo "TARGET_WORKFLOW_ID=225328600"
+          gh workflow run 225328600 -r main


### PR DESCRIPTION
OP-1 canonical entry:
- Adds: .github/workflows/mep_evidence_writeback_dispatch_entry.yml
- Triggers: workflow id=225328600 path=.github/workflows/mep_bump_bundle_version_dispatch.yml
- No manual edits to Bundled/EVIDENCE; updates happen only via workflow execution