### PR TITLE
fix(pregate): repair pre_gate syntax break ('-and #' -> valid)

### DIFF
--- a/tools/pre_gate.ps1
+++ b/tools/pre_gate.ps1
@@ -24,7 +24,7 @@ try {
   if ($status) { Warn "Working tree is dirty. Commit/stash before entering MEP."; exit 2 }
   $tools = Join-Path $root 'tools'
   if (-not (Test-Path -LiteralPath $tools)) { Fail ("Missing tools/: " + $tools); exit 1 }
-  # audit candidates: mep_*(audit|readonly) but  -and # MEP Pre-Gate (入口の手前) - minimal stable
+  # audit candidates: mep_*(audit|readonly) but  -and $true # MEP Pre-Gate (入口の手前) - minimal stable
 # exit 0: OK
 # exit 1: FAIL (tooling/bug)
 # exit 2: NG (state not suitable; approval / fixing required)
@@ -95,7 +95,7 @@ catch {
 }
 .Name -ne 'mep_audit_writeback_v112.ps1'not entry/pregate
   $candidates = @(Get-ChildItem -Path $tools -File -Filter *.ps1 |
-    Where-Object { $_.Name -match 'mep_.*(audit|readonly)' -and # MEP Pre-Gate (入口の手前) - minimal stable
+    Where-Object { $_.Name -match 'mep_.*(audit|readonly)' -and $_\.Name -notmatch 'entry|pregate' } # MEP Pre-Gate (入口の手前) - minimal stable
 # exit 0: OK
 # exit 1: FAIL (tooling/bug)
 # exit 2: NG (state not suitable; approval / fixing required)
@@ -205,5 +205,6 @@ catch {
   Fail ("Boom: " + $_.Exception.Message)
   exit 1
 }
+
 
 


### PR DESCRIPTION
目的:
- tools/pre_gate.ps1 が構文エラー（"-and" の右辺がコメントで消える）で exit=1 となり、mep_auto_loop が PREGATE_FAIL_1 で停止する問題を止める。
一次出力:
- pre_gate.ps1 が「You must provide a value expression following the '-and' operator.」を出す。
対応:
- Where-Object 行の壊れた "-and #" を、RHS を持つ安全な条件に復旧し、pre_gate を実行可能に戻す。
確認:
- PR の checks PASS → Ruleset 経由でマージ
- main で tools/pre_gate.ps1 が ParserError を出さない