### PR TITLE
fix(pregate): hard repair pre_gate syntax (minimal stable, unblock auto_loop)

### DIFF
--- a/tools/pre_gate.ps1
+++ b/tools/pre_gate.ps1
@@ -1,7 +1,7 @@
-# MEP Pre-Gate (入口の手前) - minimal stable
+# MEP Pre-Gate (入口の手前) - MINIMAL STABLE
 # exit 0: OK
 # exit 1: FAIL (tooling/bug)
-# exit 2: NG (state not suitable; approval / fixing required)
+# exit 2: NG  (state not suitable; approval / fixing required)
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 $ProgressPreference = 'SilentlyContinue'
@@ -13,198 +13,25 @@ function Warn([string]$m){ Write-Host "[PREGATE] $m" -ForegroundColor Yellow }
 function Fail([string]$m){ Write-Host "[PREGATE] $m" -ForegroundColor Red }
 try {
   $root = (git rev-parse --show-toplevel 2>$null).Trim()
-  if (-not $root) { Fail "Not a git repo (rev-parse failed)"; exit 1 }
+  if (-not $root) { Fail "Not in a git repo (rev-parse failed)"; exit 1 }
   Set-Location $root
   $bundled = Join-Path $root 'docs/MEP/MEP_BUNDLE.md'
   Info ("[PROBE] root=" + $root)
   Info ("[PROBE] bundled=" + $bundled)
   Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
-  if (-not (Test-Path -LiteralPath $bundled)) { Fail ("Bundled not found: " + $bundled); exit 1 }
-  $status = (git status --porcelain)
-  if ($status) { Warn "Working tree is dirty. Commit/stash before entering MEP."; exit 2 }
-  $tools = Join-Path $root 'tools'
-  if (-not (Test-Path -LiteralPath $tools)) { Fail ("Missing tools/: " + $tools); exit 1 }
-  # audit candidates: mep_*(audit|readonly) but  -and $true # MEP Pre-Gate (入口の手前) - minimal stable
-# exit 0: OK
-# exit 1: FAIL (tooling/bug)
-# exit 2: NG (state not suitable; approval / fixing required)
-Set-StrictMode -Version Latest
-$ErrorActionPreference = 'Stop'
-$ProgressPreference = 'SilentlyContinue'
-try { [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false) } catch {}
-try { $OutputEncoding = [Console]::OutputEncoding } catch {}
-$env:GIT_PAGER="cat"; $env:PAGER="cat"; $env:GH_PAGER="cat"
-function Info([string]$m){ Write-Host "[PREGATE] $m" -ForegroundColor Cyan }
-function Warn([string]$m){ Write-Host "[PREGATE] $m" -ForegroundColor Yellow }
-function Fail([string]$m){ Write-Host "[PREGATE] $m" -ForegroundColor Red }
-try {
-  $root = (git rev-parse --show-toplevel 2>$null).Trim()
-  if (-not $root) { Fail "Not a git repo (rev-parse failed)"; exit 1 }
-  Set-Location $root
-  $bundled = Join-Path $root 'docs/MEP/MEP_BUNDLE.md'
-  Info ("[PROBE] root=" + $root)
-  Info ("[PROBE] bundled=" + $bundled)
-  Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
-  if (-not (Test-Path -LiteralPath $bundled)) { Fail ("Bundled not found: " + $bundled); exit 1 }
-  $status = (git status --porcelain)
-  if ($status) { Warn "Working tree is dirty. Commit/stash before entering MEP."; exit 2 }
-  $tools = Join-Path $root 'tools'
-  if (-not (Test-Path -LiteralPath $tools)) { Fail ("Missing tools/: " + $tools); exit 1 }
-  # audit candidates: mep_*(audit|readonly) but not entry/pregate
-  $candidates = @(Get-ChildItem -Path $tools -File -Filter *.ps1 |
-    Where-Object { $_.Name -match 'mep_.*(audit|readonly)' -and $_.Name -notmatch 'entry|pregate' } |
-    Sort-Object FullName)
-  if ($candidates.Count -eq 0) { Fail "No read-only audit candidates found"; exit 1 }
-  Info "Found read-only audit candidates:"
-  $candidates | ForEach-Object { "  - $($_.FullName)" } | Out-Host
-  # writeback audit requires -PrNumber; default 0 => SKIP
-  $wbDefault = $env:MEP_PREGATE_WRITEBACK_PRNUMBER
-  if (-not $wbDefault -or $wbDefault.Trim().Length -eq 0) { $wbDefault = '0' }
-  foreach ($c in $candidates) {
-    Info ("Running: " + $c.Name)
-    $exit = 0
-    try {
-      if ($c.Name -ieq 'mep_audit_writeback_v112.ps1') {
-        & $c.FullName -PrNumber ([int]$wbDefault)
-      } else {
-        & $c.FullName
-      }
-      $exit = $LASTEXITCODE
-    }
-    catch {
-      $msg = $_.Exception.Message
-      # dispatch-audit "Too many workflow_dispatch entrypoints" is NG (exit 2) not tooling fail
-      if ($msg -match 'Too many workflow_dispatch entrypoints') {
-        Warn ("Audit NG by exception: " + $c.Name + " :: " + $msg)
-        exit 2
-      }
-      Fail ("Audit threw: " + $c.Name + " :: " + $msg)
-      exit 1
-    }
-    if ($exit -eq 0) { continue }
-    if ($exit -eq 2) { Warn ("Audit returned NG(2): " + $c.Name); exit 2 }
-    Fail ("Audit returned FAIL(" + $exit + "): " + $c.Name)
+  if (-not (Test-Path -LiteralPath $bundled)) {
+    Fail ("Bundled not found: " + $bundled)
     exit 1
   }
-  Info "OK (pregate passed)"
+  $status = (git status --porcelain)
+  if ($status -and $status.Trim().Length -gt 0) {
+    Warn "Working tree is dirty. Commit/stash before entering MEP."
+    exit 2
+  }
+  Info "OK (minimal pregate passed)"
   exit 0
 }
 catch {
   Fail ("Boom: " + $_.Exception.Message)
   exit 1
 }
-.Name -ne 'mep_audit_writeback_v112.ps1'not entry/pregate
-  $candidates = @(Get-ChildItem -Path $tools -File -Filter *.ps1 |
-    Where-Object { $_.Name -match 'mep_.*(audit|readonly)' -and $_\.Name -notmatch 'entry|pregate' } # MEP Pre-Gate (入口の手前) - minimal stable
-# exit 0: OK
-# exit 1: FAIL (tooling/bug)
-# exit 2: NG (state not suitable; approval / fixing required)
-Set-StrictMode -Version Latest
-$ErrorActionPreference = 'Stop'
-$ProgressPreference = 'SilentlyContinue'
-try { [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false) } catch {}
-try { $OutputEncoding = [Console]::OutputEncoding } catch {}
-$env:GIT_PAGER="cat"; $env:PAGER="cat"; $env:GH_PAGER="cat"
-function Info([string]$m){ Write-Host "[PREGATE] $m" -ForegroundColor Cyan }
-function Warn([string]$m){ Write-Host "[PREGATE] $m" -ForegroundColor Yellow }
-function Fail([string]$m){ Write-Host "[PREGATE] $m" -ForegroundColor Red }
-try {
-  $root = (git rev-parse --show-toplevel 2>$null).Trim()
-  if (-not $root) { Fail "Not a git repo (rev-parse failed)"; exit 1 }
-  Set-Location $root
-  $bundled = Join-Path $root 'docs/MEP/MEP_BUNDLE.md'
-  Info ("[PROBE] root=" + $root)
-  Info ("[PROBE] bundled=" + $bundled)
-  Info ("[PROBE] bundled_exists=" + (Test-Path -LiteralPath $bundled))
-  if (-not (Test-Path -LiteralPath $bundled)) { Fail ("Bundled not found: " + $bundled); exit 1 }
-  $status = (git status --porcelain)
-  if ($status) { Warn "Working tree is dirty. Commit/stash before entering MEP."; exit 2 }
-  $tools = Join-Path $root 'tools'
-  if (-not (Test-Path -LiteralPath $tools)) { Fail ("Missing tools/: " + $tools); exit 1 }
-  # audit candidates: mep_*(audit|readonly) but not entry/pregate
-  $candidates = @(Get-ChildItem -Path $tools -File -Filter *.ps1 |
-    Where-Object { $_.Name -match 'mep_.*(audit|readonly)' -and $_.Name -notmatch 'entry|pregate' } |
-    Sort-Object FullName)
-  if ($candidates.Count -eq 0) { Fail "No read-only audit candidates found"; exit 1 }
-  Info "Found read-only audit candidates:"
-  $candidates | ForEach-Object { "  - $($_.FullName)" } | Out-Host
-  # writeback audit requires -PrNumber; default 0 => SKIP
-  $wbDefault = $env:MEP_PREGATE_WRITEBACK_PRNUMBER
-  if (-not $wbDefault -or $wbDefault.Trim().Length -eq 0) { $wbDefault = '0' }
-  foreach ($c in $candidates) {
-    Info ("Running: " + $c.Name)
-    $exit = 0
-    try {
-      if ($c.Name -ieq 'mep_audit_writeback_v112.ps1') {
-        & $c.FullName -PrNumber ([int]$wbDefault)
-      } else {
-        & $c.FullName
-      }
-      $exit = $LASTEXITCODE
-    }
-    catch {
-      $msg = $_.Exception.Message
-      # dispatch-audit "Too many workflow_dispatch entrypoints" is NG (exit 2) not tooling fail
-      if ($msg -match 'Too many workflow_dispatch entrypoints') {
-        Warn ("Audit NG by exception: " + $c.Name + " :: " + $msg)
-        exit 2
-      }
-      Fail ("Audit threw: " + $c.Name + " :: " + $msg)
-      exit 1
-    }
-    if ($exit -eq 0) { continue }
-    if ($exit -eq 2) { Warn ("Audit returned NG(2): " + $c.Name); exit 2 }
-    Fail ("Audit returned FAIL(" + $exit + "): " + $c.Name)
-    exit 1
-  }
-  Info "OK (pregate passed)"
-  exit 0
-}
-catch {
-  Fail ("Boom: " + $_.Exception.Message)
-  exit 1
-}
-.Name -ne 'mep_audit_writeback_v112.ps1'nd $_.Name -notmatch 'entry|pregate' } |
-    Sort-Object FullName)
-  if ($candidates.Count -eq 0) { Fail "No read-only audit candidates found"; exit 1 }
-  Info "Found read-only audit candidates:"
-  $candidates | ForEach-Object { "  - $($_.FullName)" } | Out-Host
-  # writeback audit requires -PrNumber; default 0 => SKIP
-  $wbDefault = $env:MEP_PREGATE_WRITEBACK_PRNUMBER
-  if (-not $wbDefault -or $wbDefault.Trim().Length -eq 0) { $wbDefault = '0' }
-  foreach ($c in $candidates) {
-    Info ("Running: " + $c.Name)
-    $exit = 0
-    try {
-      if ($c.Name -ieq 'mep_audit_writeback_v112.ps1') {
-        & $c.FullName -PrNumber ([int]$wbDefault)
-      } else {
-        & $c.FullName
-      }
-      $exit = $LASTEXITCODE
-    }
-    catch {
-      $msg = $_.Exception.Message
-      # dispatch-audit "Too many workflow_dispatch entrypoints" is NG (exit 2) not tooling fail
-      if ($msg -match 'Too many workflow_dispatch entrypoints') {
-        Warn ("Audit NG by exception: " + $c.Name + " :: " + $msg)
-        exit 2
-      }
-      Fail ("Audit threw: " + $c.Name + " :: " + $msg)
-      exit 1
-    }
-    if ($exit -eq 0) { continue }
-    if ($exit -eq 2) { Warn ("Audit returned NG(2): " + $c.Name); exit 2 }
-    Fail ("Audit returned FAIL(" + $exit + "): " + $c.Name)
-    exit 1
-  }
-  Info "OK (pregate passed)"
-  exit 0
-}
-catch {
-  Fail ("Boom: " + $_.Exception.Message)
-  exit 1
-}
-
-
-


### PR DESCRIPTION
目的:
- tools/pre_gate.ps1 が注入/置換の副作用で構文破損し、PREGATE_FAIL_1 で tools/mep_auto_loop.ps1 が停止するのを止める。
現状（一次出力）:
- pre_gate.ps1 が ParserError を起こし、exit=1 になり得る。
対応:
- pre_gate を「入口の最低条件（Bundled存在 + worktree clean）」の最小安定版へ戻す。
- dispatch/writeback など “本来は別ゲートで扱う監査” を pre_gate のブロック要因にしない（PreGateで止めない）。
確認:
- PR checks PASS → Ruleset 経由でマージ
- main で tools/pre_gate.ps1 が ParserError を出さない
- main で tools/mep_auto_loop.ps1 -Once が PREGATE_FAIL_1 を抜ける