### PR TITLE
fix(evidence): append evidence lines for PR #1948

### DIFF
--- a/docs/MEP/MEP_BUNDLE.md
+++ b/docs/MEP/MEP_BUNDLE.md
@@ -1204,3 +1204,7 @@ e569fa490ef10efdc587c055715515cf4a8ba3ff Merge pull request #1898
   - EVIDENCE_BUNDLE_LAST_COMMIT（83816cba638e4dc8230d4f60cfa02b9374389118）
 - **アクション**: 今回の「子EVIDENCE追随破損→回復」事例をBundledに追加し、再発防止ルールを固定
 ---
+
+* - PR #1948 | mergedAt=02/08/2026 11:06:29 | mergeCommit=878ea8a0f81f84e27dc29aa971fd2c87f7f718a6 | BUNDLE_VERSION=v0.0.0+20260204_042728+main_34b5a6e0 | audit=OK,WB0000 | https://github.com/Osuu-ops/yorisoidou-system/pull/1948
+PR #1948 | audit=OK,WB0000 | appended_at=2026-02-08T11:21:54.2741312+00:00 | via=mep_append_evidence_line_full.ps1
+

--- a/docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md
+++ b/docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md
@@ -114,3 +114,6 @@ PR #1916 | audit=OK,WB0000 | appended_at=2026-02-08T10:33:50.1137989+00:00 | via
 * - PR #1921 | mergedAt=02/07/2026 09:21:59 | mergeCommit=208b100e8198cd0d2aad18db2cdd788816d1147a | BUNDLE_VERSION=v0.0.0+20260204_035621+main+evidence-child | audit=OK,WB0000 | https://github.com/Osuu-ops/yorisoidou-system/pull/1921
 PR #1921 | audit=OK,WB0000 | appended_at=2026-02-08T10:33:50.1137989+00:00 | via=mep_append_evidence_line_full.ps1
 
+* - PR #1948 | mergedAt=02/08/2026 11:06:29 | mergeCommit=878ea8a0f81f84e27dc29aa971fd2c87f7f718a6 | BUNDLE_VERSION=v0.0.0+20260204_042728+main_34b5a6e0 | audit=OK,WB0000 | https://github.com/Osuu-ops/yorisoidou-system/pull/1948
+PR #1948 | audit=OK,WB0000 | appended_at=2026-02-08T11:21:54.2741312+00:00 | via=mep_append_evidence_line_full.ps1
+


### PR DESCRIPTION
Append SSOT-format evidence lines (audit=OK,WB0000 + appended_at + via) for PR #1948 to:
- docs/MEP/MEP_BUNDLE.md
- docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md
Source of truth: PR mergeCommit=878ea8a0f81f84e27dc29aa971fd2c87f7f718a6, mergedAt=02/08/2026 11:06:29, url=https://github.com/Osuu-ops/yorisoidou-system/pull/1948