### PR TITLE
fix(op2): lock Q153 pr_creator_allowlist + TRIGGER_ACTOR_OK

### DIFF
--- a/docs/MEP/MEP_SSOT_MASTER.md
+++ b/docs/MEP/MEP_SSOT_MASTER.md
@@ -455,6 +455,19 @@
     * 一意でない場合は `stop_kind=HARD` かつ `stop_class=MACHINE_ONLY` → 環境/主体復旧RECOVERY起票
   * Relates to: Q79, Q88, Q117
 
+
+  * pr_creator_allowlist[]（一次根拠でAUTO補完・固定）:
+    * actor_login: Osuu-ops
+      actor_type: Organization
+      evidence_pr: #1950
+      evidence_merge_commit: 091ca0f2bea764d59cc99473d1d27c50dd01e138
+      evidence_merged_at: 2026-02-08T13:41:29+09:00
+      updated_at: 2026-02-08T23:18:28+09:00
+
+  * TRIGGER_ACTOR_OK（固定）:
+    * if PR.author.login == 'Osuu-ops' then OK
+    * else NG（stop_kind=HARD / stop_class=MACHINE_ONLY）
+
 * **Q154（Adopted）**：`SSOT_VERSION` の定義を固定する（再開パケットのブレ防止）。
 
   * `SSOT_VERSION` は `PARENT_BUNDLE_VERSION` を正とする。


### PR DESCRIPTION
OP-2 / Q153: pr_creator_allowlist を一次根拠（直近成功PR）から確定し、TRIGGER_ACTOR_OK を一意化。
Evidence (primary):
- PR #1950
- mergedAt: 2026-02-08T13:41:29+09:00
- mergeCommit: 091ca0f2bea764d59cc99473d1d27c50dd01e138
- author.login: Osuu-ops
Change:
- docs/MEP/MEP_SSOT_MASTER.md (Q153) に pr_creator_allowlist[] を追記
- TRIGGER_ACTOR_OK 判定を 'Osuu-ops' に固定