### PR TITLE
fix: apply writeback bundle changes from PR #1956 via normal PR

### DIFF
--- a/docs/MEP/MEP_BUNDLE.md
+++ b/docs/MEP/MEP_BUNDLE.md
@@ -1,7 +1,7 @@
 PARENT_BUNDLE_VERSION
 v0.0.0+20260204_042728+main_34b5a6e0
 
-BUNDLE_VERSION = v0.0.0+20260206_191703+main_f733f7c
+BUNDLE_VERSION = v0.0.0+20260208_181659+main_0d8637e
 BUNDLED_AT = 2026-02-02T04:05:55+0900
 OPS: Bundled writeback is executed via workflow_dispatch (mep_writeback_bundle_dispatch); local runs are for debugging only.
 # MEP_BUNDLE
@@ -1208,3 +1208,5 @@ e569fa490ef10efdc587c055715515cf4a8ba3ff Merge pull request #1898
 * - PR #1948 | mergedAt=02/08/2026 11:06:29 | mergeCommit=878ea8a0f81f84e27dc29aa971fd2c87f7f718a6 | BUNDLE_VERSION=v0.0.0+20260204_042728+main_34b5a6e0 | audit=OK,WB0000 | https://github.com/Osuu-ops/yorisoidou-system/pull/1948
 PR #1948 | audit=OK,WB0000 | appended_at=2026-02-08T11:21:54.2741312+00:00 | via=mep_append_evidence_line_full.ps1
 
+* - PR #1952 | mergedAt=02/08/2026 15:27:51 | mergeCommit=9f399007b66aad3dd96c4928fde467ddf91f27c2 | BUNDLE_VERSION=v0.0.0+20260208_181659+main_0d8637e | audit=OK,WB0000 | https://github.com/Osuu-ops/yorisoidou-system/pull/1952
+PR #1952 | audit=OK,WB0000 | appended_at=2026-02-08T18:17:02.5931387+00:00 | via=mep_append_evidence_line_full.ps1


### PR DESCRIPTION
This PR reapplies the changes from PR #1956 (auto/writeback-bundle) via a normal PR so required checks run and it can be merged under branch policy.