### PR TITLE
fix(op1): allow writeback noop file in writeback-required-checks

### DIFF
--- a/.github/workflows/writeback_required_checks.yml
+++ b/.github/workflows/writeback_required_checks.yml
@@ -22,7 +22,7 @@ jobs:
           head="${{ github.sha }}"
           files="$(git diff --name-only "$base" "$head" || true)"
           echo "$files"
-          bad="$(echo "$files" | awk 'NF' | grep -v '^docs/MEP/MEP_BUNDLE\.md$' || true)"
+          bad="$(echo "$files" | awk 'NF' | grep -Ev '^(docs/MEP/MEP_BUNDLE\.md|docs/MEP/runbook/\.noop_writeback_pr.*)$' # ALLOW_NOOP_WRITEBACK_MARKER || true)"
           if [ -n "$bad" ]; then
             echo "[NG] unexpected changed files:"
             echo "$bad"


### PR DESCRIPTION
OP-1 completion: writeback PRs may contain retrigger noop files (docs/MEP/runbook/.noop_writeback_pr*). Allowlist it in writeback_required_checks.yml to avoid automation deadlock.