### PR TITLE
fix(op1): allow writeback noop files in writeback-required-checks (line26)

### DIFF
--- a/.github/workflows/writeback_required_checks.yml
+++ b/.github/workflows/writeback_required_checks.yml
@@ -23,7 +23,7 @@ jobs:
           git fetch origin main --prune || true
           files="$(git diff --name-only origin/main...HEAD || true)"
           echo "$files"
-          bad="$(echo "$files" | awk 'NF' | grep -v '^docs/MEP/MEP_BUNDLE\.md$' || true)"
+          bad="$(echo "$files" | awk 'NF' | grep -Ev '^(docs/MEP/MEP_BUNDLE\.md|docs/MEP/runbook/\.noop_writeback_pr.*)$' || true)" # ALLOW_NOOP_WRITEBACK_MARKER
           if [ -n "$bad" ]; then
             echo "[NG] unexpected changed files:"
             echo "$bad"


### PR DESCRIPTION
OP-1 completion: scope_guard allowlist must include docs/MEP/runbook/.noop_writeback_pr* in addition to docs/MEP/MEP_BUNDLE.md.