### PR TITLE
docs(mep): OP-1 self-converge runbook (desync/no_checks/behind)

### DIFF
--- a/docs/MEP/OP1_SELF_CONVERGE_RUNBOOK.md
+++ b/docs/MEP/OP1_SELF_CONVERGE_RUNBOOK.md
@@ -1,0 +1,36 @@
+# OP-1 RUNBOOK | Self-Converge (EVIDENCE follow / writeback)
+This document is the primary evidence for OP-1 self-converge behavior.
+Goal: even when PR observation breaks (DESYNC / NO_CHECKS / BEHIND / merge blocked), the system converges by deterministic recovery actions.
+---
+## 0. Scope
+Applies to automation PRs (writeback / bundle / evidence follow) targeting base=main.
+---
+## 1. Observation (MUST)
+For a target PR:
+- Record: PR number/url, headRefName, headRefOid
+- Record: remote branch ref OID (git ls-remote origin refs/heads/<headRefName>)
+- Record: checks snapshot (gh pr checks)
+---
+## 2. Recovery Rules (Deterministic)
+### 2-1. DESYNC (headRefOid != remote ref OID)
+- Action: REISSUE (create a new PR from current branch ref)
+- Rationale: old PR is pinned to stale run/observation; reissue restores correct observation.
+### 2-2. NO_CHECKS (gh pr checks => "no checks reported")
+Try in order:
+1) Push head ref (may trigger CI if branch has new commits)
+2) If still NO_CHECKS: create an empty commit and push (force CI)
+3) If still NO_CHECKS: REISSUE
+Observed evidence: NO_CHECKS persisted after push/empty-commit but was resolved by REISSUE (PR #1987).
+### 2-3. BEHIND (branch behind origin/main)
+- Action: merge origin/main into head branch and push
+- Then: observe checks again
+### 2-4. Merge blocked (policy/permission/required checks)
+- Action: set auto-merge (squash) best-effort
+- If still blocked: STOP with resume packet (human action required)
+---
+## 3. Output (Resume Packet)
+For each converge attempt, output a Resume Packet (append-only):
+- HEAD(main)
+- PR info (number/url/headRefName/headRefOid/remoteRefOid)
+- STOP code/state, reason, next
+- checks snapshot

--- a/docs/MEP/cards/OP1_SELF_CONVERGE_CARD.md
+++ b/docs/MEP/cards/OP1_SELF_CONVERGE_CARD.md
@@ -1,0 +1,9 @@
+# CARD | OP-1 Self-Converge
+## Observe (MUST)
+- PR headRefOid vs remote ref OID
+- gh pr checks snapshot
+## Recover
+- DESYNC -> REISSUE
+- NO_CHECKS -> push -> empty commit -> REISSUE
+- BEHIND -> merge main into branch -> push
+- Merge blocked -> set auto-merge -> if blocked then STOP with resume packet


### PR DESCRIPTION
OP-1: Fix self-converge behavior as primary evidence.
- Deterministic recovery for DESYNC / NO_CHECKS / BEHIND / merge blocked
- Includes observed rule: NO_CHECKS resolved by REISSUE (e.g., PR #1987)
Purpose: make writeback/evidence follow loop "hands-off" by standardizing recovery actions and resume packet output.