### PR TITLE
feat(mep): runner auto-recovers NO_CHECKS (push/empty/reissue)

### DIFF
--- a/docs/MEP/FINAL_AUTORUN_RUNBOOK.md
+++ b/docs/MEP/FINAL_AUTORUN_RUNBOOK.md
@@ -29,3 +29,7 @@ NOTE: This runner intentionally does NOT bypass policies. It drives the loop usi
 - Confirm: HEAD(main)=5e8dcc3252dc071b4da08e4911af8355270c3874
 
 
+
+## NO_CHECKS auto-recovery
+- Runner now performs: push -> empty commit -> REISSUE automatically, then sets auto-merge when checks are visible.
+


### PR DESCRIPTION
Upgrade full-auto runner to be fully hands-off for NO_CHECKS:
- Detect NO_CHECKS -> push -> empty commit -> REISSUE automatically
- Close old PR as reissued, continue on new PR
- Re-check checks and proceed to auto-merge
Also adds a short note to FINAL_AUTORUN_RUNBOOK (if present).