### PR TITLE
feat(mep): add scheduled autorun dispatcher (daily)

### DIFF
--- a/.github/workflows/mep_autorun_schedule.yml
+++ b/.github/workflows/mep_autorun_schedule.yml
@@ -1,0 +1,22 @@
+name: MEP Autorun (Scheduled)
+on:
+  schedule:
+    - cron: "15 0 * * *"   # daily at 00:15 UTC
+  workflow_dispatch:
+concurrency:
+  group: mep-autorun-scheduled
+  cancel-in-progress: false
+permissions:
+  actions: write
+  contents: read
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch canonical writeback workflow (id=218580147) on main
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api -X POST \
+            repos/${{ github.repository }}/actions/workflows/218580147/dispatches \
+            -f ref=main


### PR DESCRIPTION
Add a scheduled GitHub Actions workflow that dispatches the canonical writeback workflow (id=218580147) on main.
- Runs daily (00:15 UTC) + supports manual workflow_dispatch
- Uses GH API via gh cli and GITHUB_TOKEN
- No inputs are sent (pr_number causes HTTP 422 on dispatch)
This is the first step toward hands-off periodic autorun.