### PR TITLE
fix(entry): place copypaste job under jobs

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch_entry.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch_entry.yml
@@ -15,6 +15,39 @@ permissions:
   contents: write
   pull-requests: write
 jobs:
+  mep_emit_copypaste_zone:
+    name: "MEP Emit Copypaste Zone"
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Emit MEP_COPYPASTE_ZONE
+        shell: bash
+        run: |
+          echo "===== MEP_COPYPASTE_ZONE BEGIN ====="
+          echo "RESTART_PACKET"
+          echo "RUN_ID=${GITHUB_RUN_ID}"
+          echo "TIMESTAMP=$(date -Iseconds)"
+          echo "RUN_INTENT=EMIT_COPYPASTE_ZONE"
+          echo "RUN_STATE_CODE=RUNNING"
+          echo "MODE=CHECK"
+          echo "NOW_WIP=EMIT_COPYPASTE_ZONE"
+          echo "MICRO_POS=14/14"
+          echo "ROUTE_SET_VERSION=RSV1"
+          echo "MACRO_POS=NORMAL(0/0) RECHECK(0/0) RECOVERY(0/0)"
+          echo "MACRO_PERCENT=0"
+          echo "STABILITY=OK"
+          echo "STOP_KIND="
+          echo "STOP_REASON_CODE="
+          echo "STOP_REASON="
+          echo "NEXT_ACTION=PASTE_ZONE_TO_CHAT"
+          echo "ENV_STATE_SNAPSHOT"
+          echo "REPO_ORIGIN=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
+          echo "BRANCH=${GITHUB_REF_NAME}"
+          echo "HEAD_SHA=${GITHUB_SHA}"
+          echo "SSOT_VERSION=UNKNOWN"
+          echo "WINDOW_RULE: NOW(-80,+160)"
+          echo "ZONE_COMPLETE: YES"
+          echo "===== MEP_COPYPASTE_ZONE END ====="
   writeback:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Removes any mis-inserted mep_emit_copypaste_zone under steps and adds it as a sibling job under jobs:.