### PR TITLE
fix(actions): refresh workflow registry (temporary push trigger)

### DIFF
--- a/.github/workflows/mep_loop_engine_v2.yml
+++ b/.github/workflows/mep_loop_engine_v2.yml
@@ -1,5 +1,7 @@
 name: MEP Loop Engine v2
 on:
+  push:
+    branches: [ main ]
   workflow_dispatch:
     inputs:
       iter:


### PR DESCRIPTION
GitHub API returns 422 'workflow_dispatch missing' despite YAML containing it. This PR adds a temporary push trigger to force workflow re-registration. After dispatch works, we will remove push again.