### PR TITLE
fix(actions): quote "on" key in engine_v2 workflow

### DIFF
--- a/.github/workflows/mep_loop_engine_v2.yml
+++ b/.github/workflows/mep_loop_engine_v2.yml
@@ -1,5 +1,5 @@
 name: MEP Loop Engine v2 (push-loop)
-on:
+"on":
   push:
     branches: [ main ]
     paths:


### PR DESCRIPTION
Engine v2 run fails with workflow file issue and no jobs. Quote the on-key to avoid YAML reserved-word parsing issues.