### PR TITLE
chore(diff): touch bundle for writeback 20260213_014510

### DIFF
--- a/docs/MEP/MEP_BUNDLE.md
+++ b/docs/MEP/MEP_BUNDLE.md
@@ -1236,3 +1236,5 @@ PR #2020 | audit=OK,WB0000 | appended_at=2026-02-11T14:42:40.4483272+00:00 | via
 PR #2028 | audit=OK,WB0000 | appended_at=2026-02-11T14:52:43.5809591+00:00 | via=mep_append_evidence_line_full.ps1
 * - PR #2034 | mergedAt=02/11/2026 16:32:26 | mergeCommit=b877a708c83d28b9147835a07e1607e75a052d14 | BUNDLE_VERSION=v0.0.0+20260211_163313+main_b877a70 | audit=OK,WB0000 | https://github.com/Osuu-ops/yorisoidou-system/pull/2034
 PR #2034 | audit=OK,WB0000 | appended_at=2026-02-11T16:33:15.6855048+00:00 | via=mep_append_evidence_line_full.ps1
+
+<!-- mep-diff-touch 2026-02-13T01:45:10+09:00 -->


### PR DESCRIPTION
Deterministic diff targeted to BundlePath (docs/MEP/MEP_BUNDLE.md) so engine_v2 phase3 sees changes and does non-NOOP PR-create.