### PR TITLE
fix(engine_v2): force diff before create_pr when clean 20260213_015224

### DIFF
--- a/.github/workflows/mep_loop_engine_v2.yml
+++ b/.github/workflows/mep_loop_engine_v2.yml
@@ -85,10 +85,21 @@ jobs:
           Set-StrictMode -Version Latest
           $ErrorActionPreference = "Stop"
           $porc = (git status --porcelain | Out-String).Trim()
-          if([string]::IsNullOrWhiteSpace($porc)){
-            Write-Host "PHASE3_CREATE_PR_NOOP (no changes)"
-            exit 0
-          }
+if([string]::IsNullOrWhiteSpace($porc)){
+  # FORCE-DIFF: create_pr 手前で clean なら差分を生成して stage（PR作成を確実にする）
+  $p = "docs/MEP_SUB/HEALTH/engine_v2_force_diff.txt"
+  $d = Split-Path -Parent $p
+  if(-not (Test-Path -LiteralPath $d)){ New-Item -ItemType Directory -Path $d -Force | Out-Null }
+  ("force-diff {0} run_id={1} sha={2}" -f (Get-Date).ToString("yyyy-MM-ddTHH:mm:ssK"), $env:GITHUB_RUN_ID, (git rev-parse HEAD)) | Out-File -LiteralPath $p -Encoding UTF8
+  git add $p | Out-Null
+  $porc = (git status --porcelain | Out-String).Trim()
+  if([string]::IsNullOrWhiteSpace($porc)){
+    Write-Host "PHASE3_CREATE_PR_NOOP (no changes)"
+    exit 0
+  } else {
+    Write-Host "PHASE3_CREATE_PR_FORCED_DIFF (staged)"
+  }
+}
           Write-Host "PHASE3_CREATE_PR_START"
           if(-not (Test-Path -LiteralPath "tools/mep_writeback_create_pr.ps1")){ throw "missing tools/mep_writeback_create_pr.ps1" }
           ./tools/mep_writeback_create_pr.ps1 -BundlePath docs/MEP/MEP_BUNDLE.md


### PR DESCRIPTION
Purpose:
- engine_v2 success but PHASE3_CREATE_PR_NOOP keeps happening because workspace is clean at create_pr time.
- Add deterministic, low-impact force-diff in PHASE3_CREATE_PR: when git status is clean, generate + stage docs/MEP_SUB/HEALTH/engine_v2_force_diff.txt, then re-check.
- If still clean => NOOP. If dirty => proceed to create PR.
This change is PR-only compliant and is intended to enable Next工程A (差分強制発生→PR作成) reliably.