### PR TITLE
fix(engine_v2): force diff safely via helper script 20260213_021030

### DIFF
--- a/.github/workflows/mep_loop_engine_v2.yml
+++ b/.github/workflows/mep_loop_engine_v2.yml
@@ -85,10 +85,19 @@ jobs:
           Set-StrictMode -Version Latest
           $ErrorActionPreference = "Stop"
           $porc = (git status --porcelain | Out-String).Trim()
-          if([string]::IsNullOrWhiteSpace($porc)){
-            Write-Host "PHASE3_CREATE_PR_NOOP (no changes)"
-            exit 0
-          }
+if([string]::IsNullOrWhiteSpace($porc)){
+  # FORCE-DIFF (safe): generate+stage a marker file, then re-check porcelain
+  if(Test-Path -LiteralPath "tools/mep_force_diff_if_clean.ps1"){
+    ./tools/mep_force_diff_if_clean.ps1 -MarkerPath "docs/MEP_SUB/HEALTH/engine_v2_force_diff.txt"
+  } else {
+    Write-Host "FORCE_DIFF_HELPER_MISSING"
+  }
+  $porc = (git status --porcelain | Out-String).Trim()
+}
+if([string]::IsNullOrWhiteSpace($porc)){
+  Write-Host "PHASE3_CREATE_PR_NOOP (no changes)"
+  exit 0
+}
           Write-Host "PHASE3_CREATE_PR_START"
           if(-not (Test-Path -LiteralPath "tools/mep_writeback_create_pr.ps1")){ throw "missing tools/mep_writeback_create_pr.ps1" }
           ./tools/mep_writeback_create_pr.ps1 -BundlePath docs/MEP/MEP_BUNDLE.md
@@ -101,3 +110,4 @@ jobs:
           if-no-files-found: error
       - name: Smoke
         run: echo "ENGINE_V2_PHASE3_OK"
+

--- a/tools/mep_force_diff_if_clean.ps1
+++ b/tools/mep_force_diff_if_clean.ps1
@@ -1,0 +1,28 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+param(
+  [string]$MarkerPath = "docs/MEP_SUB/HEALTH/engine_v2_force_diff.txt"
+)
+$porc = (git status --porcelain | Out-String).Trim()
+if(-not [string]::IsNullOrWhiteSpace($porc)){
+  Write-Host "FORCE_DIFF_SKIP (workspace dirty)"
+  exit 0
+}
+$dir = Split-Path -Parent $MarkerPath
+if(-not [string]::IsNullOrWhiteSpace($dir) -and -not (Test-Path -LiteralPath $dir)){
+  New-Item -ItemType Directory -Path $dir -Force | Out-Null
+}
+$runId = $env:GITHUB_RUN_ID
+if([string]::IsNullOrWhiteSpace($runId)){ $runId = "unknown" }
+$sha = (git rev-parse HEAD 2>$null)
+if([string]::IsNullOrWhiteSpace($sha)){ $sha = "unknown" }
+("force-diff {0} run_id={1} sha={2}" -f (Get-Date).ToString("yyyy-MM-ddTHH:mm:ssK"), $runId, $sha) |
+  Out-File -LiteralPath $MarkerPath -Encoding UTF8
+git add $MarkerPath | Out-Null
+$porc2 = (git status --porcelain | Out-String).Trim()
+if([string]::IsNullOrWhiteSpace($porc2)){
+  Write-Host "FORCE_DIFF_FAILED (still clean)"
+  exit 0
+}
+Write-Host "FORCE_DIFF_OK (staged)"
+exit 0


### PR DESCRIPTION
Purpose:
- engine_v2 can be success+restart-packet but keep emitting PHASE3_CREATE_PR_NOOP (no changes), preventing writeback PR creation.
- Reintroduce force-diff in a safer way: add a helper script and call it from PHASE3_CREATE_PR when workspace is clean, then re-check status.
Notes:
- Avoid brittle YAML block rewrites; keep workflow change minimal.