### PR TITLE
feat(issueops): add /mep run bootstrap workflow and agent

### DIFF
--- a/.github/workflows/mep_issueops_run.yml
+++ b/.github/workflows/mep_issueops_run.yml
@@ -1,0 +1,42 @@
+name: mep_issueops_run
+
+on:
+  issue_comment:
+    types: [created]
+  issues:
+    types: [edited]
+  pull_request:
+    paths:
+      - '.github/workflows/mep_issueops_run.yml'
+      - 'tools/agent/issueops.py'
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  issueops_run:
+    if: >-
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request == null) ||
+      (github.event_name == 'issues')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Run IssueOps bootstrap
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: python tools/agent/issueops.py

--- a/tools/agent/issueops.py
+++ b/tools/agent/issueops.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+import datetime as dt
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+RUN_STATE_PATH = ROOT / "mep/run_state.json"
+STATUS_PATH = ROOT / "docs/MEP/STATUS.md"
+AUDIT_PATH = ROOT / "docs/MEP/HANDOFF_AUDIT.md"
+WORK_PATH = ROOT / "docs/MEP/HANDOFF_WORK.md"
+INBOX_DIR = ROOT / "mep/inbox"
+
+
+def run(cmd):
+    return subprocess.run(cmd, check=True, text=True, capture_output=True)
+
+
+def utc_now():
+    return dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def canonicalize(text: str) -> str:
+    return text.replace("\r\n", "\n").replace("\r", "\n").strip()
+
+
+def calc_run_id(canonical_draft: str) -> str:
+    h = hashlib.sha256(canonical_draft.encode("utf-8")).hexdigest()[:12]
+    return f"RUN_{h}"
+
+
+def gh_json(args):
+    completed = run(["gh", "api", *args])
+    return json.loads(completed.stdout)
+
+
+def load_event():
+    event_path = os.environ["GITHUB_EVENT_PATH"]
+    with open(event_path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def should_run(issue, latest_comment_body):
+    body_trimmed = (issue.get("body") or "").strip()
+    body_trigger = body_trimmed.endswith("/mep run")
+    comment_trigger = "/mep run" in (latest_comment_body or "")
+    return body_trigger or comment_trigger
+
+
+def fetch_latest_comment(repo, issue_number):
+    comments = gh_json([f"repos/{repo}/issues/{issue_number}/comments", "--paginate", "-f", "per_page=1", "-f", "page=1"])
+    if comments:
+        return comments[-1].get("body") or ""
+    return ""
+
+
+def update_run_state(run_id, outcome, reason_code, next_action, workflow_run_url, pr_url):
+    now = utc_now()
+    state = {}
+    if RUN_STATE_PATH.exists():
+        state = json.loads(RUN_STATE_PATH.read_text(encoding="utf-8"))
+
+    state["run_id"] = run_id
+    state["run_status"] = "STILL_OPEN" if outcome == "PASS" else "STOPPED"
+    state["next_action"] = next_action
+    state["last_result"] = {
+        "stop_class": "" if outcome == "PASS" else outcome,
+        "reason_code": reason_code,
+        "next_action": next_action,
+        "timestamp_utc": now,
+        "action": {"name": "ISSUEOPS_BOOT", "outcome": "OK" if outcome == "PASS" else "NG"},
+        "evidence": {
+            "branch_name": f"mep/issueops-run-{run_id.lower()}",
+            "pr_url": pr_url,
+            "commit_sha": None,
+            "workflow_run_url": workflow_run_url,
+        },
+    }
+    state["updated_at"] = now
+    RUN_STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    RUN_STATE_PATH.write_text(json.dumps(state, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    STATUS_PATH.write_text(
+        "\n".join([
+            "# STATUS",
+            "",
+            f"RUN_ID: {run_id}",
+            "",
+            "RUN_STATUS: STILL_OPEN" if outcome == "PASS" else "RUN_STATUS: STOPPED",
+            "",
+            f"STOP_CLASS: {'' if outcome == 'PASS' else outcome}",
+            "",
+            f"REASON_CODE: {reason_code}",
+            "",
+            f"NEXT_ACTION: {next_action}",
+            "",
+            f"TIMESTAMP_UTC: {now}",
+            "",
+            "EVIDENCE:",
+            f"- pr_url: {pr_url or ''}",
+            f"- workflow_run_url: {workflow_run_url or ''}",
+            "",
+        ]),
+        encoding="utf-8",
+    )
+
+    AUDIT_PATH.write_text(
+        "\n".join([
+            "# HANDOFF_AUDIT",
+            "",
+            "SSOT_PATHS:",
+            "- mep/run_state.json",
+            "- mep/inbox/",
+            "- docs/MEP/STATUS.md",
+            "",
+            "LATEST_EVIDENCE_POINTERS:",
+            f"- pr_url: {pr_url or ''}",
+            "- commit_sha: ",
+            f"- workflow_run_url: {workflow_run_url or ''}",
+            "",
+        ]),
+        encoding="utf-8",
+    )
+
+    WORK_PATH.write_text(
+        "\n".join([
+            "# HANDOFF_WORK",
+            "",
+            f"NEXT_ACTION: {next_action}",
+            f"REASON_CODE: {reason_code}",
+            f"STOP_CLASS: {'' if outcome == 'PASS' else outcome}",
+            "",
+        ]),
+        encoding="utf-8",
+    )
+
+
+def write_draft(run_id, issue_body):
+    canonical = canonicalize(issue_body)
+    INBOX_DIR.mkdir(parents=True, exist_ok=True)
+    p = INBOX_DIR / f"draft_{run_id}.md"
+    p.write_text(canonical + "\n", encoding="utf-8")
+
+
+def git_pr_flow(repo, run_id, issue_number):
+    branch = f"mep/issueops-run-{run_id.lower()}"
+    run(["git", "checkout", "-b", branch])
+    run(["git", "add", "mep/inbox", "mep/run_state.json", "docs/MEP/STATUS.md", "docs/MEP/HANDOFF_AUDIT.md", "docs/MEP/HANDOFF_WORK.md"])
+    run(["git", "commit", "-m", f"chore(mep): issueops intake {run_id} (issue #{issue_number})"])
+    run(["git", "push", "-u", "origin", branch])
+    pr = run([
+        "gh", "pr", "create",
+        "--repo", repo,
+        "--base", "main",
+        "--head", branch,
+        "--title", f"chore(mep): IssueOps intake {run_id}",
+        "--body", f"Auto-generated by IssueOps from issue #{issue_number}.\n\n- run_id: {run_id}\n",
+    ])
+    return pr.stdout.strip(), branch
+
+
+def post_issue_comment(repo, issue_number, run_id, outcome, reason_code, next_action, pr_url):
+    workflow_run_url = f"{os.environ.get('GITHUB_SERVER_URL','https://github.com')}/{repo}/actions/runs/{os.environ.get('GITHUB_RUN_ID','')}"
+    body = "\n".join([
+        f"RUN_ID={run_id}",
+        f"OUTCOME={outcome}",
+        f"REASON_CODE={reason_code}",
+        f"NEXT_ACTION={next_action}",
+        f"PR_URL={pr_url or ''}",
+        f"EVIDENCE={workflow_run_url}",
+    ])
+    run(["gh", "issue", "comment", str(issue_number), "--repo", repo, "--body", body])
+    return workflow_run_url
+
+
+def main():
+    repo = os.environ["GITHUB_REPOSITORY"]
+    event = load_event()
+    issue = event.get("issue", {})
+    issue_number = issue.get("number")
+    if not issue_number:
+        print("No issue context.")
+        return 0
+
+    latest_comment_body = fetch_latest_comment(repo, issue_number)
+    if not should_run(issue, latest_comment_body):
+        print("No /mep run trigger found.")
+        return 0
+
+    issue_body = issue.get("body") or ""
+    run_id = calc_run_id(canonicalize(issue_body))
+
+    try:
+        write_draft(run_id, issue_body)
+        workflow_run_url = f"{os.environ.get('GITHUB_SERVER_URL','https://github.com')}/{repo}/actions/runs/{os.environ.get('GITHUB_RUN_ID','')}"
+        update_run_state(run_id, "PASS", "ISSUEOPS_BOOTSTRAP_OK", "OPEN_PR", workflow_run_url, None)
+        pr_url, _ = git_pr_flow(repo, run_id, issue_number)
+        update_run_state(run_id, "PASS", "ISSUEOPS_BOOTSTRAP_OK", "WAIT_PR_CHECKS", workflow_run_url, pr_url)
+        run(["git", "add", "mep/run_state.json", "docs/MEP/STATUS.md", "docs/MEP/HANDOFF_AUDIT.md", "docs/MEP/HANDOFF_WORK.md"])
+        run(["git", "commit", "-m", f"chore(mep): update issueops evidence {run_id}"])
+        run(["git", "push"])
+        post_issue_comment(repo, issue_number, run_id, "PASS", "ISSUEOPS_BOOTSTRAP_OK", "WAIT_PR_CHECKS", pr_url)
+        return 0
+    except Exception as e:
+        reason = "STATE_UPDATE_FAILED"
+        outcome = "STOP_HARD"
+        next_action = "FIX_WORKFLOW_PERMISSIONS"
+        try:
+            workflow_run_url = f"{os.environ.get('GITHUB_SERVER_URL','https://github.com')}/{repo}/actions/runs/{os.environ.get('GITHUB_RUN_ID','')}"
+            update_run_state(run_id, outcome, reason, next_action, workflow_run_url, None)
+        except Exception:
+            reason = "STATE_UPDATE_FAILED"
+        post_issue_comment(repo, issue_number, run_id, outcome, reason, next_action, None)
+        print(f"Error: {e}")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Motivation
- Provide a minimal, automated bootstrap for the new `/mep run` entrypoint that reduces manual steps and seeds the full Codex implementation pipeline. 
- On detection of `/mep run` the system must capture the issue draft, produce a stable `RUN_ID`, persist initial state artifacts and return a fixed-format result to the originating Issue. 
- Implement only the intake/PR-and-evidence phase (draft save, run_state & compiled docs update, PR creation and issue comment) so later phases (Codex execution, patch-splitting, auto-merge) can be layered on top.

### Description
- Added a GitHub Actions workflow `.github/workflows/mep_issueops_run.yml` that triggers on `issue_comment` (created) and `issues` (edited), and exposes required token permissions (`contents: write`, `pull-requests: write`, `issues: write`) for the agent to create branches/PRs and comment. 
- Added `tools/agent/issueops.py`, a CLI script that detects `/mep run` (issue body tail or latest comment), canonicalizes the issue body (CRLF→LF and trim), computes `RUN_ID=RUN_<sha256[:12]>`, and writes the draft to `mep/inbox/draft_<RUN_ID>.md`. 
- The agent updates state/compiled artifacts at `mep/run_state.json`, `docs/MEP/STATUS.md`, `docs/MEP/HANDOFF_AUDIT.md`, and `docs/MEP/HANDOFF_WORK.md`, creates a branch and PR for those artifact changes (no direct push to `main`), and posts a fixed-format comment back to the source Issue with `RUN_ID`, `OUTCOME`, `REASON_CODE`, `NEXT_ACTION`, `PR_URL`, and `EVIDENCE`. 
- Failure handling follows the specified guardrail: attempt state update on error and return `STOP_HARD` with `STATE_UPDATE_FAILED` when state cannot be persisted, and otherwise set appropriate `NEXT_ACTION` markers for operator follow-up.

### Testing
- Ran `python -m py_compile tools/agent/issueops.py` to validate Python syntax and the compile check succeeded. 
- Attempted to parse the workflow YAML via a short Python check, but environment lacked `PyYAML` (`ModuleNotFoundError: No module named 'yaml'`), so YAML semantic validation was not performed in this environment. 
- Repository-side changes and PR metadata were produced and prepared by the automation tooling (branch+PR creation flow implemented in the agent), ready for execution in CI with a properly configured `GITHUB_TOKEN`/secrets and GH CLI available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f2a9eb87c832184000ef7d8532ebc)