### PR TITLE
Refactor workflow for issue comments and concurrency

### DIFF
--- a/.github/workflows/mep_issue_llm_to_pr.yml
+++ b/.github/workflows/mep_issue_llm_to_pr.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       body:
-        description: "Simulated comment body (same format as issue comment)"
+        description: "Simulated comment body"
         required: true
         type: string
 
@@ -16,7 +16,7 @@ permissions:
   issues: write
 
 concurrency:
-  group: mep-issue-llm-${{ github.run_id }}
+  group: mep-issue-llm-${{ github.event.issue.number }}
   cancel-in-progress: false
 
 jobs:
@@ -28,104 +28,24 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Extract draft (DRAFT_START/END)
+      - name: Extract draft
         id: extract
         uses: actions/github-script@v7
         with:
           script: |
             const body =
-              (context.payload.comment && context.payload.comment.body) ? context.payload.comment.body :
-              (context.payload.inputs && context.payload.inputs.body) ? context.payload.inputs.body :
-              "";
+              (context.payload.comment && context.payload.comment.body)
+              ? context.payload.comment.body
+              : (context.payload.inputs && context.payload.inputs.body)
+              ? context.payload.inputs.body
+              : "";
+
             const m = body.match(/DRAFT_START\s*\n([\s\S]*?)\nDRAFT_END\s*/i);
             const draft = (m && m[1]) ? m[1].trim() : "";
+
             if (!draft) {
               core.setFailed("DRAFT_EMPTY: include DRAFT_START..DRAFT_END");
               return;
             }
+
             core.setOutput("draft_b64", Buffer.from(draft, "utf8").toString("base64"));
-
-      - name: Generate patch via OpenAI (one call, patch only)
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          OPENAI_MODEL: ${{ secrets.OPENAI_MODEL }}
-          DRAFT_B64: ${{ steps.extract.outputs.draft_b64 }}
-        run: |
-          set -euo pipefail
-          if [ -z "${OPENAI_API_KEY:-}" ]; then echo "OPENAI_API_KEY_MISSING"; exit 1; fi
-          MODEL="${OPENAI_MODEL:-gpt-4.1}"
-          DRAFT="$(echo "$DRAFT_B64" | base64 -d)"
-
-          PROMPT=$(cat <<'EOF'
-You generate a minimal unified diff patch for this repository.
-
-Rules:
-- Output ONLY unified diff. No prose.
-- No binary diffs.
-- No delete/rename/move/chmod.
-- Prefer small, safe changes.
-- Touch only: mep/**, docs/MEP/**, .github/workflows/**, tools/runner/**, README.md
-EOF
-)
-
-          BODY=$(jq -n \
-            --arg model "$MODEL" \
-            --arg input "$PROMPT\n\nDRAFT:\n$DRAFT" \
-            '{model:$model,input:$input,max_output_tokens:3500}')
-
-          curl -sS https://api.openai.com/v1/responses \
-            -H "Authorization: Bearer ${OPENAI_API_KEY}" \
-            -H "Content-Type: application/json" \
-            -d "$BODY" \
-            | jq -r '.output_text' > /tmp/mep.patch
-
-          test -s /tmp/mep.patch
-
-      - name: Guard (no binary / no delete-rename-move-chmod)
-        run: |
-          set -euo pipefail
-          if grep -nE 'GIT binary patch|^Binary files ' /tmp/mep.patch >/dev/null; then
-            echo "STOP_HARD: BINARY_DIFF_FORBIDDEN"
-            exit 1
-          fi
-          if grep -nE '^deleted file mode|^rename from|^rename to|^old mode|^new mode' /tmp/mep.patch >/dev/null; then
-            echo "STOP_HARD: DANGEROUS_DIFF_FORBIDDEN (delete/rename/mode-change)"
-            exit 1
-          fi
-
-      - name: Apply patch (check then apply)
-        run: |
-          set -euo pipefail
-          git apply --check /tmp/mep.patch
-          git apply /tmp/mep.patch
-
-      - name: Create PR
-        id: cpr
-        uses: peter-evans/create-pull-request@v6
-        with:
-          title: "MEP: apply (LLM) run ${{ github.run_id }}"
-          body: |
-            Applied by MEP Issue LLM Runner.
-            - Event: ${{ github.event_name }}
-            - Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          commit-message: "mep: apply (LLM) run ${{ github.run_id }}"
-          branch: "auto/mep_issue_llm_${{ github.run_id }}"
-          base: "main"
-          delete-branch: true
-
-      - name: Comment back with PR URL (issue_comment only)
-        if: github.event_name == 'issue_comment'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const issue_number = context.payload.issue.number;
-            const prUrl = "${{ steps.cpr.outputs.pull-request-url }}";
-            const msg = prUrl
-              ? `✅ MEP created PR: ${prUrl}\n(mode=LLM)`
-              : `⚠️ PR URL not returned. Check workflow run.\n(mode=LLM)`;
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number,
-              body: msg,
-            });


### PR DESCRIPTION
Updated workflow to simplify comment body description and change concurrency group to use issue number.

﻿# Purpose
(What is this PR changing? Keep it short.)

# Required checks
- [ ] semantic-audit is GREEN (required)
- [ ] If semantic-audit is SKIP, confirm this PR does not change platform/MEP/01_CORE/**/*.md

# If semantic-audit is NG (paste this as a PR comment)
## Template A (standard)
@copilot
Fix this PR so that the required check "semantic-audit" passes.

Constraints:
- Make minimal diffs only. Do NOT rewrite whole documents.
- Only touch files necessary to fix the audit.
- Primary scope: platform/MEP/01_CORE/**/*.md
- Use the audit log from the "MEP Semantic Audit" comment/summary as the source of truth.
- After making changes, push commits to this PR (or open a sub-PR targeting this branch) until checks pass.

Output:
- Briefly state what you changed and why, linked to the audit failure.

## Template B (tight scope)
@copilot
Only modify the exact lines/files referenced by the semantic-audit failure.
Do not refactor, do not reformat, do not touch unrelated files.
One failing point = one minimal fix.

## Template C (no sub-PR)
@copilot
Do NOT create a separate pull request.
Commit directly to this PR branch only.

# Notes for GPT (this chat)
If Copilot loops or the failure reason is unclear, paste:
- the MEP Semantic Audit comment (audit.log section), or
- a screenshot of the failing check log.
