### PR TITLE
Add workflow for converting issue comments to PR drafts

### DIFF
--- a/.github/workflows/mep_issue_llm_to_pr_v2.yml
+++ b/.github/workflows/mep_issue_llm_to_pr_v2.yml
@@ -1,0 +1,52 @@
+name: MEP Issue LLM to PR (LLM　v2)
+
+
+on:
+  issue_comment:
+    types: [created, edited]
+  workflow_dispatch:
+    inputs:
+      body:
+        description: "Simulated comment body"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: mep-issue-llm-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  llm_to_pr:
+    if: github.event_name == 'workflow_dispatch' || (contains(github.event.comment.body, '/mep run') && contains(github.event.comment.body, 'MODE: LLM'))
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Extract draft
+        id: extract
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body =
+              (context.payload.comment && context.payload.comment.body)
+              ? context.payload.comment.body
+              : (context.payload.inputs && context.payload.inputs.body)
+              ? context.payload.inputs.body
+              : "";
+
+            const m = body.match(/DRAFT_START\s*\n([\s\S]*?)\nDRAFT_END\s*/i);
+            const draft = (m && m[1]) ? m[1].trim() : "";
+
+            if (!draft) {
+              core.setFailed("DRAFT_EMPTY: include DRAFT_START..DRAFT_END");
+              return;
+            }
+
+            core.setOutput("draft_b64", Buffer.from(draft, "utf8").toString("base64"));


### PR DESCRIPTION
This workflow triggers on issue comments and manual dispatch, extracting draft content from comments to create pull requests.

﻿# Purpose
(What is this PR changing? Keep it short.)

# Required checks
- [ ] semantic-audit is GREEN (required)
- [ ] If semantic-audit is SKIP, confirm this PR does not change platform/MEP/01_CORE/**/*.md

# If semantic-audit is NG (paste this as a PR comment)
## Template A (standard)
@copilot
Fix this PR so that the required check "semantic-audit" passes.

Constraints:
- Make minimal diffs only. Do NOT rewrite whole documents.
- Only touch files necessary to fix the audit.
- Primary scope: platform/MEP/01_CORE/**/*.md
- Use the audit log from the "MEP Semantic Audit" comment/summary as the source of truth.
- After making changes, push commits to this PR (or open a sub-PR targeting this branch) until checks pass.

Output:
- Briefly state what you changed and why, linked to the audit failure.

## Template B (tight scope)
@copilot
Only modify the exact lines/files referenced by the semantic-audit failure.
Do not refactor, do not reformat, do not touch unrelated files.
One failing point = one minimal fix.

## Template C (no sub-PR)
@copilot
Do NOT create a separate pull request.
Commit directly to this PR branch only.

# Notes for GPT (this chat)
If Copilot loops or the failure reason is unclear, paste:
- the MEP Semantic Audit comment (audit.log section), or
- a screenshot of the failing check log.
