### PR TITLE
fix(actions): restore workflow YAML newlines (register workflow_dispatch)

### DIFF
--- a/.github/workflows/mep_issue_llm_to_pr_v2.yml
+++ b/.github/workflows/mep_issue_llm_to_pr_v2.yml
@@ -1,1 +1,99 @@
-name: MEP Issue LLM to PR (LLM v2) on:   workflow_dispatch:     inputs:       body:         description: "Comment body"         required: true         type: string   issue_comment:     types:       - created       - edited permissions:   contents: write   pull-requests: write   issues: write concurrency:   group: mep-llm-v2-${{ github.run_id }}   cancel-in-progress: false jobs:   llm_to_pr:     if: github.event_name == 'workflow_dispatch' || (contains(github.event.comment.body, '/mep run') && contains(github.event.comment.body, 'MODE: LLM'))     runs-on: ubuntu-latest     steps:       - name: Checkout         uses: actions/checkout@v4       - name: Extract draft (DRAFT_START/END)         id: extract         uses: actions/github-script@v7         with:           script: |             const body =               (context.payload.comment && context.payload.comment.body) ? context.payload.comment.body :               (context.payload.inputs && context.payload.inputs.body) ? context.payload.inputs.body :               "";             const m = body.match(/DRAFT_START\s*\n([\s\S]*?)\nDRAFT_END\s*/i);             const draft = (m && m[1]) ? m[1].trim() : "";             if (!draft) { core.setFailed("DRAFT_EMPTY"); return; }             core.setOutput("draft_b64", Buffer.from(draft, "utf8").toString("base64"));       - name: Generate patch via OpenAI (one call)         env:           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}           OPENAI_MODEL: ${{ secrets.OPENAI_MODEL }}           DRAFT_B64: ${{ steps.extract.outputs.draft_b64 }}         run: |           set -euo pipefail           [ -n "${OPENAI_API_KEY:-}" ] || (echo OPENAI_API_KEY_MISSING && exit 1)           MODEL="${OPENAI_MODEL:-gpt-4.1}"           DRAFT="$(echo "$DRAFT_B64" | base64 -d)"           PROMPT="You generate a minimal unified diff patch for this repository. Rules: - Output ONLY unified diff. No prose. - No binary diffs. - No delete/rename/move/chmod. - Touch only: mep/**, docs/MEP/**, .github/workflows/**, tools/runner/**, README.md Draft:"           BODY=$(jq -n --arg model "$MODEL" --arg input "$PROMPT\n$DRAFT" '{model:$model,input:$input,max_output_tokens:3500}')           curl -sS https://api.openai.com/v1/responses \             -H "Authorization: Bearer ${OPENAI_API_KEY}" \             -H "Content-Type: application/json" \             -d "$BODY" \             | jq -r '.output_text' > /tmp/mep.patch           test -s /tmp/mep.patch       - name: Guard         run: |           set -euo pipefail           if grep -nE 'GIT binary patch|^Binary files ' /tmp/mep.patch >/dev/null; then exit 1; fi           if grep -nE '^deleted file mode|^rename from|^rename to|^old mode|^new mode' /tmp/mep.patch >/dev/null; then exit 1; fi       - name: Apply patch         run: |           set -euo pipefail           git apply --check /tmp/mep.patch           git apply /tmp/mep.patch       - name: Create PR         id: cpr         uses: peter-evans/create-pull-request@v6         with:           title: "MEP: apply (LLM v2) run ${{ github.run_id }}"           body: |             Applied by MEP Issue LLM Runner v2.             - Event: ${{ github.event_name }}             - Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}           commit-message: "mep: apply (LLM v2) run ${{ github.run_id }}"           branch: "auto/mep_llm_v2_${{ github.run_id }}"           base: "main"           delete-branch: true       - name: Comment back (issue_comment only)         if: github.event_name == 'issue_comment'         uses: actions/github-script@v7         with:           script: |             const issue_number = context.payload.issue.number;             const prUrl = "${{ steps.cpr.outputs.pull-request-url }}";             await github.rest.issues.createComment({               owner: context.repo.owner,               repo: context.repo.repo,               issue_number,               body: prUrl ? `笨・MEP created PR: ${prUrl}\n(mode=LLM v2)` : `笞・・PR URL not returned (mode=LLM v2)`,             });
+name: MEP Issue LLM to PR (LLM v2)
+on:
+  workflow_dispatch:
+    inputs:
+      body:
+        description: "Comment body"
+        required: true
+        type: string
+  issue_comment:
+    types:
+      - created
+      - edited
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+concurrency:
+  group: mep-llm-v2-${{ github.run_id }}
+  cancel-in-progress: false
+jobs:
+  llm_to_pr:
+    if: github.event_name == 'workflow_dispatch' || (contains(github.event.comment.body, '/mep run') && contains(github.event.comment.body, 'MODE: LLM'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Extract draft (DRAFT_START/END)
+        id: extract
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body =
+              (context.payload.comment && context.payload.comment.body) ? context.payload.comment.body :
+              (context.payload.inputs && context.payload.inputs.body) ? context.payload.inputs.body :
+              "";
+            const m = body.match(/DRAFT_START\s*\n([\s\S]*?)\nDRAFT_END\s*/i);
+            const draft = (m && m[1]) ? m[1].trim() : "";
+            if (!draft) { core.setFailed("DRAFT_EMPTY"); return; }
+            core.setOutput("draft_b64", Buffer.from(draft, "utf8").toString("base64"));
+      - name: Generate patch via OpenAI (one call)
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_MODEL: ${{ secrets.OPENAI_MODEL }}
+          DRAFT_B64: ${{ steps.extract.outputs.draft_b64 }}
+        run: |
+          set -euo pipefail
+          [ -n "${OPENAI_API_KEY:-}" ] || (echo OPENAI_API_KEY_MISSING && exit 1)
+          MODEL="${OPENAI_MODEL:-gpt-4.1}"
+          DRAFT="$(echo "$DRAFT_B64" | base64 -d)"
+          PROMPT="You generate a minimal unified diff patch for this repository.
+Rules:
+- Output ONLY unified diff. No prose.
+- No binary diffs.
+- No delete/rename/move/chmod.
+- Touch only: mep/**, docs/MEP/**, .github/workflows/**, tools/runner/**, README.md
+Draft:"
+          BODY=$(jq -n --arg model "$MODEL" --arg input "$PROMPT\n$DRAFT" '{model:$model,input:$input,max_output_tokens:3500}')
+          curl -sS https://api.openai.com/v1/responses \
+            -H "Authorization: Bearer ${OPENAI_API_KEY}" \
+            -H "Content-Type: application/json" \
+            -d "$BODY" \
+            | jq -r '.output_text' > /tmp/mep.patch
+          test -s /tmp/mep.patch
+      - name: Guard
+        run: |
+          set -euo pipefail
+          if grep -nE 'GIT binary patch|^Binary files ' /tmp/mep.patch >/dev/null; then exit 1; fi
+          if grep -nE '^deleted file mode|^rename from|^rename to|^old mode|^new mode' /tmp/mep.patch >/dev/null; then exit 1; fi
+      - name: Apply patch
+        run: |
+          set -euo pipefail
+          git apply --check /tmp/mep.patch
+          git apply /tmp/mep.patch
+      - name: Create PR
+        id: cpr
+        uses: peter-evans/create-pull-request@v6
+        with:
+          title: "MEP: apply (LLM v2) run ${{ github.run_id }}"
+          body: |
+            Applied by MEP Issue LLM Runner v2.
+            - Event: ${{ github.event_name }}
+            - Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          commit-message: "mep: apply (LLM v2) run ${{ github.run_id }}"
+          branch: "auto/mep_llm_v2_${{ github.run_id }}"
+          base: "main"
+          delete-branch: true
+      - name: Comment back (issue_comment only)
+        if: github.event_name == 'issue_comment'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue_number = context.payload.issue.number;
+            const prUrl = "${{ steps.cpr.outputs.pull-request-url }}";
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              body: prUrl ? `笨・MEP created PR: ${prUrl}\n(mode=LLM v2)` : `笞・・PR URL not returned (mode=LLM v2)`,
+            });

--- a/.github/workflows/mep_issue_llm_to_pr_v3.yml
+++ b/.github/workflows/mep_issue_llm_to_pr_v3.yml
@@ -1,1 +1,107 @@
-name: MEP Issue LLM to PR (LLM v3.1)  on:   workflow_dispatch:   issue_comment:     types:       - created       - edited  permissions:   contents: write   pull-requests: write   issues: write  concurrency:   group: mep-llm-v3-${{ github.run_id }}   cancel-in-progress: false  jobs:   llm_to_pr:     if: github.event_name == 'workflow_dispatch' || (contains(github.event.comment.body, '/mep run') && contains(github.event.comment.body, 'MODE: LLM'))     runs-on: ubuntu-latest      steps:       - name: Checkout         uses: actions/checkout@v4        - name: Extract draft (DRAFT_START/END)         id: extract         uses: actions/github-script@v7         with:           script: |             // workflow_dispatch 縺ｯ inputs 繧剃ｽｿ繧上★縲∝崋螳壹・繝・せ繝域悽譁・ｒ豕ｨ蜈･・・22蝗樣∩・・            const body =               (context.payload.comment && context.payload.comment.body) ? context.payload.comment.body :               "/mep run\nMODE: LLM\nDRAFT_START\nPING_LLM_DISPATCH_V3\nDRAFT_END\n";              const m = body.match(/DRAFT_START\s*\n([\s\S]*?)\nDRAFT_END\s*/i);             const draft = (m && m[1]) ? m[1].trim() : "";             if (!draft) { core.setFailed("DRAFT_EMPTY"); return; }             core.setOutput("draft_b64", Buffer.from(draft, "utf8").toString("base64"));        - name: Generate patch via OpenAI (one call)         env:           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}           OPENAI_MODEL: ${{ secrets.OPENAI_MODEL }}           DRAFT_B64: ${{ steps.extract.outputs.draft_b64 }}         run: |           set -euo pipefail           [ -n "${OPENAI_API_KEY:-}" ] || (echo OPENAI_API_KEY_MISSING && exit 1)           MODEL="${OPENAI_MODEL:-gpt-4.1}"           DRAFT="$(echo "$DRAFT_B64" | base64 -d)"            PROMPT="You generate a minimal unified diff patch for this repository. Rules: - Output ONLY unified diff. No prose. - No binary diffs. - No delete/rename/move/chmod. - Touch only: mep/**, docs/MEP/**, .github/workflows/**, tools/runner/**, README.md Draft:"            BODY=$(jq -n --arg model "$MODEL" --arg input "$PROMPT\n$DRAFT" '{model:$model,input:$input,max_output_tokens:3500}')           curl -sS https://api.openai.com/v1/responses \             -H "Authorization: Bearer ${OPENAI_API_KEY}" \             -H "Content-Type: application/json" \             -d "$BODY" \             | jq -r '.output_text' > /tmp/mep.patch           test -s /tmp/mep.patch        - name: Guard         run: |           set -euo pipefail           if grep -nE 'GIT binary patch|^Binary files ' /tmp/mep.patch >/dev/null; then exit 1; fi           if grep -nE '^deleted file mode|^rename from|^rename to|^old mode|^new mode' /tmp/mep.patch >/dev/null; then exit 1; fi        - name: Apply patch         run: |           set -euo pipefail           git apply --check /tmp/mep.patch           git apply /tmp/mep.patch        - name: Create PR         id: cpr         uses: peter-evans/create-pull-request@v6         with:           title: "MEP: apply (LLM v3) run ${{ github.run_id }}"           body: |             Applied by MEP Issue LLM Runner v3.             - Event: ${{ github.event_name }}             - Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}           commit-message: "mep: apply (LLM v3) run ${{ github.run_id }}"           branch: "auto/mep_llm_v3_${{ github.run_id }}"           base: "main"           delete-branch: true        - name: Comment back (issue_comment only)         if: github.event_name == 'issue_comment'         uses: actions/github-script@v7         with:           script: |             const issue_number = context.payload.issue.number;             const prUrl = "${{ steps.cpr.outputs.pull-request-url }}";             await github.rest.issues.createComment({               owner: context.repo.owner,               repo: context.repo.repo,               issue_number,               body: prUrl ? `笨・MEP created PR: ${prUrl}\n(mode=LLM v3)` : `笞・・PR URL not returned (mode=LLM v3)`,             });
+name: MEP Issue LLM to PR (LLM v3.1)
+
+on:
+  workflow_dispatch:
+  issue_comment:
+    types:
+      - created
+      - edited
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: mep-llm-v3-${{ github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  llm_to_pr:
+    if: github.event_name == 'workflow_dispatch' || (contains(github.event.comment.body, '/mep run') && contains(github.event.comment.body, 'MODE: LLM'))
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Extract draft (DRAFT_START/END)
+        id: extract
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // workflow_dispatch 縺ｯ inputs 繧剃ｽｿ繧上★縲∝崋螳壹・繝・せ繝域悽譁・ｒ豕ｨ蜈･・・22蝗樣∩・・            const body =
+              (context.payload.comment && context.payload.comment.body) ? context.payload.comment.body :
+              "/mep run\nMODE: LLM\nDRAFT_START\nPING_LLM_DISPATCH_V3\nDRAFT_END\n";
+
+            const m = body.match(/DRAFT_START\s*\n([\s\S]*?)\nDRAFT_END\s*/i);
+            const draft = (m && m[1]) ? m[1].trim() : "";
+            if (!draft) { core.setFailed("DRAFT_EMPTY"); return; }
+            core.setOutput("draft_b64", Buffer.from(draft, "utf8").toString("base64"));
+
+      - name: Generate patch via OpenAI (one call)
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_MODEL: ${{ secrets.OPENAI_MODEL }}
+          DRAFT_B64: ${{ steps.extract.outputs.draft_b64 }}
+        run: |
+          set -euo pipefail
+          [ -n "${OPENAI_API_KEY:-}" ] || (echo OPENAI_API_KEY_MISSING && exit 1)
+          MODEL="${OPENAI_MODEL:-gpt-4.1}"
+          DRAFT="$(echo "$DRAFT_B64" | base64 -d)"
+
+          PROMPT="You generate a minimal unified diff patch for this repository.
+Rules:
+- Output ONLY unified diff. No prose.
+- No binary diffs.
+- No delete/rename/move/chmod.
+- Touch only: mep/**, docs/MEP/**, .github/workflows/**, tools/runner/**, README.md
+Draft:"
+
+          BODY=$(jq -n --arg model "$MODEL" --arg input "$PROMPT\n$DRAFT" '{model:$model,input:$input,max_output_tokens:3500}')
+          curl -sS https://api.openai.com/v1/responses \
+            -H "Authorization: Bearer ${OPENAI_API_KEY}" \
+            -H "Content-Type: application/json" \
+            -d "$BODY" \
+            | jq -r '.output_text' > /tmp/mep.patch
+          test -s /tmp/mep.patch
+
+      - name: Guard
+        run: |
+          set -euo pipefail
+          if grep -nE 'GIT binary patch|^Binary files ' /tmp/mep.patch >/dev/null; then exit 1; fi
+          if grep -nE '^deleted file mode|^rename from|^rename to|^old mode|^new mode' /tmp/mep.patch >/dev/null; then exit 1; fi
+
+      - name: Apply patch
+        run: |
+          set -euo pipefail
+          git apply --check /tmp/mep.patch
+          git apply /tmp/mep.patch
+
+      - name: Create PR
+        id: cpr
+        uses: peter-evans/create-pull-request@v6
+        with:
+          title: "MEP: apply (LLM v3) run ${{ github.run_id }}"
+          body: |
+            Applied by MEP Issue LLM Runner v3.
+            - Event: ${{ github.event_name }}
+            - Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          commit-message: "mep: apply (LLM v3) run ${{ github.run_id }}"
+          branch: "auto/mep_llm_v3_${{ github.run_id }}"
+          base: "main"
+          delete-branch: true
+
+      - name: Comment back (issue_comment only)
+        if: github.event_name == 'issue_comment'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue_number = context.payload.issue.number;
+            const prUrl = "${{ steps.cpr.outputs.pull-request-url }}";
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              body: prUrl ? `笨・MEP created PR: ${prUrl}\n(mode=LLM v3)` : `笞・・PR URL not returned (mode=LLM v3)`,
+            });

--- a/.github/workflows/mep_issue_llm_to_pr_v4.yml
+++ b/.github/workflows/mep_issue_llm_to_pr_v4.yml
@@ -1,1 +1,107 @@
-name: MEP Issue LLM to PR (LLM v4)  on:   workflow_dispatch:   issue_comment:     types:       - created       - edited  permissions:   contents: write   pull-requests: write   issues: write  concurrency:   group: mep-llm-v3-${{ github.run_id }}   cancel-in-progress: false  jobs:   llm_to_pr:     if: github.event_name == 'workflow_dispatch' || (contains(github.event.comment.body, '/mep run') && contains(github.event.comment.body, 'MODE: LLM'))     runs-on: ubuntu-latest      steps:       - name: Checkout         uses: actions/checkout@v4        - name: Extract draft (DRAFT_START/END)         id: extract         uses: actions/github-script@v7         with:           script: |             // workflow_dispatch 縺ｯ inputs 繧剃ｽｿ繧上★縲∝崋螳壹・繝・せ繝域悽譁・ｒ豕ｨ蜈･・・22蝗樣∩・・            const body =               (context.payload.comment && context.payload.comment.body) ? context.payload.comment.body :               "/mep run\nMODE: LLM\nDRAFT_START\nPING_LLM_DISPATCH_V3\nDRAFT_END\n";              const m = body.match(/DRAFT_START\s*\n([\s\S]*?)\nDRAFT_END\s*/i);             const draft = (m && m[1]) ? m[1].trim() : "";             if (!draft) { core.setFailed("DRAFT_EMPTY"); return; }             core.setOutput("draft_b64", Buffer.from(draft, "utf8").toString("base64"));        - name: Generate patch via OpenAI (one call)         env:           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}           OPENAI_MODEL: ${{ secrets.OPENAI_MODEL }}           DRAFT_B64: ${{ steps.extract.outputs.draft_b64 }}         run: |           set -euo pipefail           [ -n "${OPENAI_API_KEY:-}" ] || (echo OPENAI_API_KEY_MISSING && exit 1)           MODEL="${OPENAI_MODEL:-gpt-4.1}"           DRAFT="$(echo "$DRAFT_B64" | base64 -d)"            PROMPT="You generate a minimal unified diff patch for this repository. Rules: - Output ONLY unified diff. No prose. - No binary diffs. - No delete/rename/move/chmod. - Touch only: mep/**, docs/MEP/**, .github/workflows/**, tools/runner/**, README.md Draft:"            BODY=$(jq -n --arg model "$MODEL" --arg input "$PROMPT\n$DRAFT" '{model:$model,input:$input,max_output_tokens:3500}')           curl -sS https://api.openai.com/v1/responses \             -H "Authorization: Bearer ${OPENAI_API_KEY}" \             -H "Content-Type: application/json" \             -d "$BODY" \             | jq -r '.output_text' > /tmp/mep.patch           test -s /tmp/mep.patch        - name: Guard         run: |           set -euo pipefail           if grep -nE 'GIT binary patch|^Binary files ' /tmp/mep.patch >/dev/null; then exit 1; fi           if grep -nE '^deleted file mode|^rename from|^rename to|^old mode|^new mode' /tmp/mep.patch >/dev/null; then exit 1; fi        - name: Apply patch         run: |           set -euo pipefail           git apply --check /tmp/mep.patch           git apply /tmp/mep.patch        - name: Create PR         id: cpr         uses: peter-evans/create-pull-request@v6         with:           title: "MEP: apply (LLM v3) run ${{ github.run_id }}"           body: |             Applied by MEP Issue LLM Runner v3.             - Event: ${{ github.event_name }}             - Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}           commit-message: "mep: apply (LLM v3) run ${{ github.run_id }}"           branch: "auto/mep_llm_v3_${{ github.run_id }}"           base: "main"           delete-branch: true        - name: Comment back (issue_comment only)         if: github.event_name == 'issue_comment'         uses: actions/github-script@v7         with:           script: |             const issue_number = context.payload.issue.number;             const prUrl = "${{ steps.cpr.outputs.pull-request-url }}";             await github.rest.issues.createComment({               owner: context.repo.owner,               repo: context.repo.repo,               issue_number,               body: prUrl ? `笨・MEP created PR: ${prUrl}\n(mode=LLM v3)` : `笞・・PR URL not returned (mode=LLM v3)`,             });
+name: MEP Issue LLM to PR (LLM v4)
+
+on:
+  workflow_dispatch:
+  issue_comment:
+    types:
+      - created
+      - edited
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: mep-llm-v3-${{ github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  llm_to_pr:
+    if: github.event_name == 'workflow_dispatch' || (contains(github.event.comment.body, '/mep run') && contains(github.event.comment.body, 'MODE: LLM'))
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Extract draft (DRAFT_START/END)
+        id: extract
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // workflow_dispatch 縺ｯ inputs 繧剃ｽｿ繧上★縲∝崋螳壹・繝・せ繝域悽譁・ｒ豕ｨ蜈･・・22蝗樣∩・・            const body =
+              (context.payload.comment && context.payload.comment.body) ? context.payload.comment.body :
+              "/mep run\nMODE: LLM\nDRAFT_START\nPING_LLM_DISPATCH_V3\nDRAFT_END\n";
+
+            const m = body.match(/DRAFT_START\s*\n([\s\S]*?)\nDRAFT_END\s*/i);
+            const draft = (m && m[1]) ? m[1].trim() : "";
+            if (!draft) { core.setFailed("DRAFT_EMPTY"); return; }
+            core.setOutput("draft_b64", Buffer.from(draft, "utf8").toString("base64"));
+
+      - name: Generate patch via OpenAI (one call)
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_MODEL: ${{ secrets.OPENAI_MODEL }}
+          DRAFT_B64: ${{ steps.extract.outputs.draft_b64 }}
+        run: |
+          set -euo pipefail
+          [ -n "${OPENAI_API_KEY:-}" ] || (echo OPENAI_API_KEY_MISSING && exit 1)
+          MODEL="${OPENAI_MODEL:-gpt-4.1}"
+          DRAFT="$(echo "$DRAFT_B64" | base64 -d)"
+
+          PROMPT="You generate a minimal unified diff patch for this repository.
+Rules:
+- Output ONLY unified diff. No prose.
+- No binary diffs.
+- No delete/rename/move/chmod.
+- Touch only: mep/**, docs/MEP/**, .github/workflows/**, tools/runner/**, README.md
+Draft:"
+
+          BODY=$(jq -n --arg model "$MODEL" --arg input "$PROMPT\n$DRAFT" '{model:$model,input:$input,max_output_tokens:3500}')
+          curl -sS https://api.openai.com/v1/responses \
+            -H "Authorization: Bearer ${OPENAI_API_KEY}" \
+            -H "Content-Type: application/json" \
+            -d "$BODY" \
+            | jq -r '.output_text' > /tmp/mep.patch
+          test -s /tmp/mep.patch
+
+      - name: Guard
+        run: |
+          set -euo pipefail
+          if grep -nE 'GIT binary patch|^Binary files ' /tmp/mep.patch >/dev/null; then exit 1; fi
+          if grep -nE '^deleted file mode|^rename from|^rename to|^old mode|^new mode' /tmp/mep.patch >/dev/null; then exit 1; fi
+
+      - name: Apply patch
+        run: |
+          set -euo pipefail
+          git apply --check /tmp/mep.patch
+          git apply /tmp/mep.patch
+
+      - name: Create PR
+        id: cpr
+        uses: peter-evans/create-pull-request@v6
+        with:
+          title: "MEP: apply (LLM v3) run ${{ github.run_id }}"
+          body: |
+            Applied by MEP Issue LLM Runner v3.
+            - Event: ${{ github.event_name }}
+            - Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          commit-message: "mep: apply (LLM v3) run ${{ github.run_id }}"
+          branch: "auto/mep_llm_v3_${{ github.run_id }}"
+          base: "main"
+          delete-branch: true
+
+      - name: Comment back (issue_comment only)
+        if: github.event_name == 'issue_comment'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue_number = context.payload.issue.number;
+            const prUrl = "${{ steps.cpr.outputs.pull-request-url }}";
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              body: prUrl ? `笨・MEP created PR: ${prUrl}\n(mode=LLM v3)` : `笞・・PR URL not returned (mode=LLM v3)`,
+            });

--- a/.github/workflows/mep_issue_llm_to_pr_v5.yml
+++ b/.github/workflows/mep_issue_llm_to_pr_v5.yml
@@ -1,1 +1,112 @@
-name: MEP Issue LLM to PR (LLM v5) on:   workflow_dispatch:     inputs:       body:         description: "Simulated issue_comment body"         required: true         type: string   issue_comment:     types:       - created       - edited permissions:   contents: write   pull-requests: write   issues: write concurrency:   group: mep-llm-v5-${{ github.event_name }}-${{ github.run_id }}   cancel-in-progress: false jobs:   llm_to_pr:     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && contains(github.event.comment.body, '/mep run') && contains(github.event.comment.body, 'MODE: LLM'))     runs-on: ubuntu-latest     steps:       - name: Checkout         uses: actions/checkout@v4       - name: Resolve body (issue_comment or workflow_dispatch)         id: body         uses: actions/github-script@v7         with:           script: |             const isDispatch = context.eventName === "workflow_dispatch";             const body =               isDispatch                 ? (context.payload.inputs && context.payload.inputs.body ? context.payload.inputs.body : "")                 : (context.payload.comment && context.payload.comment.body ? context.payload.comment.body : "");             if (!body) {               core.setFailed("BODY_EMPTY");               return;             }             core.setOutput("body", body);       - name: Extract draft (DRAFT_START/END)         id: extract         uses: actions/github-script@v7         with:           script: |             const body = "${{ steps.body.outputs.body }}";             const m = body.match(/DRAFT_START\s*\n([\s\S]*?)\nDRAFT_END\s*/i);             const draft = (m && m[1]) ? m[1].trim() : "";             if (!draft) { core.setFailed("DRAFT_EMPTY: include DRAFT_START..DRAFT_END"); return; }             core.setOutput("draft_b64", Buffer.from(draft, "utf8").toString("base64"));       - name: Generate patch via OpenAI (one call)         env:           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}           OPENAI_MODEL: ${{ secrets.OPENAI_MODEL }}           DRAFT_B64: ${{ steps.extract.outputs.draft_b64 }}         run: |           set -euo pipefail           [ -n "${OPENAI_API_KEY:-}" ] || (echo OPENAI_API_KEY_MISSING && exit 1)           MODEL="${OPENAI_MODEL:-gpt-4.1}"           DRAFT="$(echo "$DRAFT_B64" | base64 -d)"           PROMPT="You generate a minimal unified diff patch for this repository. Rules: - Output ONLY unified diff. No prose. - No binary diffs. - No delete/rename/move/chmod. - Prefer small, safe changes. - Touch only: mep/**, docs/MEP/**, .github/workflows/**, tools/runner/**, README.md Draft:"           BODY=$(jq -n --arg model "$MODEL" --arg input "$PROMPT\n$DRAFT" '{model:$model,input:$input,max_output_tokens:3500}')           curl -sS https://api.openai.com/v1/responses \             -H "Authorization: Bearer ${OPENAI_API_KEY}" \             -H "Content-Type: application/json" \             -d "$BODY" \             | jq -r '.output_text' > /tmp/mep.patch           test -s /tmp/mep.patch       - name: Guard (no binary / no delete-rename-move-chmod)         run: |           set -euo pipefail           if grep -nE 'GIT binary patch|^Binary files ' /tmp/mep.patch >/dev/null; then echo "STOP_HARD: BINARY_DIFF_FORBIDDEN"; exit 1; fi           if grep -nE '^deleted file mode|^rename from|^rename to|^old mode|^new mode' /tmp/mep.patch >/dev/null; then echo "STOP_HARD: DANGEROUS_DIFF_FORBIDDEN"; exit 1; fi       - name: Apply patch (check then apply)         run: |           set -euo pipefail           git apply --check /tmp/mep.patch           git apply /tmp/mep.patch       - name: Create PR         id: cpr         uses: peter-evans/create-pull-request@v6         with:           title: "MEP: apply (LLM v5) run ${{ github.run_id }}"           body: |             Applied by MEP Issue LLM Runner v5.             - Event: ${{ github.event_name }}             - Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}           commit-message: "mep: apply (LLM v5) run ${{ github.run_id }}"           branch: "auto/mep_llm_v5_${{ github.run_id }}"           base: "main"           delete-branch: true       - name: Comment back (issue_comment only)         if: github.event_name == 'issue_comment'         uses: actions/github-script@v7         with:           script: |             const issue_number = context.payload.issue.number;             const prUrl = "${{ steps.cpr.outputs.pull-request-url }}";             await github.rest.issues.createComment({               owner: context.repo.owner,               repo: context.repo.repo,               issue_number,               body: prUrl ? `笨・MEP created PR: ${prUrl}\n(mode=LLM v5)` : `笞・・PR URL not returned (mode=LLM v5)`,             });
+name: MEP Issue LLM to PR (LLM v5)
+on:
+  workflow_dispatch:
+    inputs:
+      body:
+        description: "Simulated issue_comment body"
+        required: true
+        type: string
+  issue_comment:
+    types:
+      - created
+      - edited
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+concurrency:
+  group: mep-llm-v5-${{ github.event_name }}-${{ github.run_id }}
+  cancel-in-progress: false
+jobs:
+  llm_to_pr:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && contains(github.event.comment.body, '/mep run') && contains(github.event.comment.body, 'MODE: LLM'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Resolve body (issue_comment or workflow_dispatch)
+        id: body
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const isDispatch = context.eventName === "workflow_dispatch";
+            const body =
+              isDispatch
+                ? (context.payload.inputs && context.payload.inputs.body ? context.payload.inputs.body : "")
+                : (context.payload.comment && context.payload.comment.body ? context.payload.comment.body : "");
+            if (!body) {
+              core.setFailed("BODY_EMPTY");
+              return;
+            }
+            core.setOutput("body", body);
+      - name: Extract draft (DRAFT_START/END)
+        id: extract
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = "${{ steps.body.outputs.body }}";
+            const m = body.match(/DRAFT_START\s*\n([\s\S]*?)\nDRAFT_END\s*/i);
+            const draft = (m && m[1]) ? m[1].trim() : "";
+            if (!draft) { core.setFailed("DRAFT_EMPTY: include DRAFT_START..DRAFT_END"); return; }
+            core.setOutput("draft_b64", Buffer.from(draft, "utf8").toString("base64"));
+      - name: Generate patch via OpenAI (one call)
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_MODEL: ${{ secrets.OPENAI_MODEL }}
+          DRAFT_B64: ${{ steps.extract.outputs.draft_b64 }}
+        run: |
+          set -euo pipefail
+          [ -n "${OPENAI_API_KEY:-}" ] || (echo OPENAI_API_KEY_MISSING && exit 1)
+          MODEL="${OPENAI_MODEL:-gpt-4.1}"
+          DRAFT="$(echo "$DRAFT_B64" | base64 -d)"
+          PROMPT="You generate a minimal unified diff patch for this repository.
+Rules:
+- Output ONLY unified diff. No prose.
+- No binary diffs.
+- No delete/rename/move/chmod.
+- Prefer small, safe changes.
+- Touch only: mep/**, docs/MEP/**, .github/workflows/**, tools/runner/**, README.md
+Draft:"
+          BODY=$(jq -n --arg model "$MODEL" --arg input "$PROMPT\n$DRAFT" '{model:$model,input:$input,max_output_tokens:3500}')
+          curl -sS https://api.openai.com/v1/responses \
+            -H "Authorization: Bearer ${OPENAI_API_KEY}" \
+            -H "Content-Type: application/json" \
+            -d "$BODY" \
+            | jq -r '.output_text' > /tmp/mep.patch
+          test -s /tmp/mep.patch
+      - name: Guard (no binary / no delete-rename-move-chmod)
+        run: |
+          set -euo pipefail
+          if grep -nE 'GIT binary patch|^Binary files ' /tmp/mep.patch >/dev/null; then echo "STOP_HARD: BINARY_DIFF_FORBIDDEN"; exit 1; fi
+          if grep -nE '^deleted file mode|^rename from|^rename to|^old mode|^new mode' /tmp/mep.patch >/dev/null; then echo "STOP_HARD: DANGEROUS_DIFF_FORBIDDEN"; exit 1; fi
+      - name: Apply patch (check then apply)
+        run: |
+          set -euo pipefail
+          git apply --check /tmp/mep.patch
+          git apply /tmp/mep.patch
+      - name: Create PR
+        id: cpr
+        uses: peter-evans/create-pull-request@v6
+        with:
+          title: "MEP: apply (LLM v5) run ${{ github.run_id }}"
+          body: |
+            Applied by MEP Issue LLM Runner v5.
+            - Event: ${{ github.event_name }}
+            - Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          commit-message: "mep: apply (LLM v5) run ${{ github.run_id }}"
+          branch: "auto/mep_llm_v5_${{ github.run_id }}"
+          base: "main"
+          delete-branch: true
+      - name: Comment back (issue_comment only)
+        if: github.event_name == 'issue_comment'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue_number = context.payload.issue.number;
+            const prUrl = "${{ steps.cpr.outputs.pull-request-url }}";
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              body: prUrl ? `笨・MEP created PR: ${prUrl}\n(mode=LLM v5)` : `笞・・PR URL not returned (mode=LLM v5)`,
+            });


### PR DESCRIPTION
Fix: restore workflow YAML newlines (LF) so 'on:' block is parsed and triggers are registered.

Restored from last known multi-line commits on origin/main:
- .github/workflows/mep_issue_llm_to_pr_v2.yml <= 0bc55c9bd54103820289d65d7f7a5198054ea81d
- .github/workflows/mep_issue_llm_to_pr_v3.yml <= e6bca1246c0df1717bfa53d2b6e84e40ca274735
- .github/workflows/mep_issue_llm_to_pr_v4.yml <= f85284693dd0d9350d37d6631edd9d5843771ec1
- .github/workflows/mep_issue_llm_to_pr_v5.yml <= b28341004712d5f568b52adcfda47b591c2dad2a

Expected: gh api /dispatches no longer returns HTTP 422; issue_comment/workflow_dispatch triggers appear and runs are created.