### PR TITLE
fix(actions): normalize issue_comment trigger for v2x/v5x

### DIFF
--- a/.github/workflows/mep_issue_llm_to_pr_v2x.yml
+++ b/.github/workflows/mep_issue_llm_to_pr_v2x.yml
@@ -1,2 +1,4 @@
 name: MEP Issue LLM to PR (LLM v2 X)
 on:
+  issue_comment:
+    types: [created]

--- a/.github/workflows/mep_issue_llm_to_pr_v5x.yml
+++ b/.github/workflows/mep_issue_llm_to_pr_v5x.yml
@@ -1,2 +1,4 @@
 name: MEP Issue LLM to PR (LLM v5 X)
 on:
+  issue_comment:
+    types: [created]


### PR DESCRIPTION
v2x/v5x show zero issue_comment runs. Normalize on:issue_comment to types:[created] (known-good minimal form) to restore triggering.