### PR TITLE
fix(actions): restore v2x/v5x jobs (issue_comment entry)

### DIFF
--- a/.github/workflows/mep_issue_llm_to_pr_v2x.yml
+++ b/.github/workflows/mep_issue_llm_to_pr_v2x.yml
@@ -1,4 +1,2 @@
 name: MEP Issue LLM to PR (LLM v2 X)
 on:
-  issue_comment:
-    types: [created]

--- a/.github/workflows/mep_issue_llm_to_pr_v5x.yml
+++ b/.github/workflows/mep_issue_llm_to_pr_v5x.yml
@@ -1,4 +1,2 @@
 name: MEP Issue LLM to PR (LLM v5 X)
 on:
-  issue_comment:
-    types: [created]


### PR DESCRIPTION
v2x/v5x appeared to have only 'on:' without jobs, so restore full workflow bodies from v2r/v5r while keeping issue_comment(created) entry and X names.