### PR TITLE
fix(actions): add issue_comment Issue Entry workflow

### DIFF
--- a/.github/workflows/mep_issue_llm_to_pr_issue_entry.yml
+++ b/.github/workflows/mep_issue_llm_to_pr_issue_entry.yml
@@ -1,0 +1,98 @@
+name: MEP Issue LLM to PR (Issue Entry)
+on:
+  issue_comment:
+    types:
+      - created
+      - edited
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+concurrency:
+  group: mep-llm-issue-entry-${{ github.event_name }}-${{ github.run_id }}
+  cancel-in-progress: false
+jobs:
+  llm_to_pr:
+    if: contains(github.event.comment.body, '/mep run') && contains(github.event.comment.body, 'MODE: LLM')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Resolve body (issue_comment)
+        id: body
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = (context.payload.comment && context.payload.comment.body) ? context.payload.comment.body : "";
+            if (!body) { core.setFailed("BODY_EMPTY"); return; }
+            core.setOutput("body", body);
+      - name: Extract draft (DRAFT_START/END)
+        id: extract
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = `${{ steps.body.outputs.body }}`;
+            const m = body.match(/DRAFT_START\s*\n([\s\S]*?)\nDRAFT_END\s*/i);
+            const draft = (m && m[1]) ? m[1].trim() : "";
+            if (!draft) { core.setFailed("DRAFT_EMPTY: include DRAFT_START..DRAFT_END"); return; }
+            core.setOutput("draft_b64", Buffer.from(draft, "utf8").toString("base64"));
+      - name: Generate patch via OpenAI (one call)
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_MODEL: ${{ secrets.OPENAI_MODEL }}
+          DRAFT_B64: ${{ steps.extract.outputs.draft_b64 }}
+        run: |
+          set -euo pipefail
+          [ -n "${OPENAI_API_KEY:-}" ] || (echo OPENAI_API_KEY_MISSING && exit 1)
+          MODEL="${OPENAI_MODEL:-gpt-4.1}"
+          DRAFT="$(echo "$DRAFT_B64" | base64 -d)"
+          PROMPT="You generate a minimal unified diff patch for this repository.
+Rules:
+- Output ONLY unified diff. No prose.
+- No binary diffs.
+- No delete/rename/move/chmod.
+- Prefer small, safe changes.
+- Touch only: mep/**, docs/MEP/**, .github/workflows/**, tools/runner/**, README.md
+Draft:"
+          BODY=$(jq -n --arg model "$MODEL" --arg input "$PROMPT\n$DRAFT" '{model:$model,input:$input,max_output_tokens:3500}')
+          curl -sS https://api.openai.com/v1/responses \
+            -H "Authorization: Bearer ${OPENAI_API_KEY}" \
+            -H "Content-Type: application/json" \
+            -d "$BODY" \
+            | jq -r '.output_text' > /tmp/mep.patch
+          test -s /tmp/mep.patch
+      - name: Guard (no binary / no delete-rename-move-chmod)
+        run: |
+          set -euo pipefail
+          if grep -nE 'GIT binary patch|^Binary files ' /tmp/mep.patch >/dev/null; then echo "STOP_HARD: BINARY_DIFF_FORBIDDEN"; exit 1; fi
+          if grep -nE '^deleted file mode|^rename from|^rename to|^old mode|^new mode' /tmp/mep.patch >/dev/null; then echo "STOP_HARD: DANGEROUS_DIFF_FORBIDDEN"; exit 1; fi
+      - name: Apply patch (check then apply)
+        run: |
+          set -euo pipefail
+          git apply --check /tmp/mep.patch
+          git apply /tmp/mep.patch
+      - name: Create PR
+        id: cpr
+        uses: peter-evans/create-pull-request@v6
+        with:
+          title: "MEP: apply (Issue Entry) run ${{ github.run_id }}"
+          body: |
+            Applied by MEP Issue Entry workflow.
+            - Event: ${{ github.event_name }}
+            - Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          commit-message: "mep: apply (Issue Entry) run ${{ github.run_id }}"
+          branch: "auto/mep_issue_entry_${{ github.run_id }}"
+          base: "main"
+          delete-branch: true
+      - name: Comment back
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue_number = context.payload.issue.number;
+            const prUrl = "${{ steps.cpr.outputs.pull-request-url }}";
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              body: prUrl ? `✅ MEP created PR: ${prUrl}\n(mode=Issue Entry)` : `⚠️ PR URL not returned (mode=Issue Entry)`,
+            });


### PR DESCRIPTION
Adds a clean issue_comment-only entry workflow (new file) to restore Issue→LLM→PR triggering without relying on workflow_dispatch.