### PR TITLE
fix(actions): use PAT for create-pull-request (required checks fire)

### DIFF
--- a/.github/workflows/mep_llm_dispatch_entry.yml
+++ b/.github/workflows/mep_llm_dispatch_entry.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Hello github-script
         uses: actions/github-script@v7
         with:
+          token: ${{ secrets.MEP_PR_TOKEN }}
           script: |
             core.info("hello");
       - name: Long bash (no network)
@@ -39,6 +40,7 @@ jobs:
       - name: Create PR (create-pull-request)
         uses: peter-evans/create-pull-request@v6
         with:
+          token: ${{ secrets.MEP_PR_TOKEN }}
           title: "MEP: apply (Dispatch Entry) run ${{ github.run_id }}"
           body: |
             Applied by MEP LLM Dispatch Entry.


### PR DESCRIPTION
PRs created via GITHUB_TOKEN produce zero check-runs/statuses, blocking merge by ruleset (5/5 required). Switch create-pull-request token to secrets.MEP_PR_TOKEN.