### PR TITLE
P2 guard: checkout PR head + diagnose SSOT missing

### DIFF
--- a/.github/workflows/mep_required_checks_ssot_guard_pr.yml
+++ b/.github/workflows/mep_required_checks_ssot_guard_pr.yml
@@ -11,7 +11,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-      - name: required checks ssot vs statusCheckRollup
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}`n      - name: required checks ssot vs statusCheckRollup
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
P2_REQUIRED_CHECKS guard fix
- Ensure actions/checkout checks out PR head SHA (github.event.pull_request.head.sha)
- Emit SSOT existence check in logs to make REQUIRED_CHECKS_SSOT_MISSING diagnosable
Why:
- gate job failing on PRs due to SSOT file missing at runtime (likely wrong ref checkout)