### PR TITLE
OP: Canonicalize v2 LLM dispatch entry; deprecate old

### DIFF
--- a/.github/workflows/mep_llm_dispatch_entry.yml
+++ b/.github/workflows/mep_llm_dispatch_entry.yml
@@ -1,4 +1,4 @@
-name: MEP LLM Dispatch Entry (ACTIVE)
+name: MEP LLM Dispatch Entry (ACTIVE) (DEPRECATED - use mep_llm_dispatch_entry_v2.yml)
 on:
   workflow_dispatch:
     inputs:

--- a/docs/MEP/ENTRY_CANONICAL.md
+++ b/docs/MEP/ENTRY_CANONICAL.md
@@ -1,0 +1,3 @@
+# ENTRY Canonical
+- Canonical dispatch entry: .github/workflows/mep_llm_dispatch_entry_v2.yml
+- Old entry (mep_llm_dispatch_entry.yml) is deprecated due to 422/ghost registration history.


### PR DESCRIPTION
Make v2 entry the canonical dispatch entry; mark old as deprecated and add docs/MEP/ENTRY_CANONICAL.md.