### PR TITLE
tools/docs: add P4 thresholds hardcode audit (non-CI)

### DIFF
--- a/docs/MEP/P4_THRESHOLDS_ENFORCE_REPORT.md
+++ b/docs/MEP/P4_THRESHOLDS_ENFORCE_REPORT.md
@@ -1,0 +1,13 @@
+# P4 Thresholds Enforce Report (v0)
+目的:
+- P4閾値（bytes/files/added）が SSOT に集約されていることを監査する
+- 参照側（workflow/runner）に固定値が散在しないことを確認する
+監査ツール:
+- tools/runner/p4_thresholds_audit.ps1
+運用:
+- 監査はローカルで実行できる（CI必須にはしない＝既存Required checksを壊さない）
+- 監査で検出が出た場合、該当箇所を SSOT参照へ統一する（PRで実施）
+実行例（PowerShell）:
+- pwsh -File tools/runner/p4_thresholds_audit.ps1
+  - exit 0: OK
+  - exit 2: hardcode検出（要修正）

--- a/tools/runner/p4_thresholds_audit.ps1
+++ b/tools/runner/p4_thresholds_audit.ps1
@@ -1,0 +1,52 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+param(
+  [string]$RepoRoot = (git rev-parse --show-toplevel),
+  [string]$SsotPath = "docs/MEP/P4_THRESHOLDS_SSOT.md"
+)
+if (-not $RepoRoot) { throw "REPO_ROOT_NOT_FOUND" }
+Set-Location $RepoRoot
+$targets = @(
+  ".github/workflows",
+  "tools",
+  "mep",
+  "docs"
+)
+$patterns = @(
+  "max_bytes\s*=\s*250000",
+  "max_files\s*=\s*60",
+  "max_added\s*=\s*2000",
+  "P4_MAX_BYTES\s*=\s*250000",
+  "P4_MAX_FILES\s*=\s*60",
+  "P4_MAX_ADDED\s*=\s*2000"
+)
+$ignore = @(
+  [IO.Path]::GetFullPath((Join-Path $RepoRoot $SsotPath)).ToLowerInvariant()
+)
+$hits = New-Object System.Collections.Generic.List[object]
+foreach($t in $targets){
+  $p = Join-Path $RepoRoot $t
+  if (-not (Test-Path $p)) { continue }
+  Get-ChildItem -Path $p -Recurse -File -ErrorAction SilentlyContinue | ForEach-Object {
+    $full = $_.FullName.ToLowerInvariant()
+    if ($ignore -contains $full) { return }
+    $text = $null
+    try { $text = Get-Content $_.FullName -Raw -ErrorAction Stop } catch { return }
+    foreach($pat in $patterns){
+      if ($text -match $pat){
+        $hits.Add([pscustomobject]@{ file=$_.FullName; pattern=$pat })
+      }
+    }
+  }
+}
+"REPO_ROOT=$RepoRoot"
+"SSOT=$SsotPath"
+"HITS=$($hits.Count)"
+if ($hits.Count -gt 0) {
+  $hits | Sort-Object file,pattern | Format-Table -AutoSize | Out-String | Write-Output
+  exit 2
+} else {
+  "OK: no hardcoded P4 thresholds found outside SSOT"
+  exit 0
+}


### PR DESCRIPTION
Add tools/runner/p4_thresholds_audit.ps1 and docs report. No workflow behavior change; avoids adding new required checks.