### PR TITLE
fix: p4_thresholds_audit.ps1 parser error

### DIFF
--- a/tools/runner/p4_thresholds_audit.ps1
+++ b/tools/runner/p4_thresholds_audit.ps1
@@ -2,9 +2,12 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 $ProgressPreference = "SilentlyContinue"
 param(
-  [string]$RepoRoot = (git rev-parse --show-toplevel),
+  [string]$RepoRoot = "",
   [string]$SsotPath = "docs/MEP/P4_THRESHOLDS_SSOT.md"
 )
+if (-not $RepoRoot) {
+  $RepoRoot = (git rev-parse --show-toplevel).Trim()
+}
 if (-not $RepoRoot) { throw "REPO_ROOT_NOT_FOUND" }
 Set-Location $RepoRoot
 $targets = @(


### PR DESCRIPTION
Fix invalid param default that caused ParserError. No workflow behavior change.