### PR TITLE
docs: v2 step summary observability pointers

### DIFF
--- a/.github/workflows/mep_llm_dispatch_entry_v2.yml
+++ b/.github/workflows/mep_llm_dispatch_entry_v2.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+
       - name: Checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Add a non-behavioral step to v2 workflow that prints RUN_URL and how to use tools/runner/mep_observe_run.ps1 into Step Summary.