### PR TITLE
fix: p4_thresholds_audit.ps1 param position (v3)

### DIFF
--- a/tools/runner/p4_thresholds_audit.ps1
+++ b/tools/runner/p4_thresholds_audit.ps1
@@ -1,10 +1,10 @@
-Set-StrictMode -Version Latest
-$ErrorActionPreference = "Stop"
-$ProgressPreference = "SilentlyContinue"
 param(
   [string]$RepoRoot,
   [string]$SsotPath
 )
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
 if (-not $RepoRoot) {
   $RepoRoot = (git rev-parse --show-toplevel).Trim()
 }


### PR DESCRIPTION
Move param(...) to the top of the script to satisfy PowerShell script param rules. Fixes runtime InvalidOperation. No workflow behavior change.