### PR TITLE
runner: wire pr-probe subcommand (Phase2)

### DIFF
--- a/tools/runner/runner.py
+++ b/tools/runner/runner.py
@@ -265,6 +265,7 @@ def main() -> int:
         return status()
     if args.cmd == "apply":
         return apply(Path(args.draft_file))
-    return 1
+    if args.cmd == "pr-probe":
+        return pr_probe(args.run_id)    return 1
 if __name__ == "__main__":
     sys.exit(main())


### PR DESCRIPTION
Fix Phase2 wiring: add argparse subcommand pr-probe and main dispatch to call pr_probe(). No behavior change beyond enabling the CLI.