### PR TITLE
runner: fix newline before __main__ guard

### DIFF
--- a/tools/runner/runner.py
+++ b/tools/runner/runner.py
@@ -269,5 +269,7 @@ def main() -> int:
         return apply(Path(args.draft_file))
     if args.cmd == "pr-probe":
         return pr_probe(args.run_id)
-    return 1if __name__ == "__main__":
+    return 1
+
+if __name__ == "__main__":
     sys.exit(main())


### PR DESCRIPTION
Fix runner.py SyntaxError caused by missing newline between "return 1" and "__main__" guard.
This restores runnable CLI for boot/status/apply/pr-probe.