### PR TITLE
runner: repair main() wiring (post-2234)

### DIFF
--- a/tools/runner/runner.py
+++ b/tools/runner/runner.py
@@ -346,7 +346,8 @@ def main() -> int:
     ap_probe = sub.add_parser("pr-probe")
     ap_probe.add_argument("--run-id", required=True)
     ap_create = sub.add_parser("pr-create")
-    ap_create.add_argument("--run-id", required=True)    args = ap.parse_args()
+    ap_create.add_argument("--run-id", required=True)
+    args = ap.parse_args()
     if args.cmd == "boot":
         return boot()
     if args.cmd == "status":
@@ -356,7 +357,8 @@ def main() -> int:
     if args.cmd == "pr-probe":
         return pr_probe(args.run_id)
     if args.cmd == "pr-create":
-        return pr_create(args.run_id)    return 1
+        return pr_create(args.run_id)
+    return 1
 
 if __name__ == "__main__":
     sys.exit(main())


### PR DESCRIPTION
Repair runner.py after PR2234 introduced SyntaxError by concatenated lines. Replace main() block with a clean argparse wiring for boot/status/apply/pr-probe/pr-create. Restores runnable CLI.