### PR TITLE
runner: add Phase5 compaction

### DIFF
--- a/tools/runner/runner.py
+++ b/tools/runner/runner.py
@@ -596,6 +596,147 @@ def merge_finish(run_id: str) -> int:
     write_json(RUN_STATE, rs); update_compiled(rs)
     print(json.dumps({"state":"OK","pr_url":pr_url,"run_status":rs["run_status"]}, ensure_ascii=False))
     return 0
+def compact() -> int:
+    # Phase5 minimal: history retention + pinned_overflow detection + (optional) delete if explicitly allowed
+    rs = load_json(RUN_STATE) if RUN_STATE.exists() else default_run_state()
+    rs["updated_at"] = utc_now_z()
+    rs["last_result"]["timestamp_utc"] = rs["updated_at"]
+    rs["last_result"]["action"] = {"name": "COMPACTION", "outcome": "OK"}
+    pol = load_yaml(POLICY) if POLICY.exists() else {}
+    retention = (pol.get("retention") or {})
+    limits = (pol.get("limits") or {})
+    keep_runs = int(retention.get("keep_runs", 0) or 0)
+    history_k = int(retention.get("history_k", 0) or 0)
+    pinned_runs = retention.get("pinned_runs", []) or []
+    pinned_max = int(retention.get("pinned_max", 0) or 0)
+    allow_delete = bool(retention.get("allow_delete", False))
+    # Safety defaults (if missing)
+    if keep_runs <= 0:
+        keep_runs = 20
+    if history_k <= 0:
+        history_k = 10
+    if pinned_max <= 0:
+        pinned_max = 50
+    # Maintain run_state.history as append-only summary (best-effort)
+    hist = rs.get("history") or []
+    if not isinstance(hist, list):
+        hist = []
+    # build summary entry for current run_state
+    lr = rs.get("last_result") or {}
+    ev = lr.get("evidence") or {}
+    entry = {
+        "run_id": rs.get("run_id","") or "",
+        "result_state": rs.get("run_status","") or "",
+        "stop_class": lr.get("stop_class","") or "",
+        "reason_code": lr.get("reason_code","") or "",
+        "evidence": {
+            "pr_url": ev.get("pr_url"),
+            "commit_sha": ev.get("commit_sha"),
+            "workflow_run_url": ev.get("workflow_run_url"),
+            "branch_name": ev.get("branch_name"),
+        },
+        "timestamp_utc": lr.get("timestamp_utc") or rs.get("updated_at") or utc_now_z(),
+    }
+    hist.append(entry)
+    # Keep last K
+    if len(hist) > history_k:
+        hist = hist[-history_k:]
+    rs["history"] = hist
+    # pinned overflow detection
+    pinned_total = len(pinned_runs)
+    if pinned_total > pinned_max:
+        rs["last_result"]["stop_class"] = "WAIT"
+        rs["last_result"]["reason_code"] = "PINNED_OVERFLOW"
+        rs["next_action"] = "RESOLVE_PINNED_OVERFLOW"
+        write_json(RUN_STATE, rs); update_compiled(rs)
+        print(json.dumps({
+            "state":"STOP",
+            "reason_code":rs["last_result"]["reason_code"],
+            "next_action":rs["next_action"],
+            "pinned_total":pinned_total,
+            "pinned_max":pinned_max
+        }, ensure_ascii=False))
+        return 2
+    # NOTE: Actual deletion of old runs is not implemented as file deletions here (runner is repo-level).
+    # Instead we enforce policy contract:
+    # - If allow_delete is false: emit STOP_WAIT with candidate guidance when keep_runs threshold would be exceeded.
+    # In this codebase, "runs" are represented externally (folders under mep/inbox/work_items/results). We'll scan those.
+    # scan local run folders
+    inbox = (MEP_DIR / "inbox")
+    work_items = (MEP_DIR / "work_items")
+    results = (MEP_DIR / "results")
+    def _list_runs_from_dir(d: Path) -> set[str]:
+        out=set()
+        if not d.exists():
+            return out
+        for p in d.iterdir():
+            name = p.name
+            # draft_<RUN_ID>.md in inbox
+            if d == inbox and name.startswith("draft_RUN_") and name.endswith(".md"):
+                rid = name[len("draft_"):-len(".md")]
+                out.add(rid)
+            # mep/work_items/<RUN_ID>/
+            if d == work_items and p.is_dir() and name.startswith("RUN_"):
+                out.add(name)
+            # mep/results/<RUN_ID>/
+            if d == results and p.is_dir() and name.startswith("RUN_"):
+                out.add(name)
+        return out
+    run_ids = set()
+    run_ids |= _list_runs_from_dir(inbox)
+    run_ids |= _list_runs_from_dir(work_items)
+    run_ids |= _list_runs_from_dir(results)
+    # exclude STILL_OPEN (cannot know precisely without per-run state store; so we exclude current run_id and any pinned)
+    current = rs.get("run_id","") or ""
+    candidates = sorted([r for r in run_ids if r and r != current and r not in pinned_runs])
+    # If exceeds keep_runs, we would delete oldest "DONE/FAILED/SKIPPED" ideally; but we don't have per-run status store.
+    # Therefore we only stop and ask for enabling allow_delete after wiring per-run state.
+    if len(run_ids) > keep_runs and not allow_delete:
+        rs["last_result"]["stop_class"] = "WAIT"
+        rs["last_result"]["reason_code"] = "RETENTION_ACTION_REQUIRED"
+        rs["next_action"] = "SET_retention.allow_delete_true_OR_IMPLEMENT_PER_RUN_STATE"
+        write_json(RUN_STATE, rs); update_compiled(rs)
+        print(json.dumps({
+            "state":"STOP",
+            "reason_code":rs["last_result"]["reason_code"],
+            "next_action":rs["next_action"],
+            "run_count_detected":len(run_ids),
+            "keep_runs":keep_runs,
+            "delete_candidates_sample":candidates[:10],
+        }, ensure_ascii=False))
+        return 2
+    # If allow_delete is true, perform conservative deletion: delete only results/work_items for the oldest candidates (lexicographic)
+    # This is a placeholder safety implementation (no inbox deletion) to avoid losing original draft evidence.
+    if len(run_ids) > keep_runs and allow_delete:
+        overflow = len(run_ids) - keep_runs
+        to_delete = candidates[:overflow]
+        for rid in to_delete:
+            # remove results and work_items folders only
+            d1 = results / rid
+            d2 = work_items / rid
+            for d in (d1,d2):
+                if d.exists() and d.is_dir():
+                    for child in d.rglob("*"):
+                        if child.is_file():
+                            child.unlink()
+                    # remove dirs bottom-up
+                    for child in sorted([x for x in d.rglob("*") if x.is_dir()], key=lambda x: len(str(x)), reverse=True):
+                        try: child.rmdir()
+                        except Exception: pass
+                    try: d.rmdir()
+                    except Exception: pass
+        rs["last_result"]["stop_class"] = ""
+        rs["last_result"]["reason_code"] = ""
+        rs["next_action"] = "STATUS"
+        write_json(RUN_STATE, rs); update_compiled(rs)
+        print(json.dumps({"state":"OK","deleted_count":len(to_delete),"deleted_run_ids":to_delete}, ensure_ascii=False))
+        return 0
+    rs["last_result"]["stop_class"] = ""
+    rs["last_result"]["reason_code"] = ""
+    rs["next_action"] = "STATUS"
+    write_json(RUN_STATE, rs); update_compiled(rs)
+    print(json.dumps({"state":"OK","run_count_detected":len(run_ids),"keep_runs":keep_runs}, ensure_ascii=False))
+    return 0
 def main() -> int:
     ap = argparse.ArgumentParser(prog="runner.py")
     sub = ap.add_subparsers(dest="cmd", required=True)
@@ -613,6 +754,7 @@ def main() -> int:
     ap_safe.add_argument("--run-id", required=True)
     ap_finish = sub.add_parser("merge-finish")
     ap_finish.add_argument("--run-id", required=True)
+    sub.add_parser("compact")
     args = ap.parse_args()
     if args.cmd == "boot":
         return boot()
@@ -630,6 +772,8 @@ def main() -> int:
         return apply_safe(args.run_id)
     if args.cmd == "merge-finish":
         return merge_finish(args.run_id)
+    if args.cmd == "compact":
+        return compact()
     return 1
 
 if __name__ == "__main__":


### PR DESCRIPTION
Implement Spec v2.1 Phase5 minimal: compact command updates run_state.history (retention.history_k), detects pinned_overflow, detects keep_runs overflow and either STOP_WAIT with candidates or (if retention.allow_delete=true) deletes oldest results/work_items folders. No deletion of inbox drafts.