### PR TITLE
runner: wire handoff ACK + gate destructive ops

### DIFF
--- a/tools/runner/runner.py
+++ b/tools/runner/runner.py
@@ -63,93 +63,11 @@ def default_run_state() -> dict:
             "options": [],
             "delete_candidates_sample": [],
         },
-        "work_summary": {
-            "total": "unknown",
-            "ready": "unknown",
-            "in_progress": "unknown",
-            "done": "unknown",
-            "stop": "unknown",
-        },
         "history": [],
         "updated_at": now,
-        "last_good": None,
+        "handoff": None,
+        "handoff_ack": None,
     }
-import re
-def _sha256_hex(s: str) -> str:
-    import hashlib
-    return hashlib.sha256(s.encode("utf-8")).hexdigest()
-def compute_handoff_digest(head_sha: str, rs: dict) -> str:
-    lr = rs.get("last_result", {}) or {}
-    parts = [
-        head_sha or "",
-        rs.get("run_id","") or "",
-        rs.get("run_status","") or "",
-        rs.get("next_action","") or "",
-        lr.get("stop_class","") or "",
-        lr.get("reason_code","") or "",
-        rs.get("updated_at","") or "",
-    ]
-    return _sha256_hex("\n".join(parts))
-def compiled_min_check(status_md: Path, audit_md: Path, work_md: Path) -> tuple[bool,str]:
-    # A章最小必須：簡易チェック（欠落ならNG）
-    try:
-        s = status_md.read_text(encoding="utf-8")
-        a = audit_md.read_text(encoding="utf-8")
-        w = work_md.read_text(encoding="utf-8")
-    except Exception:
-        return (False, "COMPILED_READ_FAILED")
-    need_status = ["RUN_ID:", "RUN_STATUS:", "STOP_CLASS:", "REASON_CODE:", "NEXT_ACTION:", "TIMESTAMP_UTC:", "EVIDENCE:"]
-    if any(x not in s for x in need_status):
-        return (False, "COMPILED_TEMPLATE_INCOMPLETE_STATUS")
-    need_audit = ["SSOT_PATHS:", "mep/boot_spec.yaml", "mep/policy.yaml", "mep/run_state.json", "LATEST_EVIDENCE_POINTERS:"]
-    if any(x not in a for x in need_audit):
-        return (False, "COMPILED_TEMPLATE_INCOMPLETE_AUDIT")
-    need_work = ["NEXT_ACTION:", "REASON_CODE:", "STOP_CLASS:"]
-    if any(x not in w for x in need_work):
-        return (False, "COMPILED_TEMPLATE_INCOMPLETE_WORK")
-    return (True, "")
-def update_handoff_packet_and_ack(rs: dict) -> dict:
-    # packet
-    head_sha = _run(["git","rev-parse","HEAD"]).strip()
-    packet_id = f"HP_{utc_now_z().replace(':','').replace('-','')}"
-    ssot_paths = ["mep/boot_spec.yaml","mep/policy.yaml","mep/run_state.json"]
-    compiled_paths = ["docs/MEP/STATUS.md","docs/MEP/HANDOFF_AUDIT.md","docs/MEP/HANDOFF_WORK.md"]
-    rs["handoff"] = {
-        "packet_id": packet_id,
-        "generated_at_utc": utc_now_z(),
-        "head_sha": head_sha,
-        "ssot_paths": ssot_paths,
-        "compiled_paths": compiled_paths,
-        "digest": compute_handoff_digest(head_sha, rs),
-    }
-    ok, reason = compiled_min_check(STATUS_MD, HANDOFF_AUDIT_MD, HANDOFF_WORK_MD)
-    if ok:
-        rs["handoff_ack"] = {
-            "status": "ACK",
-            "checked_at_utc": utc_now_z(),
-            "reason_code": None,
-            "packet_id": packet_id,
-        }
-    else:
-        rs["handoff_ack"] = {
-            "status": "NACK",
-            "checked_at_utc": utc_now_z(),
-            "reason_code": reason,
-            "packet_id": packet_id,
-        }
-        # force STOP_WAIT-like state
-        rs["last_result"]["stop_class"] = "WAIT"
-        rs["last_result"]["reason_code"] = "HANDOFF_ACK_REQUIRED"
-        rs["next_action"] = "NEED_HANDOFF_ACK"
-    return rs
-def require_handoff_ack(rs: dict) -> tuple[bool,dict]:
-    ha = rs.get("handoff_ack") or {}
-    if ha.get("status") == "ACK":
-        return (True, rs)
-    rs["last_result"]["stop_class"] = "WAIT"
-    rs["last_result"]["reason_code"] = "HANDOFF_ACK_REQUIRED"
-    rs["next_action"] = "NEED_HANDOFF_ACK"
-    return (False, rs)
 def update_compiled(rs: dict) -> None:
     run_id = rs.get("run_id") or "NONE"
     run_status = rs.get("run_status", "")
@@ -215,16 +133,88 @@ def _run(cmd: list[str]) -> str:
     if p.returncode != 0:
         raise RuntimeError(p.stderr.strip() or "command failed")
     return p.stdout
+def _sha256_hex(s: str) -> str:
+    return hashlib.sha256(s.encode("utf-8")).hexdigest()
+def compute_handoff_digest(head_sha: str, rs: dict) -> str:
+    lr = rs.get("last_result", {}) or {}
+    parts = [
+        head_sha or "",
+        rs.get("run_id", "") or "",
+        rs.get("run_status", "") or "",
+        rs.get("next_action", "") or "",
+        lr.get("stop_class", "") or "",
+        lr.get("reason_code", "") or "",
+        rs.get("updated_at", "") or "",
+    ]
+    return _sha256_hex("\n".join(parts))
+def compiled_min_check() -> tuple[bool, str]:
+    try:
+        s = STATUS_MD.read_text(encoding="utf-8")
+        a = HANDOFF_AUDIT_MD.read_text(encoding="utf-8")
+        w = HANDOFF_WORK_MD.read_text(encoding="utf-8")
+    except Exception:
+        return (False, "COMPILED_READ_FAILED")
+    need_status = ["RUN_ID:", "RUN_STATUS:", "STOP_CLASS:", "REASON_CODE:", "NEXT_ACTION:", "TIMESTAMP_UTC:", "EVIDENCE:"]
+    if any(x not in s for x in need_status):
+        return (False, "COMPILED_TEMPLATE_INCOMPLETE_STATUS")
+    need_audit = ["SSOT_PATHS:", "mep/boot_spec.yaml", "mep/policy.yaml", "mep/run_state.json", "LATEST_EVIDENCE_POINTERS:"]
+    if any(x not in a for x in need_audit):
+        return (False, "COMPILED_TEMPLATE_INCOMPLETE_AUDIT")
+    need_work = ["NEXT_ACTION:", "REASON_CODE:", "STOP_CLASS:"]
+    if any(x not in w for x in need_work):
+        return (False, "COMPILED_TEMPLATE_INCOMPLETE_WORK")
+    return (True, "")
+def update_handoff_packet_and_ack(rs: dict) -> dict:
+    head_sha = _run(["git", "rev-parse", "HEAD"]).strip()
+    packet_id = "HP_" + utc_now_z().replace(":", "").replace("-", "")
+    rs["handoff"] = {
+        "packet_id": packet_id,
+        "generated_at_utc": utc_now_z(),
+        "head_sha": head_sha,
+        "ssot_paths": ["mep/boot_spec.yaml", "mep/policy.yaml", "mep/run_state.json"],
+        "compiled_paths": ["docs/MEP/STATUS.md", "docs/MEP/HANDOFF_AUDIT.md", "docs/MEP/HANDOFF_WORK.md"],
+        "digest": compute_handoff_digest(head_sha, rs),
+    }
+    ok, reason = compiled_min_check()
+    if ok:
+        rs["handoff_ack"] = {
+            "status": "ACK",
+            "checked_at_utc": utc_now_z(),
+            "reason_code": None,
+            "packet_id": packet_id,
+        }
+    else:
+        rs["handoff_ack"] = {
+            "status": "NACK",
+            "checked_at_utc": utc_now_z(),
+            "reason_code": reason,
+            "packet_id": packet_id,
+        }
+        rs["last_result"]["stop_class"] = "WAIT"
+        rs["last_result"]["reason_code"] = "HANDOFF_ACK_REQUIRED"
+        rs["next_action"] = "NEED_HANDOFF_ACK"
+    return rs
+def require_handoff_ack(rs: dict) -> tuple[bool, dict]:
+    ha = rs.get("handoff_ack") or {}
+    if ha.get("status") == "ACK":
+        return (True, rs)
+    rs["last_result"]["stop_class"] = "WAIT"
+    rs["last_result"]["reason_code"] = "HANDOFF_ACK_REQUIRED"
+    rs["next_action"] = "NEED_HANDOFF_ACK"
+    return (False, rs)
+def _after_compiled(rs: dict) -> dict:
+    # ensure compiled exists, then create packet+ack and persist
+    rs = update_handoff_packet_and_ack(rs)
+    write_json(RUN_STATE, rs)
+    update_compiled(rs)
+    return rs
 def boot() -> int:
     if not BOOT_SPEC.exists():
         ensure_parent(BOOT_SPEC)
         BOOT_SPEC.write_text("# mep/boot_spec.yaml (AUTO GENERATED)\n", encoding="utf-8")
     if not POLICY.exists():
         ensure_parent(POLICY)
-        POLICY.write_text(
-            "# mep/policy.yaml (AUTO GENERATED)\npaths_allow: []\npaths_deny: []\n",
-            encoding="utf-8",
-        )
+        POLICY.write_text("# mep/policy.yaml (AUTO GENERATED)\npaths_allow: []\npaths_deny: []\n", encoding="utf-8")
     rs = load_json(RUN_STATE) if RUN_STATE.exists() else default_run_state()
     rs["updated_at"] = utc_now_z()
     rs["last_result"]["timestamp_utc"] = rs["updated_at"]
@@ -232,7 +222,8 @@ def boot() -> int:
     rs["next_action"] = "STATUS"
     write_json(RUN_STATE, rs)
     update_compiled(rs)
-    print(json.dumps({"run_id": rs.get("run_id",""), "run_status": rs.get("run_status",""), "next_action": rs.get("next_action","")}, ensure_ascii=False))
+    rs = _after_compiled(rs)
+    print(json.dumps({"run_id": rs.get("run_id", ""), "run_status": rs.get("run_status", ""), "next_action": rs.get("next_action", "")}, ensure_ascii=False))
     return 0
 def status() -> int:
     if not RUN_STATE.exists():
@@ -244,7 +235,8 @@ def status() -> int:
     rs["next_action"] = "STATUS"
     write_json(RUN_STATE, rs)
     update_compiled(rs)
-    print(json.dumps({"run_id": rs.get("run_id",""), "run_status": rs.get("run_status",""), "next_action": rs.get("next_action","")}, ensure_ascii=False))
+    rs = _after_compiled(rs)
+    print(json.dumps({"run_id": rs.get("run_id", ""), "run_status": rs.get("run_status", ""), "next_action": rs.get("next_action", "")}, ensure_ascii=False))
     return 0
 def apply(draft_file: Path) -> int:
     if not draft_file.exists():
@@ -267,7 +259,8 @@ def apply(draft_file: Path) -> int:
     rs["next_action"] = "STATUS"
     write_json(RUN_STATE, rs)
     update_compiled(rs)
-    print(json.dumps({"run_id": run_id, "next_action": rs["next_action"]}, ensure_ascii=False))
+    rs = _after_compiled(rs)
+    print(json.dumps({"run_id": run_id, "next_action": rs.get("next_action", "")}, ensure_ascii=False))
     return 0
 def pr_probe(run_id: str) -> int:
     branch = f"mep/run_{run_id}"
@@ -285,8 +278,8 @@ def pr_probe(run_id: str) -> int:
         write_json(RUN_STATE, rs); update_compiled(rs)
         return 1
     try:
-        open_json = _run(["gh","pr","list","--repo",repo,"--head",branch,"--state","open","--json","number,url","-q","."])
-        closed_json = _run(["gh","pr","list","--repo",repo,"--head",branch,"--state","closed","--json","number,url","-q","."])
+        open_json = _run(["gh", "pr", "list", "--repo", repo, "--head", branch, "--state", "open", "--json", "number,url", "-q", "."])
+        closed_json = _run(["gh", "pr", "list", "--repo", repo, "--head", branch, "--state", "closed", "--json", "number,url", "-q", "."])
         open_prs = json.loads(open_json) if open_json.strip() else []
         closed_prs = json.loads(closed_json) if closed_json.strip() else []
     except Exception:
@@ -305,7 +298,6 @@ def pr_probe(run_id: str) -> int:
         rs["last_result"]["reason_code"] = ""
         rs["next_action"] = "STATUS"
         write_json(RUN_STATE, rs); update_compiled(rs)
-        print(json.dumps({"state":"OK","branch_name":branch,"pr_url":ev["pr_url"]}, ensure_ascii=False))
         return 0
     if len(open_prs) == 0 and len(closed_prs) >= 1:
         rs["last_result"]["stop_class"] = "WAIT"
@@ -342,38 +334,34 @@ def pr_create(run_id: str) -> int:
         rs["next_action"] = "SET_GH_REPO"
         write_json(RUN_STATE, rs); update_compiled(rs)
         return 1
-    # ensure branch exists
     try:
-        _run(["git","rev-parse","--verify",branch])
+        _run(["git", "rev-parse", "--verify", branch])
     except Exception:
-        _run(["git","checkout","-b",branch])
-        _run(["git","push","-u","origin",branch])
+        _run(["git", "checkout", "-b", branch])
+        _run(["git", "push", "-u", "origin", branch])
     else:
         try:
-            _run(["git","ls-remote","--exit-code","--heads","origin",branch])
+            _run(["git", "ls-remote", "--exit-code", "--heads", "origin", branch])
         except Exception:
-            _run(["git","push","-u","origin",branch])
-    open_json = _run(["gh","pr","list","--repo",repo,"--head",branch,"--state","open","--json","number,url","-q","."])
+            _run(["git", "push", "-u", "origin", branch])
+    open_json = _run(["gh", "pr", "list", "--repo", repo, "--head", branch, "--state", "open", "--json", "number,url", "-q", "."])
     open_prs = json.loads(open_json) if open_json.strip() else []
     if len(open_prs) > 1:
         rs["last_result"]["stop_class"] = "HARD"
         rs["last_result"]["reason_code"] = "MULTIPLE_PR_FOR_ONE_RUN"
         rs["next_action"] = "MANUAL_RESOLUTION_REQUIRED"
-        rs["last_result"]["evidence"] = {"branch_name": branch}
         write_json(RUN_STATE, rs); update_compiled(rs)
         return 1
     if len(open_prs) == 1:
         pr_url = open_prs[0].get("url")
         rs["last_result"]["evidence"] = {"branch_name": branch, "pr_url": pr_url}
         write_json(RUN_STATE, rs); update_compiled(rs)
-        print(json.dumps({"state":"OK","branch_name":branch,"pr_url":pr_url}, ensure_ascii=False))
         return 0
     title = f"MEP RUN {run_id}"
     body = f"Runner created PR for RUN_ID={run_id}"
-    pr_url = _run(["gh","pr","create","--repo",repo,"--head",branch,"--base","main","--title",title,"--body",body]).strip()
+    pr_url = _run(["gh", "pr", "create", "--repo", repo, "--head", branch, "--base", "main", "--title", title, "--body", body]).strip()
     rs["last_result"]["evidence"] = {"branch_name": branch, "pr_url": pr_url}
     write_json(RUN_STATE, rs); update_compiled(rs)
-    print(json.dumps({"state":"OK","branch_name":branch,"pr_url":pr_url}, ensure_ascii=False))
     return 0
 def assemble_pr(run_id: str) -> int:
     results_dir = MEP_DIR / "results" / run_id
@@ -401,7 +389,7 @@ def assemble_pr(run_id: str) -> int:
         return 1
     total_bytes = 0
     total_lines = 0
-    deny = ["GIT binary patch","Binary files ","deleted file mode","rename from","rename to","old mode","new mode"]
+    deny = ["GIT binary patch", "Binary files ", "deleted file mode", "rename from", "rename to", "old mode", "new mode"]
     for p in patches:
         txt = p.read_text(encoding="utf-8", errors="replace")
         total_bytes += len(txt.encode("utf-8", errors="replace"))
@@ -423,9 +411,13 @@ def assemble_pr(run_id: str) -> int:
     rs["last_result"]["reason_code"] = ""
     rs["next_action"] = "READY_TO_APPLY_SAFE_PATH"
     write_json(RUN_STATE, rs); update_compiled(rs)
-    print(json.dumps({"state":"OK","patches":len(patches),"bytes":total_bytes,"lines":total_lines,"next_action":rs["next_action"]}, ensure_ascii=False))
     return 0
 def apply_safe(run_id: str) -> int:
+    rs_guard = load_json(RUN_STATE) if RUN_STATE.exists() else default_run_state()
+    ok, rs_guard = require_handoff_ack(rs_guard)
+    if not ok:
+        write_json(RUN_STATE, rs_guard); update_compiled(rs_guard)
+        return 2
     branch = f"mep/run_{run_id}"
     results_dir = MEP_DIR / "results" / run_id
     patches = sorted(results_dir.glob("*.patch")) if results_dir.exists() else []
@@ -440,7 +432,7 @@ def apply_safe(run_id: str) -> int:
         rs["next_action"] = "WAIT_FOR_WORKER_RESULTS"
         write_json(RUN_STATE, rs); update_compiled(rs)
         return 2
-    repo = os.environ.get("GH_REPO","")
+    repo = os.environ.get("GH_REPO", "")
     if not repo:
         rs["last_result"]["stop_class"] = "HARD"
         rs["last_result"]["reason_code"] = "REPO_NOT_SET"
@@ -448,18 +440,18 @@ def apply_safe(run_id: str) -> int:
         write_json(RUN_STATE, rs); update_compiled(rs)
         return 1
     try:
-        _run(["git","checkout",branch])
+        _run(["git", "checkout", branch])
     except Exception:
-        _run(["git","checkout","-b",branch])
-        _run(["git","push","-u","origin",branch])
+        _run(["git", "checkout", "-b", branch])
+        _run(["git", "push", "-u", "origin", branch])
     for p in patches:
-        _run(["git","apply","--check",str(p)])
+        _run(["git", "apply", "--check", str(p)])
     for p in patches:
-        _run(["git","apply",str(p)])
-    _run(["git","add","-A"])
-    _run(["git","commit","-m",f"mep: apply patches for {run_id}"])
-    _run(["git","push","origin",branch])
-    open_json = _run(["gh","pr","list","--repo",repo,"--head",branch,"--state","open","--json","number,url","-q","."])
+        _run(["git", "apply", str(p)])
+    _run(["git", "add", "-A"])
+    _run(["git", "commit", "-m", f"mep: apply patches for {run_id}"])
+    _run(["git", "push", "origin", branch])
+    open_json = _run(["gh", "pr", "list", "--repo", repo, "--head", branch, "--state", "open", "--json", "number,url", "-q", "."])
     open_prs = json.loads(open_json) if open_json.strip() else []
     if len(open_prs) > 1:
         rs["last_result"]["stop_class"] = "HARD"
@@ -472,22 +464,26 @@ def apply_safe(run_id: str) -> int:
     else:
         title = f"MEP RUN {run_id} (apply)"
         body = f"Runner applied patches and updated branch for RUN_ID={run_id}"
-        pr_url = _run(["gh","pr","create","--repo",repo,"--head",branch,"--base","main","--title",title,"--body",body]).strip()
-    sha = _run(["git","rev-parse","HEAD"]).strip()
+        pr_url = _run(["gh", "pr", "create", "--repo", repo, "--head", branch, "--base", "main", "--title", title, "--body", body]).strip()
+    sha = _run(["git", "rev-parse", "HEAD"]).strip()
     rs["last_result"]["evidence"] = {"branch_name": branch, "pr_url": pr_url, "commit_sha": sha}
     rs["last_result"]["stop_class"] = ""
     rs["last_result"]["reason_code"] = ""
     rs["next_action"] = "STATUS"
     write_json(RUN_STATE, rs); update_compiled(rs)
-    print(json.dumps({"state":"OK","branch_name":branch,"pr_url":pr_url,"commit_sha":sha}, ensure_ascii=False))
     return 0
 def merge_finish(run_id: str) -> int:
+    rs_guard = load_json(RUN_STATE) if RUN_STATE.exists() else default_run_state()
+    ok, rs_guard = require_handoff_ack(rs_guard)
+    if not ok:
+        write_json(RUN_STATE, rs_guard); update_compiled(rs_guard)
+        return 2
     rs = load_json(RUN_STATE) if RUN_STATE.exists() else default_run_state()
     rs["run_id"] = run_id
     rs["updated_at"] = utc_now_z()
     rs["last_result"]["timestamp_utc"] = rs["updated_at"]
     rs["last_result"]["action"] = {"name": "MERGE_FINISH", "outcome": "OK"}
-    repo = os.environ.get("GH_REPO","")
+    repo = os.environ.get("GH_REPO", "")
     ev = rs.get("last_result", {}).get("evidence", {}) or {}
     pr_url = ev.get("pr_url") or ""
     if not repo or not pr_url:
@@ -498,7 +494,7 @@ def merge_finish(run_id: str) -> int:
         return 2
     pr_num = int(pr_url.rstrip("/").split("/")[-1])
     for _ in range(360):
-        out = _run(["gh","pr","checks",str(pr_num),"--repo",repo])
+        out = _run(["gh", "pr", "checks", str(pr_num), "--repo", repo])
         if "0 pending checks" in out and "0 failing" in out:
             break
         time.sleep(5)
@@ -508,9 +504,9 @@ def merge_finish(run_id: str) -> int:
         rs["next_action"] = "WAIT_FOR_CHECKS"
         write_json(RUN_STATE, rs); update_compiled(rs)
         return 2
-    _run(["gh","pr","merge",str(pr_num),"--repo",repo,"--auto","--squash"])
+    _run(["gh", "pr", "merge", str(pr_num), "--repo", repo, "--auto", "--squash"])
     for _ in range(360):
-        j = _run(["gh","pr","view",str(pr_num),"--repo",repo,"--json","state","-q","{state:.state}"])
+        j = _run(["gh", "pr", "view", str(pr_num), "--repo", repo, "--json", "state", "-q", "{state:.state}"])
         if '"state":"MERGED"' in j:
             break
         time.sleep(5)
@@ -525,9 +521,13 @@ def merge_finish(run_id: str) -> int:
     rs["last_result"]["reason_code"] = ""
     rs["next_action"] = "ALL_DONE"
     write_json(RUN_STATE, rs); update_compiled(rs)
-    print(json.dumps({"state":"OK","pr_url":pr_url,"run_status":rs["run_status"]}, ensure_ascii=False))
     return 0
 def compact() -> int:
+    rs_guard = load_json(RUN_STATE) if RUN_STATE.exists() else default_run_state()
+    ok, rs_guard = require_handoff_ack(rs_guard)
+    if not ok:
+        write_json(RUN_STATE, rs_guard); update_compiled(rs_guard)
+        return 2
     rs = load_json(RUN_STATE) if RUN_STATE.exists() else default_run_state()
     rs["updated_at"] = utc_now_z()
     rs["last_result"]["timestamp_utc"] = rs["updated_at"]
@@ -545,10 +545,10 @@ def compact() -> int:
     lr = rs.get("last_result") or {}
     ev = lr.get("evidence") or {}
     hist.append({
-        "run_id": rs.get("run_id","") or "",
-        "result_state": rs.get("run_status","") or "",
-        "stop_class": lr.get("stop_class","") or "",
-        "reason_code": lr.get("reason_code","") or "",
+        "run_id": rs.get("run_id", "") or "",
+        "result_state": rs.get("run_status", "") or "",
+        "stop_class": lr.get("stop_class", "") or "",
+        "reason_code": lr.get("reason_code", "") or "",
         "evidence": {
             "pr_url": ev.get("pr_url"),
             "commit_sha": ev.get("commit_sha"),
@@ -565,16 +565,15 @@ def compact() -> int:
         rs["last_result"]["reason_code"] = "PINNED_OVERFLOW"
         rs["next_action"] = "RESOLVE_PINNED_OVERFLOW"
         rs["last_result"]["options"] = [
-            {"id":"A","label":"Reduce pinned_runs in mep/policy.yaml retention.pinned_runs","action":"EDIT_POLICY"},
-            {"id":"B","label":"Increase retention.pinned_max","action":"EDIT_POLICY"},
+            {"id": "A", "label": "Reduce retention.pinned_runs in mep/policy.yaml", "action": "EDIT_POLICY"},
+            {"id": "B", "label": "Increase retention.pinned_max in mep/policy.yaml", "action": "EDIT_POLICY"},
         ]
         write_json(RUN_STATE, rs); update_compiled(rs)
-        print(json.dumps({"state":"STOP","reason_code":rs["last_result"]["reason_code"]}, ensure_ascii=False))
         return 2
     work_items = (MEP_DIR / "work_items")
     results = (MEP_DIR / "results")
     def _scan_dir(d: Path) -> set[str]:
-        out=set()
+        out = set()
         if not d.exists():
             return out
         for p in d.iterdir():
@@ -584,14 +583,14 @@ def compact() -> int:
     run_ids = set()
     run_ids |= _scan_dir(work_items)
     run_ids |= _scan_dir(results)
-    current = rs.get("run_id","") or ""
+    current = rs.get("run_id", "") or ""
     protected = set([current]) | set(pinned_runs)
     def _ts(x: dict) -> str:
-        return str(x.get("timestamp_utc","") or "")
-    seen=set()
-    ordered=[]
+        return str(x.get("timestamp_utc", "") or "")
+    seen = set()
+    ordered = []
     for h in sorted(hist, key=_ts):
-        rid = h.get("run_id","") or ""
+        rid = h.get("run_id", "") or ""
         if not rid or rid in seen:
             continue
         seen.add(rid)
@@ -608,11 +607,10 @@ def compact() -> int:
             rs["last_result"]["reason_code"] = "RETENTION_ACTION_REQUIRED"
             rs["next_action"] = "SET_retention.allow_delete_true_OR_REDUCE_KEEP_RUNS"
             rs["last_result"]["options"] = [
-                {"id":"A","label":"Set retention.allow_delete: true to allow auto deletion of results/work_items only","action":"EDIT_POLICY"},
-                {"id":"B","label":"Increase retention.keep_runs to avoid deletion","action":"EDIT_POLICY"},
+                {"id": "A", "label": "Set retention.allow_delete: true (delete results/work_items only)", "action": "EDIT_POLICY"},
+                {"id": "B", "label": "Increase retention.keep_runs to avoid deletion", "action": "EDIT_POLICY"},
             ]
             write_json(RUN_STATE, rs); update_compiled(rs)
-            print(json.dumps({"state":"STOP","reason_code":rs["last_result"]["reason_code"],"delete_candidates_sample":to_delete[:10]}, ensure_ascii=False))
             return 2
         for rid in to_delete:
             for d in (results / rid, work_items / rid):
@@ -621,21 +619,23 @@ def compact() -> int:
                         if child.is_file():
                             child.unlink()
                     for child in sorted([x for x in d.rglob("*") if x.is_dir()], key=lambda x: len(str(x)), reverse=True):
-                        try: child.rmdir()
-                        except Exception: pass
-                    try: d.rmdir()
-                    except Exception: pass
+                        try:
+                            child.rmdir()
+                        except Exception:
+                            pass
+                    try:
+                        d.rmdir()
+                    except Exception:
+                        pass
         rs["last_result"]["stop_class"] = ""
         rs["last_result"]["reason_code"] = ""
         rs["next_action"] = "STATUS"
         write_json(RUN_STATE, rs); update_compiled(rs)
-        print(json.dumps({"state":"OK","deleted_count":len(to_delete)}, ensure_ascii=False))
         return 0
     rs["last_result"]["stop_class"] = ""
     rs["last_result"]["reason_code"] = ""
     rs["next_action"] = "STATUS"
     write_json(RUN_STATE, rs); update_compiled(rs)
-    print(json.dumps({"state":"OK","run_count_detected":len(run_ids),"keep_runs":keep_runs}, ensure_ascii=False))
     return 0
 def main() -> int:
     ap = argparse.ArgumentParser(prog="runner.py")


### PR DESCRIPTION
Fix missing handoff/handoff_ack wiring: boot/status/apply now generate handoff packet+ACK/NACK and persist. Also gate apply-safe/merge-finish/compact unless ACK. Stable rewrite to avoid patch concatenation issues.