### PR TITLE
runner: apply-safe rebase run branch on origin/main (fix missing file on old run branch)

### DIFF
--- a/tools/runner/runner.py
+++ b/tools/runner/runner.py
@@ -419,6 +419,8 @@ def apply_safe(run_id: str) -> int:
         write_json(RUN_STATE, rs_guard); update_compiled(rs_guard)
         return 2
     branch = f"mep/run_{run_id}"
+    # APPLY_SAFE_REBASE_ON_ORIGIN_MAIN
+    _run(["git","fetch","origin","main"])
     results_dir = MEP_DIR / "results" / run_id
     patches = sorted(results_dir.glob("*.patch")) if results_dir.exists() else []
     rs = load_json(RUN_STATE) if RUN_STATE.exists() else default_run_state()
@@ -442,8 +444,8 @@ def apply_safe(run_id: str) -> int:
     try:
         _run(["git","checkout","-f",branch])
     except Exception:
-        _run(["git","checkout","-B",branch])
-        _run(["git", "push", "-u", "origin", branch])
+    _run(["git","checkout","-B",branch,"origin/main"])
+    _run(["git","push","-u","origin",branch,"--force-with-lease"])
     for p in patches:
         _run(["git", "apply", "--check", str(p)])
     for p in patches:


### PR DESCRIPTION
Fix apply-safe reruns:
- Always fetch origin/main
- Always `git checkout -B mep/run_<RUN_ID> origin/main` before applying patches
- Push with --force-with-lease
Prevents failures like:
  docs/MEP/SYSTEM_MAP.md: No such file or directory
when the existing run branch is older than current main.