### PR TITLE
ci: add Runner PyCompile Guard workflow (PR)

### DIFF
--- a/.github/workflows/runner_pycompile_guard.yml
+++ b/.github/workflows/runner_pycompile_guard.yml
@@ -1,0 +1,16 @@
+name: Runner PyCompile Guard (PR)
+on:
+  pull_request:
+    branches: [ main ]
+permissions:
+  contents: read
+jobs:
+  runner-pycompile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: PyCompile runner.py
+        run: python -m py_compile tools/runner/runner.py


### PR DESCRIPTION
Adds a dedicated PR workflow that runs:
  python -m py_compile tools/runner/runner.py
Purpose: prevent merges that break runner CLI (IndentationError etc.).