### PR TITLE
docs: fixed handoff end-of-chat MEP_BOOT + add CHAT_CHAIN_LEDGER

### DIFF
--- a/docs/MEP/CHAT_CHAIN_LEDGER.md
+++ b/docs/MEP/CHAT_CHAIN_LEDGER.md
@@ -1,0 +1,26 @@
+# CHAT_CHAIN_LEDGER（固定｜append-only｜チャットID連鎖台帳）
+このファイルは runner 生成物ではない（固定層）。
+会話ログではなく、この台帳（一次根拠＝commit/PR）でチャット連鎖を追跡する。
+## 目的
+- URLに依存せず、CHAT_IDで「どこから来てどこへ行くか」を追えるようにする
+- 引継ぎの「読み込み完了（CHECKPOINT_IN）」と「書き出し完了（CHECKPOINT_OUT）」を証跡として固定する
+- 並走（A/B/C）でも、ID検索で復元できる
+## ルール（NORMATIVE）
+- append-only（追記のみ。過去行の編集禁止）
+- 1エントリ1行（JSON Lines推奨）
+- 最低2種類：
+  - CHECKPOINT_IN（新チャット冒頭：読み込みOKの印）
+  - CHECKPOINT_OUT（チャット末尾：引継ぎOKの印）
+## エントリ最小スキーマ（推奨）
+- kind: "CHECKPOINT_IN" | "CHECKPOINT_OUT"
+- this_chat_id
+- parent_chat_id（CHECKPOINT_INのみ必須）
+- next_chat_id（CHECKPOINT_OUTのみ必須）
+- checked_at_utc
+- main_head
+- fixed_handoff_version
+- portfolio_id（任意：BIZ_A/BIZ_B/BIZ_C など）
+- current_phase / next_item（ROADMAPの宣言）
+## 追記例（JSON Lines）
+{"kind":"CHECKPOINT_IN","this_chat_id":"CHAT_...","parent_chat_id":"CHAT_...","checked_at_utc":"...Z","main_head":"...","fixed_handoff_version":"v1.0","portfolio_id":"UNSELECTED","current_phase":"A_DONE","next_item":"B-1 SSOT_SCAN"}
+{"kind":"CHECKPOINT_OUT","this_chat_id":"CHAT_...","next_chat_id":"CHAT_...","checked_at_utc":"...Z","main_head":"...","fixed_handoff_version":"v1.0","portfolio_id":"UNSELECTED","current_phase":"A_DONE","next_item":"B-1 SSOT_SCAN"}

--- a/docs/MEP/FIXED_HANDOFF.md
+++ b/docs/MEP/FIXED_HANDOFF.md
@@ -1,0 +1,34 @@
+# FIXED_HANDOFF（固定｜入口規約｜迷子ゼロ）
+このファイルは runner 生成物ではない（固定層）。
+会話文ではなく GitHub（固定層＋SSOT＋一次根拠）を正として運用する。
+## 正（優先順位）
+1) 一次根拠：PR/commit/run/gh一次出力
+2) 機械SSOT：mep/run_state.json
+3) 固定層：
+   - docs/MEP/MASTER_GOAL.md
+   - docs/MEP/ROADMAP.md
+   - docs/MEP/BRANCHPOINTS.md
+   - docs/MEP/CHAT_CHAIN_LEDGER.md
+4) runner生成物（参照用）：
+   - docs/MEP/STATUS.md
+   - docs/MEP/HANDOFF_WORK.md
+   - docs/MEP/HANDOFF_AUDIT.md
+## 入口（固定手順）
+1) git fetch --prune origin
+2) git checkout -f main
+3) git reset --hard origin/main
+4) python tools/runner/runner.py status
+## 安全ゲート
+- destructive ops（apply-safe/merge-finish/compact delete）は handoff_ack.status == ACK が無い限り進めない
+
+## 終端必須出力（NORMATIVE）｜MEP_BOOT_OUTPUT_REQUIRED
+各チャットは「引継ぎタイミング（終端）」で必ず次を行う：
+1) NEXT_CHAT_ID を生成（衝突しない形式：例 CHAT_YYYYMMDDTHHMMSSZ_xxx）
+2) docs/MEP/CHAT_CHAIN_LEDGER.md に CHECKPOINT_OUT を追記（append-only）
+3) 次チャット冒頭に貼る本文として、下記 [MEP_BOOT] ブロックを **そのまま提示**する
+   - PARENT_CHAT_ID は「このチャットが払い出した NEXT_CHAT_ID」を **具体値で埋める**（プレースホルダ禁止）
+### 次チャット冒頭に貼る本文（固定）
+[MEP_BOOT]
+PARENT_CHAT_ID: （ここに前チャットが提示した NEXT_CHAT_ID を貼る）
+@github docs/MEP/FIXED_HANDOFF.md を読み、PARENT_CHAT_IDに一致するCHECKPOINT_OUTを docs/MEP/CHAT_CHAIN_LEDGER.md から復元して開始せよ。
+開始後、このチャットの THIS_CHAT_ID を生成し、CHECKPOINT_IN を台帳へ追記せよ。


### PR DESCRIPTION
Adds fixed (non-generated) handoff governance:
- docs/MEP/CHAT_CHAIN_LEDGER.md (append-only; CHECKPOINT_IN/OUT)
- docs/MEP/FIXED_HANDOFF.md update: requires end-of-chat output of [MEP_BOOT] with concrete NEXT_CHAT_ID (no placeholders)
Purpose:
- ID-based chain-of-custody across chats (URL-independent)
- Prevents “which handoff do I paste?” ambiguity by forcing explicit ID in every handoff.