### PR TITLE
MEP: Unify Issue entry surface (NO_LLM/LLM) + guard non-entry workflows

### DIFF
--- a/.github/workflows/mep_dispatch_entry_min3.yml
+++ b/.github/workflows/mep_dispatch_entry_min3.yml
@@ -7,8 +7,8 @@ on:
         required: true
         type: string
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+  pull-requests: read
   issues: write
 jobs:
   entry:

--- a/.github/workflows/mep_dispatch_entry_min4.yml
+++ b/.github/workflows/mep_dispatch_entry_min4.yml
@@ -7,8 +7,8 @@ on:
         required: true
         type: string
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+  pull-requests: read
   issues: write
 concurrency:
   group: mep-min4-${{ github.event_name }}-${{ github.run_id }}

--- a/.github/workflows/mep_dispatch_entry_min5.yml
+++ b/.github/workflows/mep_dispatch_entry_min5.yml
@@ -7,8 +7,8 @@ on:
         required: true
         type: string
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+  pull-requests: read
   issues: write
 concurrency:
   group: mep-min5-${{ github.event_name }}-${{ github.run_id }}

--- a/.github/workflows/mep_dispatch_entry_min6.yml
+++ b/.github/workflows/mep_dispatch_entry_min6.yml
@@ -7,8 +7,8 @@ on:
         required: true
         type: string
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+  pull-requests: read
   issues: write
 concurrency:
   group: mep-min6-${{ github.event_name }}-${{ github.run_id }}

--- a/.github/workflows/mep_dispatch_entry_min8_longrun.yml
+++ b/.github/workflows/mep_dispatch_entry_min8_longrun.yml
@@ -7,8 +7,8 @@ on:
         required: true
         type: string
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+  pull-requests: read
   issues: write
 concurrency:
   group: mep-min8-${{ github.event_name }}-${{ github.run_id }}

--- a/.github/workflows/mep_dispatch_from_issue.yml
+++ b/.github/workflows/mep_dispatch_from_issue.yml
@@ -2,7 +2,7 @@ name: MEP Dispatch (from Issue)
 
 on:
   issues:
-    types: [opened, edited, labeled]
+    types: [labeled]
 
 permissions:
   contents: read
@@ -147,3 +147,4 @@ jobs:
                 "- Next PR: implement UPDATE_SPEC/REGENERATE with safe two-step (draft -> approve label -> PR)."
               ].join("\n")
             });
+

--- a/docs/MEP/ISSUE_ENTRY_USAGE.md
+++ b/docs/MEP/ISSUE_ENTRY_USAGE.md
@@ -1,0 +1,20 @@
+# ISSUE_ENTRY_USAGE（固定｜入口｜Issue草案→PR_CREATE）
+## 目的
+Issueに草案を投入して、PR_CREATE→PR_CHECKS（Bライン）へ自動接続する。
+## 入口コマンド（唯一）
+Issueコメントに以下を貼る：
+### NO_LLM（パッチ直接）
+/mep run
+MODE: NO_LLM
+PATCH_START
+<unified diff patch>
+PATCH_END
+### LLM（草案→パッチ生成）
+/mep run
+MODE: LLM
+DRAFT_START
+<draft text>
+DRAFT_END
+## 規約
+- 入口は上記のみ（他の入口workflowは誤起動防止のため封印/ガードされる）
+- PR上では Required checks が必ず走る（SSOT_SCAN/CONFLICT_SCAN を含む）


### PR DESCRIPTION
What:
- Add docs/MEP/ISSUE_ENTRY_USAGE.md (single Issue command surface)
- Restrict mep_dispatch_from_issue.yml to labeled-only (OBSERVE stays)
- Soft-seal experimental mep_dispatch_entry_min* workflows (remove write perms)
Why:
- Prevent '入口乱立' (misfire) and keep 'Issue→PR_CREATE→PR_CHECKS' stable toward full-loop coverage.