### PR TITLE
MEP: EXEC bootstrap one-shot (PS) + FIXED_HANDOFF EXEC_AUTO

### DIFF
--- a/docs/MEP/FIXED_HANDOFF.md
+++ b/docs/MEP/FIXED_HANDOFF.md
@@ -41,6 +41,16 @@ PARENT_CHAT_ID: （ここに前チャットが提示した NEXT_CHAT_ID を貼�
 ## 最短入口（SHORT_ENTRY_GUIDE｜NORMATIVE）
 
 ### GENESIS_AUTO（DRAFT専用一括｜AUTO_BOOTSTRAP）
+
+### EXEC_AUTO（EXEC専用一括｜AUTO_BOOTSTRAP_EXEC）
+目的：実装中（EXEC_MODE）で「一次根拠アンカー＋台帳＋MEP_BOOT」を PowerShell 1コマンドで完結させる（作業ツリーはクリーン必須）。
+使い方（PowerShell）
+- リポジトリ直下で実行（main HEADを一次根拠に ledger-in/out → MEP_BOOT）：
+  .\tools\runner\bootstrap_exec.ps1
+備考：
+- 作業ツリーが汚れていると停止（誤アンカー防止）。
+- DRAFT_MODE は GENESIS_AUTO（bootstrap.ps1）を使う。
+
 目的：新規（GENESIS）で「一次根拠アンカー＋台帳＋MEP_BOOT」を PowerShell 1コマンドで完結させる（DRAFT_MODE専用）。
 使い方（PowerShell）
 - リポジトリ直下で実行（commit→ledger-in→ledger-out→MEP_BOOT）：
@@ -133,6 +143,16 @@ v3.0 （更新: 2026-02-15T16:31:33Z）
 ## 最短入口（SHORT_ENTRY_GUIDE｜NORMATIVE）
 
 ### GENESIS_AUTO（DRAFT専用一括｜AUTO_BOOTSTRAP）
+
+### EXEC_AUTO（EXEC専用一括｜AUTO_BOOTSTRAP_EXEC）
+目的：実装中（EXEC_MODE）で「一次根拠アンカー＋台帳＋MEP_BOOT」を PowerShell 1コマンドで完結させる（作業ツリーはクリーン必須）。
+使い方（PowerShell）
+- リポジトリ直下で実行（main HEADを一次根拠に ledger-in/out → MEP_BOOT）：
+  .\tools\runner\bootstrap_exec.ps1
+備考：
+- 作業ツリーが汚れていると停止（誤アンカー防止）。
+- DRAFT_MODE は GENESIS_AUTO（bootstrap.ps1）を使う。
+
 目的：新規（GENESIS）で「一次根拠アンカー＋台帳＋MEP_BOOT」を PowerShell 1コマンドで完結させる（DRAFT_MODE専用）。
 使い方（PowerShell）
 - リポジトリ直下で実行（commit→ledger-in→ledger-out→MEP_BOOT）：
@@ -228,6 +248,7 @@ PARENT_CHECKPOINT_OUT_JSONL: <親のCHECKPOINT_OUT 1行JSONL（next_chat_id==PAR
   python tools/runner/runner.py ledger-out --this-chat-id <THIS_CHAT_ID> --portfolio-id <PORTFOLIO_ID> --mode <MODE> --primary-anchor <ANCHOR> --current-phase <PHASE> --next-item <NEXT>
 - 出力：next_chat_id（JSON）＋ [MEP_BOOT] を stdout に出す → そのまま次チャット冒頭へ貼る
 注：上の <...> は説明用。実運用では AI が具体値を埋めた [MEP_BOOT] を必ず提示する。
+
 
 
 

--- a/tools/runner/bootstrap_exec.ps1
+++ b/tools/runner/bootstrap_exec.ps1
@@ -1,0 +1,42 @@
+param(
+  [string]$PortfolioId = "UNSELECTED",
+  [string]$Phase = "EXEC_BOOTSTRAP",
+  [string]$NextItem = "CONTINUE",
+  [string]$PrimaryAnchor = ""
+)
+# repo root前提（ここで実行）
+if (-not (Test-Path ".git")) {
+  Write-Error "Not inside repository root. cd into yorisoidou-system first."
+  exit 1
+}
+# 実装系は「作業ツリー汚れ禁止」
+$dirty = git status --porcelain
+if ($dirty) {
+  Write-Error "Working tree is dirty. Commit/stash first (EXEC bootstrap requires clean tree)."
+  exit 1
+}
+# main同期（一次根拠は main HEAD を使う）
+git fetch --prune origin
+git switch main
+git reset --hard origin/main
+$sha = git rev-parse HEAD
+if (-not $PrimaryAnchor) { $PrimaryAnchor = "COMMIT:$sha" }
+Write-Host "PRIMARY_ANCHOR: $PrimaryAnchor"
+# CHECKPOINT_IN
+$ledgerIn = python tools/runner/runner.py ledger-in `
+  --parent-chat-id GENESIS `
+  --portfolio-id $PortfolioId `
+  --mode EXEC_MODE `
+  --primary-anchor $PrimaryAnchor `
+  --current-phase $Phase `
+  --next-item $NextItem | ConvertFrom-Json
+$thisChatId = $ledgerIn.this_chat_id
+Write-Host "THIS_CHAT_ID: $thisChatId"
+# CHECKPOINT_OUT（runner が [MEP_BOOT] を出す）
+python tools/runner/runner.py ledger-out `
+  --this-chat-id $thisChatId `
+  --portfolio-id $PortfolioId `
+  --mode EXEC_MODE `
+  --primary-anchor $PrimaryAnchor `
+  --current-phase $Phase `
+  --next-item $NextItem


### PR DESCRIPTION
- tools/runner/bootstrap_exec.ps1 を追加（EXEC_MODE: main HEADを一次根拠に ledger-in/out → MEP_BOOT）
- docs/MEP/FIXED_HANDOFF.md に EXEC_AUTO を正式追記
- 8ゲート/ワークフロー本体は未変更（入口補助のみ）