### PR TITLE
MEP: Add observability comment for Issue NO_LLM (always run url + status)

### DIFF
--- a/.github/workflows/mep_issue_patch_to_pr.yml
+++ b/.github/workflows/mep_issue_patch_to_pr.yml
@@ -111,3 +111,27 @@ jobs:
               issue_number,
               body: msg,
             });
+      - name: MEP_RUN_OBSERVE (always comment run url)
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const isDispatch = context.eventName === "workflow_dispatch";
+            const n = isDispatch ? parseInt("${{ steps.body.outputs.issue_number || '0' }}", 10) : (context.payload.issue ? context.payload.issue.number : 0);
+            if (!n) { core.info("No issue_number; skip observe comment."); return; }
+            const runUrl = context.serverUrl + "/" + context.repo.owner + "/" + context.repo.repo + "/actions/runs/" + context.runId;
+            const status = "${{ job.status }}";
+            const msg = [
+              "MEP NO_LLM observe",
+              "",
+              "- run: " + runUrl,
+              "- job.status: " + status,
+              "- note: if PR URL is not posted above, open the run and check the failed step."
+            ].join("\n");
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: n,
+              body: msg
+            });
+


### PR DESCRIPTION
What:
- Add an always() step to mep_issue_patch_to_pr.yml that comments back the Actions run URL + job status to the Issue.
Why:
- Issue entry currently can fail silently (no PR URL), making it hard to tell if it is progressing or stuck.
- This makes STOP/WAIT visible directly on the Issue thread.
