### PR TITLE
Fix: NO_LLM workflow avoids JOBS=0 by splitting jobs (issue_comment/dispatch)

### DIFF
--- a/.github/workflows/mep_issue_patch_to_pr.yml
+++ b/.github/workflows/mep_issue_patch_to_pr.yml
@@ -16,69 +16,34 @@ concurrency:
   group: mep-issue-${{ github.event.issue.number || github.run_id }}
   cancel-in-progress: false
 jobs:
-  patch_to_pr:
-    if: ${{ github.event_name == 'workflow_dispatch' || (contains(github.event.comment.body, '/mep run') && (contains(github.event.comment.body, 'MODE: NO_LLM') || !contains(github.event.comment.body, 'MODE:'))) }}
+  issue_comment_to_pr:
+    if: ${{ github.event_name == 'issue_comment' && contains(github.event.comment.body, '/mep run') && (contains(github.event.comment.body, 'MODE: NO_LLM') || !contains(github.event.comment.body, 'MODE:')) }}
     runs-on: ubuntu-latest
     steps:
-      - name: OBSERVE_START (always comment run url)
+      - name: OBSERVE_START (issue_comment)
         if: always()
         uses: actions/github-script@v7
         with:
           script: |
-            const isDispatch = context.eventName === "workflow_dispatch";
-            const n = isDispatch
-              ? parseInt((context.payload.inputs && context.payload.inputs.issue_number) ? context.payload.inputs.issue_number : "0", 10)
-              : (context.payload.issue ? context.payload.issue.number : 0);
-            if (!n) { core.info("No issue_number; skip."); return; }
+            const n = context.payload.issue.number;
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const msg = [
-              "MEP NO_LLM observe (start)",
-              "",
-              `- run: ${runUrl}`,
-              `- event: ${context.eventName}`,
-              `- job: ${context.job}`
-            ].join("\n");
             await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: n,
-              body: msg,
+              owner: context.repo.owner, repo: context.repo.repo, issue_number: n,
+              body: `MEP NO_LLM observe (start)\n- run: ${runUrl}\n- event: ${context.eventName}\n- job: ${context.job}`
             });
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Resolve body (issue_comment or workflow_dispatch)
-        id: body
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const isDispatch = context.eventName === "workflow_dispatch";
-            if (!isDispatch) {
-              core.setOutput("body", (context.payload.comment && context.payload.comment.body) ? context.payload.comment.body : "");
-              core.setOutput("issue_number", String(context.payload.issue.number));
-              return;
-            }
-            const n = parseInt((context.payload.inputs && context.payload.inputs.issue_number) ? context.payload.inputs.issue_number : "0", 10);
-            if (!n) { core.setFailed("ISSUE_NUMBER_REQUIRED"); return; }
-            const owner = context.repo.owner;
-            const repo  = context.repo.repo;
-            const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number: n, per_page: 100 });
-            const mine = comments.reverse().find(c => (c.body || "").includes("/mep run"));
-            core.setOutput("body", mine ? (mine.body || "") : "");
-            core.setOutput("issue_number", String(n));
-      - name: Extract patch from body (PATCH_START/END preferred)
+      - uses: actions/checkout@v4
+      - name: Extract patch from comment (PATCH_START/END)
         id: extract
         uses: actions/github-script@v7
         with:
           script: |
-            const body = `${{ steps.body.outputs.body }}` || "";
+            const body = (context.payload.comment && context.payload.comment.body) ? context.payload.comment.body : "";
             let patch = "";
             const m = body.match(/PATCH_START\s*\n([\s\S]*?)\nPATCH_END\s*/i);
             if (m && m[1]) patch = m[1].trim();
-            if (!patch) {
-              core.setFailed("NO_PATCH: Use PATCH_START..PATCH_END (preferred).");
-              return;
-            }
+            if (!patch) { core.setFailed("NO_PATCH: Use PATCH_START..PATCH_END."); return; }
             core.setOutput("patch_b64", Buffer.from(patch, "utf8").toString("base64"));
+            core.setOutput("issue_number", String(context.payload.issue.number));
       - name: Write patch to file
         run: |
           echo "${{ steps.extract.outputs.patch_b64 }}" | base64 -d > /tmp/mep.patch
@@ -87,14 +52,8 @@ jobs:
       - name: Guard (no binary / no delete-rename-move/chmod)
         run: |
           set -euo pipefail
-          if grep -nE 'GIT binary patch|^Binary files ' /tmp/mep.patch >/dev/null; then
-            echo "STOP_HARD: BINARY_DIFF_FORBIDDEN"
-            exit 1
-          fi
-          if grep -nE '^deleted file mode|^rename from|^rename to|^old mode|^new mode' /tmp/mep.patch >/dev/null; then
-            echo "STOP_HARD: DANGEROUS_DIFF_FORBIDDEN"
-            exit 1
-          fi
+          if grep -nE 'GIT binary patch|^Binary files ' /tmp/mep.patch >/dev/null; then echo "STOP_HARD: BINARY_DIFF_FORBIDDEN"; exit 1; fi
+          if grep -nE '^deleted file mode|^rename from|^rename to|^old mode|^new mode' /tmp/mep.patch >/dev/null; then echo "STOP_HARD: DANGEROUS_DIFF_FORBIDDEN"; exit 1; fi
       - name: Apply patch (check then apply)
         run: |
           set -euo pipefail
@@ -104,51 +63,110 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v6
         with:
-          title: "MEP: apply patch from issue #${{ steps.body.outputs.issue_number }}"
+          title: "MEP: apply patch from issue #${{ steps.extract.outputs.issue_number }}"
           body: |
             Applied by MEP Issue Patch Runner (NO_LLM).
             - Event: ${{ github.event_name }}
-            - Issue: #${{ steps.body.outputs.issue_number }}
+            - Issue: #${{ steps.extract.outputs.issue_number }}
             - Patch bytes: ${{ env.PATCH_BYTES }}
-          commit-message: "mep: apply patch from issue #${{ steps.body.outputs.issue_number }}"
-          branch: "auto/mep_issue_${{ steps.body.outputs.issue_number }}_${{ github.run_id }}"
+          commit-message: "mep: apply patch from issue #${{ steps.extract.outputs.issue_number }}"
+          branch: "auto/mep_issue_${{ steps.extract.outputs.issue_number }}_${{ github.run_id }}"
           base: "main"
           delete-branch: true
-      - name: Comment PR URL (always)
+      - name: Comment PR URL + END (issue_comment)
         if: always()
         uses: actions/github-script@v7
         with:
           script: |
-            const n = parseInt("${{ steps.body.outputs.issue_number || '0' }}", 10);
-            if (!n) { core.info("No issue_number; skip."); return; }
+            const n = parseInt("${{ steps.extract.outputs.issue_number || '0' }}", 10);
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const prUrl = "${{ steps.cpr.outputs.pull-request-url }}";
-            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const msg = prUrl
-              ? `✅ MEP created PR: ${prUrl}\n(run: ${runUrl})`
-              : `⚠️ MEP did not return PR URL.\n(run: ${runUrl})`;
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: n,
-              body: msg,
-            });
-      - name: OBSERVE_END (always comment job status)
+            const msg1 = prUrl ? `✅ MEP created PR: ${prUrl}\n(run: ${runUrl})` : `⚠️ MEP did not return PR URL.\n(run: ${runUrl})`;
+            const msg2 = `MEP NO_LLM observe (end)\n- run: ${runUrl}\n- job.status: ${{ job.status }}`;
+            await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: n, body: msg1 });
+            await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: n, body: msg2 });
+  dispatch_to_pr:
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: OBSERVE_START (dispatch)
         if: always()
         uses: actions/github-script@v7
         with:
           script: |
-            const n = parseInt("${{ steps.body.outputs.issue_number || '0' }}", 10);
-            if (!n) { core.info("No issue_number; skip."); return; }
+            const n = parseInt((context.payload.inputs && context.payload.inputs.issue_number) ? context.payload.inputs.issue_number : "0", 10);
+            if (!n) { core.setFailed("ISSUE_NUMBER_REQUIRED"); return; }
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const msg = [
-              "MEP NO_LLM observe (end)",
-              "",
-              `- run: ${runUrl}`,
-              `- job.status: ${{ job.status }}`
-            ].join("\n");
             await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: n,
-              body: msg,
+              owner: context.repo.owner, repo: context.repo.repo, issue_number: n,
+              body: `MEP NO_LLM observe (start)\n- run: ${runUrl}\n- event: ${context.eventName}\n- job: ${context.job}`
             });
+      - uses: actions/checkout@v4
+      - name: Load latest /mep run comment from issue
+        id: load
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const n = parseInt((context.payload.inputs && context.payload.inputs.issue_number) ? context.payload.inputs.issue_number : "0", 10);
+            if (!n) { core.setFailed("ISSUE_NUMBER_REQUIRED"); return; }
+            const owner = context.repo.owner;
+            const repo  = context.repo.repo;
+            const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number: n, per_page: 100 });
+            const mine = comments.reverse().find(c => (c.body || "").includes("/mep run"));
+            const body = mine ? (mine.body || "") : "";
+            if (!body) { core.setFailed("NO_MEP_RUN_COMMENT_FOUND"); return; }
+            core.setOutput("body", body);
+            core.setOutput("issue_number", String(n));
+      - name: Extract patch from loaded body
+        id: extract
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = `${{ steps.load.outputs.body }}` || "";
+            let patch = "";
+            const m = body.match(/PATCH_START\s*\n([\s\S]*?)\nPATCH_END\s*/i);
+            if (m && m[1]) patch = m[1].trim();
+            if (!patch) { core.setFailed("NO_PATCH: Use PATCH_START..PATCH_END."); return; }
+            core.setOutput("patch_b64", Buffer.from(patch, "utf8").toString("base64"));
+            core.setOutput("issue_number", "${{ steps.load.outputs.issue_number }}");
+      - name: Write patch to file
+        run: |
+          echo "${{ steps.extract.outputs.patch_b64 }}" | base64 -d > /tmp/mep.patch
+          test -s /tmp/mep.patch
+          echo "PATCH_BYTES=$(wc -c < /tmp/mep.patch)" >> $GITHUB_ENV
+      - name: Guard (no binary / no delete-rename-move/chmod)
+        run: |
+          set -euo pipefail
+          if grep -nE 'GIT binary patch|^Binary files ' /tmp/mep.patch >/dev/null; then echo "STOP_HARD: BINARY_DIFF_FORBIDDEN"; exit 1; fi
+          if grep -nE '^deleted file mode|^rename from|^rename to|^old mode|^new mode' /tmp/mep.patch >/dev/null; then echo "STOP_HARD: DANGEROUS_DIFF_FORBIDDEN"; exit 1; fi
+      - name: Apply patch (check then apply)
+        run: |
+          set -euo pipefail
+          git apply --check /tmp/mep.patch
+          git apply /tmp/mep.patch
+      - name: Create PR
+        id: cpr
+        uses: peter-evans/create-pull-request@v6
+        with:
+          title: "MEP: apply patch from issue #${{ steps.extract.outputs.issue_number }}"
+          body: |
+            Applied by MEP Issue Patch Runner (NO_LLM) via workflow_dispatch.
+            - Event: ${{ github.event_name }}
+            - Issue: #${{ steps.extract.outputs.issue_number }}
+            - Patch bytes: ${{ env.PATCH_BYTES }}
+          commit-message: "mep: apply patch from issue #${{ steps.extract.outputs.issue_number }}"
+          branch: "auto/mep_issue_${{ steps.extract.outputs.issue_number }}_${{ github.run_id }}"
+          base: "main"
+          delete-branch: true
+      - name: Comment PR URL + END (dispatch)
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const n = parseInt("${{ steps.extract.outputs.issue_number || '0' }}", 10);
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const prUrl = "${{ steps.cpr.outputs.pull-request-url }}";
+            const msg1 = prUrl ? `✅ MEP created PR: ${prUrl}\n(run: ${runUrl})` : `⚠️ MEP did not return PR URL.\n(run: ${runUrl})`;
+            const msg2 = `MEP NO_LLM observe (end)\n- run: ${runUrl}\n- job.status: ${{ job.status }}`;
+            await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: n, body: msg1 });
+            await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: n, body: msg2 });


### PR DESCRIPTION
What:
- Split mep_issue_patch_to_pr.yml into two jobs:
  - issue_comment_to_pr (reads github.event.comment.body)
  - dispatch_to_pr (reads issue_number input and loads latest /mep run comment)
- This avoids JOBS=0 failures caused by referencing github.event.comment on workflow_dispatch.
Why:
- Recent runs fail with JOBS=0 ("workflow file issue") even though the workflow exists.
