### PR TITLE
Fix: concurrency group safe to prevent JOBS=0 (workflow file issue)

### DIFF
--- a/.github/workflows/mep_issue_patch_to_pr.yml
+++ b/.github/workflows/mep_issue_patch_to_pr.yml
@@ -13,7 +13,7 @@ permissions:
   pull-requests: write
   issues: write
 concurrency:
-  group: mep-issue-${{ github.event.issue.number || github.run_id }}
+  group: mep-issue-${{ github.run_id }}
   cancel-in-progress: false
 jobs:
   issue_comment_to_pr:
@@ -170,3 +170,4 @@ jobs:
             const msg2 = `MEP NO_LLM observe (end)\n- run: ${runUrl}\n- job.status: ${{ job.status }}`;
             await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: n, body: msg1 });
             await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: n, body: msg2 });
+


### PR DESCRIPTION
What:
- Change concurrency.group to use only github.run_id (safe for all event types).
Why:
- Recent runs fail with JOBS=0 ("workflow file issue") before jobs are created.
- Accessing github.event.issue.number can be undefined depending on event; safer to avoid it.
