### PR TITLE
Fix: harden Actions YAML parsing (eliminate JOBS=0 workflow file issue)

### DIFF
--- a/.github/workflows/mep_issue_patch_to_pr.yml
+++ b/.github/workflows/mep_issue_patch_to_pr.yml
@@ -1,5 +1,5 @@
 name: MEP Issue Patch to PR (NO_LLM) [MIN_STABLE]
-on:
+"on":
   issue_comment:
     types: [created, edited]
 permissions:
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: OBSERVE_START (always)
-        if: always()
+        if: ${{ always() }}
         uses: actions/github-script@v7
         with:
           script: |
@@ -65,7 +65,7 @@ jobs:
           base: "main"
           delete-branch: true
       - name: COMMENT_RESULT (always)
-        if: always()
+        if: ${{ always() }}
         uses: actions/github-script@v7
         with:
           script: |
@@ -77,3 +77,4 @@ jobs:
             const msg2 = `MEP NO_LLM observe (end)\n- run: ${runUrl}\n- job.status: ${{ job.status }}`;
             await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: n, body: msg1 });
             await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: n, body: msg2 });
+


### PR DESCRIPTION
What:
- Quote the YAML "on" key as "on": to avoid YAML1.1 boolean traps.
- Change if: always() to if: ${{ always() }} (explicit expression).
Why:
- Latest runs fail with JOBS=0 and "workflow file issue" before any job is created.
- This aims to make the workflow parse deterministically in GitHub Actions.
