### PR TITLE
Fix: restore MIN_STABLE (unquoted on:) to eliminate JOBS=0 workflow file issue

### DIFF
--- a/.github/workflows/mep_issue_patch_to_pr.yml
+++ b/.github/workflows/mep_issue_patch_to_pr.yml
@@ -1,5 +1,5 @@
 name: MEP Issue Patch to PR (NO_LLM) [MIN_STABLE]
-"on":
+on:
   issue_comment:
     types: [created, edited]
 permissions:
@@ -11,8 +11,7 @@ jobs:
     if: ${{ contains(github.event.comment.body, '/mep run') && (contains(github.event.comment.body, 'MODE: NO_LLM') || !contains(github.event.comment.body, 'MODE:')) }}
     runs-on: ubuntu-latest
     steps:
-      - name: OBSERVE_START (always)
-        if: ${{ always() }}
+      - name: OBSERVE_START
         uses: actions/github-script@v7
         with:
           script: |
@@ -40,12 +39,12 @@ jobs:
           echo "${{ steps.extract.outputs.patch_b64 }}" | base64 -d > /tmp/mep.patch
           test -s /tmp/mep.patch
           echo "PATCH_BYTES=$(wc -c < /tmp/mep.patch)" >> $GITHUB_ENV
-      - name: Guard (no binary / no delete-rename-move/chmod)
+      - name: Guard (no binary / no delete/rename/mode)
         run: |
           set -euo pipefail
           if grep -nE 'GIT binary patch|^Binary files ' /tmp/mep.patch >/dev/null; then echo "STOP_HARD: BINARY_DIFF_FORBIDDEN"; exit 1; fi
           if grep -nE '^deleted file mode|^rename from|^rename to|^old mode|^new mode' /tmp/mep.patch >/dev/null; then echo "STOP_HARD: DANGEROUS_DIFF_FORBIDDEN"; exit 1; fi
-      - name: Apply patch (check then apply)
+      - name: Apply patch
         run: |
           set -euo pipefail
           git apply --check /tmp/mep.patch
@@ -64,8 +63,8 @@ jobs:
           branch: "auto/mep_issue_${{ steps.extract.outputs.issue_number }}_${{ github.run_id }}"
           base: "main"
           delete-branch: true
-      - name: COMMENT_RESULT (always)
-        if: ${{ always() }}
+      - name: COMMENT_RESULT
+        if: always()
         uses: actions/github-script@v7
         with:
           script: |
@@ -77,4 +76,3 @@ jobs:
             const msg2 = `MEP NO_LLM observe (end)\n- run: ${runUrl}\n- job.status: ${{ job.status }}`;
             await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: n, body: msg1 });
             await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: n, body: msg2 });
-


### PR DESCRIPTION
What:
- Restore mep_issue_patch_to_pr.yml to MIN_STABLE with standard `on:` key (unquoted).
Why:
- Runs are failing with JOBS=0 and "workflow file issue" before any job is created.
- Quoted `"on":` can break GitHub Actions YAML parsing; restoring known-good format fixes parsing.
