### PR TITLE
Fix: restore MIN_STABLE (unquoted on:) to eliminate JOBS=0 workflow file issue

### DIFF
--- a/.github/workflows/mep_issue_patch_to_pr.yml
+++ b/.github/workflows/mep_issue_patch_to_pr.yml
@@ -64,7 +64,7 @@ jobs:
           base: "main"
           delete-branch: true
       - name: COMMENT_RESULT
-        if: always()
+        if: ${{ always() }}
         uses: actions/github-script@v7
         with:
           script: |
@@ -76,3 +76,4 @@ jobs:
             const msg2 = `MEP NO_LLM observe (end)\n- run: ${runUrl}\n- job.status: ${{ job.status }}`;
             await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: n, body: msg1 });
             await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: n, body: msg2 });
+


### PR DESCRIPTION
What:
- Change step-level `if: always()` to `if: ${{ always() }}` in mep_issue_patch_to_pr.yml.
Why:
- Recent runs fail with JOBS=0 and "workflow file issue" (parse-time failure).
- Explicit expression form is the stable GitHub Actions syntax.
