### PR TITLE
MEP: refresh SystemPack gate workflow registration (dispatch-ready)

### DIFF
--- a/.github/workflows/mep_writeback_bundle_entry_with_system_pack_dispatch.yml
+++ b/.github/workflows/mep_writeback_bundle_entry_with_system_pack_dispatch.yml
@@ -1,3 +1,4 @@
+# reindex: force workflow registration refresh 2026-02-16T16:47:29Z
 name: MEP Writeback Bundle (Entry + SystemPack Gate)
 on:
   workflow_dispatch:
@@ -88,3 +89,4 @@ JSON
             --data "${body}" \
             "${API}"
           echo "OK: dispatched mep_writeback_bundle_dispatch_entry.yml"
+


### PR DESCRIPTION
Scope:
- Workflow-only change: .github/workflows/mep_writeback_bundle_entry_with_system_pack_dispatch.yml
Changes:
- Remove any push trigger (workflow_dispatch-only)
- Add/refresh reindex comment to force Actions registration