### PR TITLE
Fix: NO_LLM entry via workflow_dispatch (issue_comment disabled)

### DIFF
--- a/.github/workflows/mep_issue_patch_to_pr.yml
+++ b/.github/workflows/mep_issue_patch_to_pr.yml
@@ -1,44 +1,67 @@
-name: MEP Issue Patch to PR (NO_LLM) [STEP1_PR_ONLY]
+name: MEP Issue Patch to PR (NO_LLM) [DISPATCH_ENTRY]
 on:
-  issue_comment:
-    types: [created, edited]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Issue number to read latest /mep run (PATCH_START..END) from"
+        required: true
+        type: string
 permissions:
   contents: write
   pull-requests: write
   issues: write
 jobs:
-  patch_to_pr:
-    if: ${{ contains(github.event.comment.body, '/mep run') && (contains(github.event.comment.body, 'MODE: NO_LLM') || !contains(github.event.comment.body, 'MODE:')) }}
+  dispatch_to_pr:
     runs-on: ubuntu-latest
     steps:
-      - name: Observe start (comment run URL)
+      - name: OBSERVE_START (comment run url)
         uses: actions/github-script@v7
         with:
           script: |
-            const n = context.payload.issue.number;
+            const n = parseInt((context.payload.inputs && context.payload.inputs.issue_number) ? context.payload.inputs.issue_number : "0", 10);
+            if (!n) { core.setFailed("ISSUE_NUMBER_REQUIRED"); return; }
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             await github.rest.issues.createComment({
               owner: context.repo.owner, repo: context.repo.repo, issue_number: n,
-              body: `MEP NO_LLM observe (start)\n- run: ${runUrl}`
+              body: `MEP NO_LLM dispatch observe (start)\n- run: ${runUrl}`
             });
       - uses: actions/checkout@v4
+      - name: Load latest /mep run comment from issue
+        id: load
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const n = parseInt((context.payload.inputs && context.payload.inputs.issue_number) ? context.payload.inputs.issue_number : "0", 10);
+            if (!n) { core.setFailed("ISSUE_NUMBER_REQUIRED"); return; }
+            const owner = context.repo.owner;
+            const repo  = context.repo.repo;
+            const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number: n, per_page: 100 });
+            const mine = comments.reverse().find(c => (c.body || "").includes("/mep run"));
+            const body = mine ? (mine.body || "") : "";
+            if (!body) { core.setFailed("NO_MEP_RUN_COMMENT_FOUND"); return; }
+            core.setOutput("body", body);
+            core.setOutput("issue_number", String(n));
       - name: Extract patch (PATCH_START/END)
         id: extract
         uses: actions/github-script@v7
         with:
           script: |
-            const body = context.payload.comment.body || "";
+            const body = `${{ steps.load.outputs.body }}` || "";
             const m = body.match(/PATCH_START\s*\n([\s\S]*?)\nPATCH_END\s*/i);
             const patch = (m && m[1]) ? m[1].trim() : "";
             if (!patch) { core.setFailed("NO_PATCH: Use PATCH_START..PATCH_END."); return; }
             core.setOutput("patch_b64", Buffer.from(patch, "utf8").toString("base64"));
-            core.setOutput("issue_number", String(context.payload.issue.number));
       - name: Write patch to file
         run: |
           echo "${{ steps.extract.outputs.patch_b64 }}" | base64 -d > /tmp/mep.patch
           test -s /tmp/mep.patch
           echo "PATCH_BYTES=$(wc -c < /tmp/mep.patch)" >> $GITHUB_ENV
-      - name: Apply patch (check then apply)
+      - name: Guard (no binary / no delete-rename-move/chmod)
+        run: |
+          set -euo pipefail
+          if grep -nE 'GIT binary patch|^Binary files ' /tmp/mep.patch >/dev/null; then echo "STOP_HARD: BINARY_DIFF_FORBIDDEN"; exit 1; fi
+          if grep -nE '^deleted file mode|^rename from|^rename to|^old mode|^new mode' /tmp/mep.patch >/dev/null; then echo "STOP_HARD: DANGEROUS_DIFF_FORBIDDEN"; exit 1; fi
+      - name: Apply patch
         run: |
           set -euo pipefail
           git apply --check /tmp/mep.patch
@@ -47,27 +70,25 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v6
         with:
-          title: "MEP: apply patch from issue #${{ steps.extract.outputs.issue_number }}"
+          title: "MEP: apply patch from issue #${{ steps.load.outputs.issue_number }}"
           body: |
-            Applied by MEP NO_LLM STEP1 (PR only).
-            - Issue: #${{ steps.extract.outputs.issue_number }}
+            Applied by MEP NO_LLM (workflow_dispatch).
+            - Issue: #${{ steps.load.outputs.issue_number }}
             - Patch bytes: ${{ env.PATCH_BYTES }}
             - Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          commit-message: "mep: apply patch from issue #${{ steps.extract.outputs.issue_number }}"
-          branch: "auto/mep_issue_${{ steps.extract.outputs.issue_number }}_${{ github.run_id }}"
+          commit-message: "mep: apply patch from issue #${{ steps.load.outputs.issue_number }}"
+          branch: "auto/mep_issue_${{ steps.load.outputs.issue_number }}_${{ github.run_id }}"
           base: "main"
           delete-branch: true
-      - name: Comment result (always)
+      - name: COMMENT_RESULT (always)
         if: ${{ always() }}
         uses: actions/github-script@v7
         with:
           script: |
-            const n = parseInt("${{ steps.extract.outputs.issue_number || '0' }}", 10);
+            const n = parseInt("${{ steps.load.outputs.issue_number || '0' }}", 10);
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const prUrl = "${{ steps.cpr.outputs.pull-request-url }}";
             const msg = prUrl
               ? `✅ MEP created PR: ${prUrl}\n(run: ${runUrl})`
               : `⚠️ PR URL not returned\n(run: ${runUrl})`;
-            if (n) {
-              await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: n, body: msg });
-            }
+            if (n) await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: n, body: msg });


### PR DESCRIPTION
What:
- Switch NO_LLM Issue entry to workflow_dispatch.
- Issue comments are treated as input storage; dispatch reads latest /mep run and creates PR.
Why:
- Repo has ZERO issue_comment workflow runs, so issue_comment triggers cannot be used.
- This restores deterministic loop control and makes STOP/WAIT visible on the Issue via comments.
