### PR TITLE
Fix: NO_LLM apply patch newline normalization (strip CR)

### DIFF
--- a/.github/workflows/mep_issue_patch_to_pr.yml
+++ b/.github/workflows/mep_issue_patch_to_pr.yml
@@ -53,7 +53,7 @@ jobs:
             core.setOutput("patch_b64", Buffer.from(patch, "utf8").toString("base64"));
       - name: Write patch to file
         run: |
-          echo "${{ steps.extract.outputs.patch_b64 }}" | base64 -d > /tmp/mep.patch
+          echo "${{ steps.extract.outputs.patch_b64 }}" | base64 -d | tr -d '\r' > /tmp/mep.patch
           test -s /tmp/mep.patch
           echo "PATCH_BYTES=$(wc -c < /tmp/mep.patch)" >> $GITHUB_ENV
       - name: Guard (no binary / no delete-rename-move/chmod)
@@ -63,6 +63,7 @@ jobs:
           if grep -nE '^deleted file mode|^rename from|^rename to|^old mode|^new mode' /tmp/mep.patch >/dev/null; then echo "STOP_HARD: DANGEROUS_DIFF_FORBIDDEN"; exit 1; fi
       - name: Apply patch
         run: |
+          echo "MEP_PATCH_PREVIEW_HEAD" ; head -n 5 /tmp/mep.patch || true
           set -euo pipefail
           git apply --check /tmp/mep.patch
           git apply /tmp/mep.patch
@@ -92,3 +93,4 @@ jobs:
               ? `✅ MEP created PR: ${prUrl}\n(run: ${runUrl})`
               : `⚠️ PR URL not returned\n(run: ${runUrl})`;
             if (n) await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: n, body: msg });
+


### PR DESCRIPTION
What:
- Strip CR (\r) after base64 decode before git apply in mep_issue_patch_to_pr.yml.
- Add small patch head preview to logs.
Why:
- Current dispatch run fails at "Apply patch" with: error: corrupt patch at line N (exit code 128).
- CRLF in Issue comments is the common cause; normalizing makes apply deterministic.
