### PR TITLE
MEP: upload SystemPack outputs artifact

### DIFF
--- a/.github/workflows/system_pack_gate_push_trigger.yml
+++ b/.github/workflows/system_pack_gate_push_trigger.yml
@@ -31,3 +31,8 @@ jobs:
             sys.exit(1)
           print("OK: system_pack_engine gate DONE")
           PY
+      - name: Upload SystemPack Outputs
+        uses: actions/upload-artifact@v4
+        with:
+          name: system_pack_out
+          path: ./_system_pack_out


### PR DESCRIPTION
Workflow-only.
Uploads ./_system_pack_out as artifact so we can inspect resolved_spec.json state without fetching logs.
