### PR TITLE
Fix: NO_LLM dispatch supports PATCH_B64_START/END (stable input)

### DIFF
--- a/.github/workflows/mep_issue_patch_to_pr.yml
+++ b/.github/workflows/mep_issue_patch_to_pr.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       issue_number:
-        description: "Issue number to read latest /mep run (PATCH_START..END) from"
+        description: "Issue number to read latest /mep run from"
         required: true
         type: string
 permissions:
@@ -41,21 +41,37 @@ jobs:
             if (!body) { core.setFailed("NO_MEP_RUN_COMMENT_FOUND"); return; }
             core.setOutput("body", body);
             core.setOutput("issue_number", String(n));
-      - name: Extract patch (PATCH_START/END)
+      - name: Extract patch (PATCH_START/END or PATCH_B64_START/END)
         id: extract
         uses: actions/github-script@v7
         with:
           script: |
             const body = `${{ steps.load.outputs.body }}` || "";
-            const m = body.match(/PATCH_START\s*\n([\s\S]*?)\nPATCH_END\s*/i);
-            const patch = (m && m[1]) ? m[1].trim() : "";
-            if (!patch) { core.setFailed("NO_PATCH: Use PATCH_START..PATCH_END."); return; }
+            // A) PATCH_B64_START/END (preferred: ASCII-safe)
+            let b64 = "";
+            const mb = body.match(/PATCH_B64_START\s*\n([\s\S]*?)\nPATCH_B64_END\s*/i);
+            if (mb && mb[1]) b64 = mb[1].trim().replace(/\s+/g, "");
+            if (b64) {
+              core.setOutput("patch_b64", b64);
+              core.setOutput("patch_src", "PATCH_B64");
+              return;
+            }
+            // B) PATCH_START/END (raw diff)
+            let patch = "";
+            const mp = body.match(/PATCH_START\s*\n([\s\S]*?)\nPATCH_END\s*/i);
+            if (mp && mp[1]) patch = mp[1].trim();
+            if (!patch) {
+              core.setFailed("NO_PATCH: Use PATCH_B64_START..END or PATCH_START..END.");
+              return;
+            }
             core.setOutput("patch_b64", Buffer.from(patch, "utf8").toString("base64"));
+            core.setOutput("patch_src", "PATCH_RAW");
       - name: Write patch to file (normalize CRLF)
         run: |
           set -euo pipefail
           printf '%s' "${{ steps.extract.outputs.patch_b64 }}" | base64 -d | tr -d '\r' > /tmp/mep.patch
           test -s /tmp/mep.patch
+          echo "MEP_PATCH_SRC=${{ steps.extract.outputs.patch_src }}" >> $GITHUB_ENV
           echo "MEP_PATCH_PREVIEW_HEAD"
           head -n 12 /tmp/mep.patch || true
           echo "PATCH_BYTES=$(wc -c < /tmp/mep.patch)" >> $GITHUB_ENV
@@ -77,6 +93,7 @@ jobs:
           body: |
             Applied by MEP NO_LLM (workflow_dispatch).
             - Issue: #${{ steps.load.outputs.issue_number }}
+            - Patch src: ${{ env.MEP_PATCH_SRC }}
             - Patch bytes: ${{ env.PATCH_BYTES }}
             - Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           commit-message: "mep: apply patch from issue #${{ steps.load.outputs.issue_number }}"


### PR DESCRIPTION
What:
- Update mep_issue_patch_to_pr.yml to accept either:
  - PATCH_B64_START..PATCH_B64_END (ASCII-safe)
  - PATCH_START..PATCH_END (raw diff)
- Keep CR stripping before git apply.
Why:
- Current run fails at Extract patch with NO_PATCH because issue uses PATCH_B64_*.
- CRLF + non-ASCII in issue can break raw patch; base64 is the stable contract.
