### PR TITLE
MEP: always upload system_pack_out artifact

### DIFF
--- a/.github/workflows/system_pack_gate_push_trigger.yml
+++ b/.github/workflows/system_pack_gate_push_trigger.yml
@@ -32,6 +32,7 @@ jobs:
           print("OK: system_pack_engine gate DONE")
           PY
       - name: Upload SystemPack Outputs
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: system_pack_out


### PR DESCRIPTION
Workflow-only.
Ensure the system_pack_out artifact is uploaded even if Gate decision fails (if: always()).
