### PR TITLE
MEP: restore dispatch after SystemPack gate

### DIFF
--- a/.github/workflows/system_pack_gate_push_trigger.yml
+++ b/.github/workflows/system_pack_gate_push_trigger.yml
@@ -37,3 +37,4 @@ jobs:
         with:
           name: system_pack_out
           path: ./_system_pack_out
+


### PR DESCRIPTION
Workflow-only.
Restores the dispatch step now that SystemPack gate converges to DONE reliably.
