### PR TITLE
runner: assemble-pr allow NEW_FILE_TARGET_EXISTS (defer normalization to apply-safe)

### DIFF
--- a/tools/runner/runner.py
+++ b/tools/runner/runner.py
@@ -442,11 +442,10 @@ def assemble_pr(run_id: str) -> int:
             exists_effective = exists_in_base or (tpath in created_paths)
             if tkind == "NEW":
                 if exists_effective:
-                    rs["last_result"]["stop_class"] = "HARD"
-                    rs["last_result"]["reason_code"] = "NEW_FILE_TARGET_EXISTS"
-                    rs["next_action"] = "REGENERATE_PATCH_AS_UPDATE"
-                    write_json(RUN_STATE, rs); update_compiled(rs)
-                    return 1
+                    # ASSEMBLE_PR_A2_ALLOW_NEWFILE_EXISTS
+                    # Allow continuation: target already exists on origin/main.
+                    # apply-safe will normalize/skip/convert NEW-file patches safely.
+                    continue
                 created_paths.add(tpath)
             elif tkind == "UPD":
                 if not exists_effective:


### PR DESCRIPTION
What:
- In assemble-pr PATCH_TYPE_SCAN_A1, do NOT STOP_HARD on NEW_FILE_TARGET_EXISTS.
- Allow continuation and defer safe normalization/skip/convert to apply-safe (APPLY_SAFE_A2_NORMALIZE_NEWFILE already on main).
Why:
- Avoid early hard-stop for NEW-file patches targeting paths that already exist on origin/main (common in parallel runs / already-applied docs).
Scope:
- Gate1–7 hardening only. Gate8 handled in New Chat 2.
Safety:
- Dangerous diffs still blocked by assemble-pr denylist/limits; apply-safe performs final normalization.