### PR TITLE
SSOT: Q170 Gate8 RESTART_PACKET sink -> Adopted

### DIFF
--- a/docs/MEP/MEP_SSOT_MASTER.md
+++ b/docs/MEP/MEP_SSOT_MASTER.md
@@ -933,7 +933,7 @@ generated_at: (UTC/ISO)
 
 ### Gate8（RESTART_PACKET）出力先固定（追加）
 
-* **Q170（Draft）**：最小必須8ゲートのうち **Gate8（RESTART_PACKET）** の正規出力先（証跡の正）を **PR conversation comment（当該PRスレッドのトップコメント群）**に固定する。
+* **Q170（Adopted）**：最小必須8ゲートのうち **Gate8（RESTART_PACKET）** の正規出力先（証跡の正）を **PR conversation comment（当該PRスレッドのトップコメント群）**に固定する。
 
   * 目的：次サイクル起動情報を **GitHub上に一意・永続・参照容易**な形で残す（workflow実行条件やartifact有無に依存しない）。
   * 正規フォーマット（固定キー）：


### PR DESCRIPTION
Promotes Q170 from Draft to Adopted in docs/MEP/MEP_SSOT_MASTER.md. Gate8 output sink is fixed to PR conversation comment with RESTART_KEY idempotency and failure semantics (STOP_KIND=HARD / STOP_REASON_CODE=G8_RESTART_PACKET_FAILED). Evidence: PR #2390 comments + main anchor.