### PR TITLE
Enhance: Dispatch(from Issue) -> AutoLoop artifacts + PR + comment

### DIFF
--- a/.github/workflows/mep_dispatch_from_issue.yml
+++ b/.github/workflows/mep_dispatch_from_issue.yml
@@ -5,6 +5,7 @@ on:
     types: [labeled]
 
 permissions:
+  contents: write
   contents: read
   issues: write
   pull-requests: write
@@ -14,6 +15,65 @@ jobs:
     if: contains(github.event.issue.labels.*.name, 'mep-dispatch')
     runs-on: ubuntu-latest
     steps:
+
+      - uses: actions/checkout@v4
+      - name: MEP_DISPATCH_FROM_ISSUE_AUTOLOOP
+        shell: bash
+        run: |
+          echo "MEP_DISPATCH_FROM_ISSUE_AUTOLOOP=1" >> $GITHUB_ENV
+      - name: Generate artifacts from Issue (SYSTEM/BUSINESS)
+        env:
+          GH_REPO: ${{ github.repository }}
+          GITHUB_EVENT_PATH: ${{ github.event_path }}
+          GITHUB_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          python3 tools/issue_artifact_loop.py
+      - name: Upload workflow artifacts (downloadable)
+        uses: actions/upload-artifact@v4
+        with:
+          name: MEP_STANDALONE_ARTIFACTS_ISSUE_${{ github.event.issue.number }}
+          path: docs/MEP/ARTIFACTS/**/ISSUE_${{ github.event.issue.number }}/
+      - name: Create PR to store artifacts in repo (no auto-merge)
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "MEP: issue artifacts ISSUE #${{ github.event.issue.number }}"
+          title: "MEP: issue artifacts ISSUE #${{ github.event.issue.number }}"
+          body: |
+            Dispatch(from Issue) generated artifacts (SYSTEM/BUSINESS).
+            - Issue: #${{ github.event.issue.number }}
+            - Download: Actions artifact "MEP_STANDALONE_ARTIFACTS_ISSUE_${{ github.event.issue.number }}"
+          branch: auto/standalone_issue_${{ github.event.issue.number }}_${{ github.run_id }}
+          base: main
+          add-paths: |
+            docs/MEP/ARTIFACTS/
+      - name: Comment DONE with pointers
+        uses: actions/github-script@v7
+        env:
+          GITHUB_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          script: |
+            const issue = context.payload.issue.number;
+            const runUrl = process.env.GITHUB_RUN_URL || "";
+            const labels = (context.payload.issue.labels || []).map(x => x.name);
+            const lane = labels.includes("mep-biz") ? "BUSINESS" : "SYSTEM";
+            const body = [
+              "[MEP][DISPATCH_FROM_ISSUE][AUTOLOOP] DONE",
+              "",
+              `- Lane: ${lane}`,
+              `- Run: ${runUrl}`,
+              `- Download: Actions Artifact MEP_STANDALONE_ARTIFACTS_ISSUE_${issue}`,
+              `- Repo path: docs/MEP/ARTIFACTS/${lane}/ISSUE_${issue}/`,
+              "",
+              "Files:",
+              "- AUDIT.md",
+              "- MERGED_DRAFT.md",
+              "- INPUT_PACKET.md",
+              "- RUN_SUMMARY.md",
+              "- RESTART_PACKET.txt",
+            ].join("\\n");
+            await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: issue, body });
+
       - name: Checkout (main)
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Issue-labeled entry (mep-dispatch) now generates artifacts via tools/issue_artifact_loop.py, uploads them, creates PR under auto/standalone_issue_<n>_<run>, and comments DONE pointers back to the Issue. This replaces Standalone AutoLoop which has 0 issues-runs observed.