### PR TITLE
Fix: unblock G0-min (issue_artifact_loop indentation)

### DIFF
--- a/tools/issue_artifact_loop.py
+++ b/tools/issue_artifact_loop.py
@@ -45,7 +45,7 @@ def main():
     merged.append("")
     merged.append(body.rstrip())
     (outdir/"MERGED_DRAFT.md").write_text("\n".join(merged).rstrip()+"\n", encoding="utf-8")
-        import hashlib
+import hashlib
     merged_path = outdir/"MERGED_DRAFT.md"
     merged_bytes = merged_path.read_bytes()
     sha256 = hashlib.sha256(merged_bytes).hexdigest()


### PR DESCRIPTION
Fix IndentationError in tools/issue_artifact_loop.py (unexpected indent around top-level imports). This unblocks G0-min Issue AutoLoop (mep-dispatch) so it can generate artifacts, create PR, and comment DONE.