### PR TITLE
MEP: Register Standalone AutoLoop Dispatch workflow (safe push trigger)

### DIFF
--- a/.github/workflows/mep_standalone_autoloop_dispatch.yml
+++ b/.github/workflows/mep_standalone_autoloop_dispatch.yml
@@ -1,5 +1,9 @@
 name: MEP Standalone AutoLoop (Dispatch)
 on:
+  push:
+    paths:
+      - '.github/workflows/mep_standalone_autoloop_dispatch.yml'
+  workflow_dispatch:
   workflow_dispatch:
     inputs:
       issue_number:
@@ -103,4 +107,5 @@ jobs:
               issue_number: issue,
               body
             });
+
 


### PR DESCRIPTION
Adds push(paths) trigger ONLY for the dispatch workflow file to force GitHub workflow registration/visibility. No impact on other paths.