### PR TITLE
MEP: Fix Standalone auto-merge step (gh cli)

### DIFF
--- a/.github/workflows/mep_standalone_autoloop_dispatch.yml
+++ b/.github/workflows/mep_standalone_autoloop_dispatch.yml
@@ -18,74 +18,31 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Build pseudo event json (from issue)
+      - name: Auto-merge artifacts PR (gh cli)
+        if: steps.cpr.outputs.pull-request-number != ''
         env:
-          GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ISSUE_NUMBER: ${{ inputs.issue_number }}
-          GITHUB_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUM: ${{ steps.cpr.outputs.pull-request-number }}
         run: |
           set -euo pipefail
-          mkdir -p _tmp
-          gh api "repos/${GH_REPO}/issues/${ISSUE_NUMBER}" > _tmp/issue.json
-          python3 - << 'PY'
-          import json, pathlib
-          issue = json.loads(pathlib.Path("_tmp/issue.json").read_text(encoding="utf-8"))
-          ev = {"issue": issue}
-          pathlib.Path("_tmp/event.json").write_text(json.dumps(ev, ensure_ascii=False), encoding="utf-8")
-          PY
-          echo "EVENT_JSON=_tmp/event.json" >> "$GITHUB_ENV"
-      - name: Generate artifacts (SYSTEM/BUSINESS) from Issue
-        env:
-          ISSUE_NUMBER: ${{ inputs.issue_number }}
-          GH_REPO: ${{ github.repository }}
-          GITHUB_EVENT_PATH: ${{ env.EVENT_JSON }}
-          GITHUB_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          python3 tools/issue_artifact_loop.py
-      - name: Upload workflow artifacts (downloadable)
-        uses: actions/upload-artifact@v4
-        with:
-          name: MEP_STANDALONE_ARTIFACTS_ISSUE_${{ inputs.issue_number }}
-          path: docs/MEP/ARTIFACTS/**/ISSUE_${{ inputs.issue_number }}/
-      - name: Create PR to store artifacts in repo
-        id: cpr
-        uses: peter-evans/create-pull-request@v6
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "MEP: issue artifacts ISSUE #${{ inputs.issue_number }}"
-          title: "MEP: issue artifacts ISSUE #${{ inputs.issue_number }}"
-          body: |
-            Standalone AutoLoop (Dispatch) generated artifacts.
-            - Issue: #${{ inputs.issue_number }}
-            - Download: Actions artifact "MEP_STANDALONE_ARTIFACTS_ISSUE_${{ inputs.issue_number }}"
-          branch: auto/standalone_dispatch_${{ inputs.issue_number }}_${{ github.run_id }}
-          base: main
-          add-paths: |
-            docs/MEP/ARTIFACTS/
-      - name: Auto-merge artifacts PR (so INPUT_PACKET lands on main)
-        if: steps.cpr.outputs.pull-request-number != ''
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const pr = Number('${{ steps.cpr.outputs.pull-request-number }}');
-            await github.rest.pulls.enableAutoMerge({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: pr,
-              merge_method: 'squash'
-            }).catch(() => {});
-            for (let i = 0; i < 180; i++) {
-              const r = await github.rest.pulls.get({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: pr
-              });
-              if (r.data.merged) { core.info('MERGED'); return; }
-              await new Promise(res => setTimeout(res, 5000));
-            }
-            core.setFailed('Artifacts PR not merged yet (auto-merge waiting).');
-      - name: Comment "できました" with pointers
+          echo "PR_NUM=$PR_NUM"
+          echo "GH_REPO=$GH_REPO"
+          # request auto-merge (squash)
+          gh pr merge "$PR_NUM" --repo "$GH_REPO" --auto --squash
+          # wait until merged (max ~15 min)
+          for i in $(seq 1 180); do
+            mergedAt=$(gh pr view "$PR_NUM" --repo "$GH_REPO" --json mergedAt -q .mergedAt || true)
+            state=$(gh pr view "$PR_NUM" --repo "$GH_REPO" --json state -q .state || true)
+            echo "state=$state mergedAt=$mergedAt"
+            if [ "$mergedAt" != "null" ] && [ -n "$mergedAt" ]; then
+              echo "MERGED"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "PR not merged yet (auto-merge waiting)."
+          exit 1      - name: Comment "できました" with pointers
         uses: actions/github-script@v7
         with:
           script: |
@@ -111,4 +68,5 @@ jobs:
               issue_number: issue,
               body
             });
+
 


### PR DESCRIPTION
Fixes Standalone auto-loop failure: actions/github-script v7 lacks github.rest.pulls.enableAutoMerge. Replace auto-merge step with gh pr merge --auto --squash and wait until merged so INPUT_PACKET lands on main.