### PR TITLE
MEP: Entry executes NEXT_ACTION (apply-safe/merge-finish) + Gate8 dispatch

### DIFF
--- a/.github/workflows/mep_entry_clean.yml
+++ b/.github/workflows/mep_entry_clean.yml
@@ -1,4 +1,4 @@
-name: MEP Entry Clean
+name: MEP Entry Clean (Exec NEXT_ACTION)
 on:
   workflow_dispatch:
     inputs:
@@ -14,27 +14,107 @@ concurrency:
   group: mep-loop
   cancel-in-progress: true
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
   actions: write
+  issues: write
 jobs:
-  zone:
+  entry:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Install deps (pyyaml)
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 -m pip install --upgrade pip
+          python3 -m pip install pyyaml
       - name: Emit MEP_COPYPASTE_ZONE
         shell: bash
         run: |
           echo "===== MEP_COPYPASTE_ZONE BEGIN ====="
-echo "RESTART_PACKET"
-echo "RUN_STATE_CODE=RUNNING"
-echo "MODE=DISPATCH_LOOP_ENTRY"
-echo "ITER=${{ inputs.iter }}"
-echo "MAX_ITER=${{ inputs.max_iter }}"
-echo "REPO_ORIGIN=https://github.com/${GITHUB_REPOSITORY}"
-echo "BRANCH=${GITHUB_REF_NAME}"
-echo "HEAD_SHA=${GITHUB_SHA}"
-echo "NEXT_ACTION=ENGINE_DISPATCH_IF_WITHIN_LIMIT"
-echo "===== MEP_COPYPASTE_ZONE END ====="
-      - name: Dispatch Engine (bounded)
+          echo "RESTART_PACKET"
+          echo "RUN_STATE_CODE=RUNNING"
+          echo "MODE=DISPATCH_LOOP_ENTRY"
+          echo "ITER=${{ inputs.iter }}"
+          echo "MAX_ITER=${{ inputs.max_iter }}"
+          echo "REPO_ORIGIN=https://github.com/${GITHUB_REPOSITORY}"
+          echo "BRANCH=${GITHUB_REF_NAME}"
+          echo "HEAD_SHA=${GITHUB_SHA}"
+          echo "NEXT_ACTION=EXEC_NEXT_ACTION"
+          echo "===== MEP_COPYPASTE_ZONE END ====="
+      - name: EXEC NEXT_ACTION via runner (apply-safe / merge-finish when appropriate)
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+import json, os, sys, importlib.util
+from pathlib import Path
+# load runner.py by file path (no assumptions about package)
+spec = importlib.util.spec_from_file_location("runner", "tools/runner/runner.py")
+mod = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(mod)
+p = Path("mep/run_state.json")
+if not p.exists():
+  print("STOP_HARD: RUN_STATE_MISSING", file=sys.stderr)
+  sys.exit(1)
+rs = json.loads(p.read_text(encoding="utf-8"))
+next_action = str(rs.get("next_action") or "")
+run_id = str(rs.get("run_id") or "")
+os.environ["GH_REPO"] = os.environ.get("GH_REPO") or os.environ.get("GITHUB_REPOSITORY","")
+print(f"[runner] next_action={next_action} run_id={run_id}")
+# Always refresh compiled views + ack packet (safe)
+try:
+  mod.status()
+except SystemExit as e:
+  raise
+except Exception as e:
+  print(f"STOP_HARD: RUNNER_STATUS_FAILED: {e}", file=sys.stderr)
+  sys.exit(1)
+# Reload after status (status rewrites run_state)
+rs = json.loads(p.read_text(encoding="utf-8"))
+next_action = str(rs.get("next_action") or "")
+run_id = str(rs.get("run_id") or "")
+# Gate7->Gate? currently stuck at READY_TO_APPLY_SAFE_PATH
+if next_action == "READY_TO_APPLY_SAFE_PATH":
+  if not run_id:
+    print("STOP_HARD: RUN_ID_MISSING", file=sys.stderr)
+    sys.exit(1)
+  rc = mod.apply_safe(run_id)
+  if rc not in (0,2):
+    sys.exit(rc)
+  # Reload state after apply_safe
+  rs = json.loads(p.read_text(encoding="utf-8"))
+  run_id = str(rs.get("run_id") or "")
+  # Attempt merge_finish (will WAIT if checks pending / evidence missing)
+  rc2 = mod.merge_finish(run_id)
+  if rc2 not in (0,2):
+    sys.exit(rc2)
+print("[runner] EXEC_NEXT_ACTION done")
+PY
+      - name: Dispatch Gate8 (Writeback Bundle Entry) after merge attempt
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Gate8 DoD-min exists in mep_writeback_bundle_dispatch_entry.yml; run with pr_number=0 (auto latest merged)
+          curl --fail-with-body -sS -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            "https://api.github.com/repos/${REPO}/actions/workflows/mep_writeback_bundle_dispatch_entry.yml/dispatches" \
+            -d "{\"ref\":\"main\",\"inputs\":{\"pr_number\":\"0\",\"write_handoff\":\"true\"}}"
+      - name: Dispatch Engine (bounded, continue loop)
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -43,19 +123,16 @@ echo "===== MEP_COPYPASTE_ZONE END ====="
           set -euo pipefail
           ITER="${{ inputs.iter }}"
           MAX="${{ inputs.max_iter }}"
-          # hard safety cap
           if [ -z "${MAX}" ]; then MAX="50"; fi
           if [ "${MAX}" -gt 200 ]; then MAX="200"; fi
-          # next iteration
           NEXT=$((ITER+1))
           if [ "${NEXT}" -gt "${MAX}" ]; then
             echo "[STOP] reached max_iter: ${MAX}"
             exit 0
           fi
           echo "[GO] dispatch Engine: iter=${NEXT}/${MAX}"
-          curl -sS -X POST \
+          curl --fail-with-body -sS -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${GH_TOKEN}" \
             "https://api.github.com/repos/${REPO}/actions/workflows/mep_engine.yml/dispatches" \
             -d "{\"ref\":\"main\",\"inputs\":{\"iter\":\"${NEXT}\",\"max_iter\":\"${MAX}\"}}"
-# registry-refresh: 20260212_135722


### PR DESCRIPTION
Context (evidence):
- mep/run_state.json shows RUN_ID=RUN_5e80a72dfa04, RUN_STATUS=STILL_OPEN, NEXT_ACTION=READY_TO_APPLY_SAFE_PATH, LAST=ASSEMBLE_PR/OK.
- tools/runner/runner.py sets next_action=READY_TO_APPLY_SAFE_PATH after assemble_pr, and implements apply_safe(run_id) + merge_finish(run_id).
Change:
- Update .github/workflows/mep_entry_clean.yml to:
  1) setup python + install pyyaml (runner requires yaml)
  2) run runner.status (refresh compiled + ack packet)
  3) if next_action==READY_TO_APPLY_SAFE_PATH => run runner.apply_safe(run_id) then runner.merge_finish(run_id)
  4) dispatch Gate8 writeback bundle entry (pr_number=0)
  5) continue loop by dispatching mep_engine.yml bounded
Goal:
- close the gap between Gate7 (READY_TO_APPLY_SAFE_PATH) and Gate8 (RESTART_PACKET / writeback bundle), enabling an automated loop path.