### PR TITLE
MEP: registry refresh mep_entry_clean (20260218T162201Z)

### DIFF
--- a/.github/workflows/mep_entry_clean.yml
+++ b/.github/workflows/mep_entry_clean.yml
@@ -136,3 +136,4 @@ PY
             -H "Authorization: Bearer ${GH_TOKEN}" \
             "https://api.github.com/repos/${REPO}/actions/workflows/mep_engine.yml/dispatches" \
             -d "{\"ref\":\"main\",\"inputs\":{\"iter\":\"${NEXT}\",\"max_iter\":\"${MAX}\"}}"
+# registry-refresh: 20260218T162201Z


### PR DESCRIPTION
Touch workflow file to refresh GitHub registration (comment-only).