### PR TITLE
fix(runner): pr_probe false MULTIPLE_PR_FOR_ONE_RUN

### DIFF
--- a/tools/runner/runner.py
+++ b/tools/runner/runner.py
@@ -345,6 +345,8 @@ def pr_probe(run_id: str) -> int:
         rs["last_result"]["stop_class"] = ""
         rs["last_result"]["reason_code"] = ""
         rs["next_action"] = "STATUS"
+        write_json(RUN_STATE, rs); update_compiled(rs)
+        return 0
     # Clear stale STOP(HARD)/REPO_NOT_SET if repo is now resolvable
     repo = ""
     try:


### PR DESCRIPTION
Fix pr_probe: when exactly 1 PR exists for branch mep/run_RUN_ID, persist evidence and return early.
This prevents false HARD stop MULTIPLE_PR_FOR_ONE_RUN.