### PR TITLE
fix(actions): don't fail dispatch while auto-merge pending

### DIFF
--- a/.github/workflows/mep_standalone_autoloop_dispatch.yml
+++ b/.github/workflows/mep_standalone_autoloop_dispatch.yml
@@ -93,9 +93,8 @@ jobs:
             fi
             sleep 5
           done
-          echo "PR not merged yet (auto-merge waiting)."
-          exit 1
-
+          echo "PR not merged yet (auto-merge waiting). Proceeding without failing the run."
+          exit 0
       - name: Comment "できました" with pointers
         uses: actions/github-script@v7
         with:


### PR DESCRIPTION
Fix Standalone AutoLoop (Dispatch):
- Auto-merge step waited ~15min then exited 1 if PR not merged yet.
- Change to exit 0 so the workflow succeeds while auto-merge continues asynchronously.