### PR TITLE
MEP: fix Gate0 dispatch + run-id

### DIFF
--- a/.github/workflows/mep_gate0_unified_entry.yml
+++ b/.github/workflows/mep_gate0_unified_entry.yml
@@ -1,1 +1,27 @@
-mep_gate0_unified_entry.yml
+# registry-refresh: FIX_GATE0_RUNID_AND_DISPATCH
+name: MEP Gate0 Unified Entry
+on:
+  workflow_dispatch:
+permissions:
+  contents: write
+  pull-requests: write
+  actions: write
+jobs:
+  loop:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - run: pip install pyyaml
+      - name: Run Runner Status
+        run: |
+          python tools/runner/runner.py status
+      - name: Run Runner Step (merge-finish with run-id)
+        shell: bash
+        run: |
+          set -euo pipefail
+          RID="$(python -c 'import json;print(json.load(open("mep/run_state.json"))["run_id"])')"
+          echo "RUN_ID=${RID}"
+          python tools/runner/runner.py merge-finish --run-id "${RID}"


### PR DESCRIPTION
Fix Gate0 workflow: prevent PowerShell variable expansion, pass --run-id to merge-finish, and refresh workflow registry.