### PR TITLE
fix(actions): repair standalone dispatch workflow parse (422)

### DIFF
--- a/.github/workflows/mep_standalone_autoloop_dispatch.yml
+++ b/.github/workflows/mep_standalone_autoloop_dispatch.yml
@@ -51,15 +51,15 @@ jobs:
           python3 tools/issue_artifact_loop.py
 
       - name: Upload workflow artifacts (downloadable)
-        uses: actions/upload-artifact@v4
-        with:
+      uses: actions/upload-artifact@v4
+      with:
           name: MEP_STANDALONE_ARTIFACTS_ISSUE_${{ inputs.issue_number }}
           path: docs/MEP/ARTIFACTS/**/ISSUE_${{ inputs.issue_number }}/
 
       - name: Create PR to store artifacts in repo
         id: cpr
-        uses: peter-evans/create-pull-request@v6
-        with:
+      uses: peter-evans/create-pull-request@v6
+      with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "MEP: issue artifacts ISSUE #${{ inputs.issue_number }}"
           title: "MEP: issue artifacts ISSUE #${{ inputs.issue_number }}"
@@ -88,8 +88,8 @@ jobs:
           fi
           gh pr merge "$PR_NUMBER" --squash --auto --delete-branch || true
           exit 0      - name: Comment "できました" with pointers
-        uses: actions/github-script@v7
-        with:
+      uses: actions/github-script@v7
+      with:
           script: |
             const issue = Number('${{ inputs.issue_number }}');
             const runUrl = `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`;


### PR DESCRIPTION
Fix workflow_dispatch 422 for mep_standalone_autoloop_dispatch.yml:
- GitHub complained "Unexpected value uses/with" at specific lines.
- Normalize indentation for stray uses:/with: lines to valid step-level placement.