### PR TITLE
MEP: Gate0 audit comments STOP instead of failing

### DIFF
--- a/.github/workflows/mep_gate0_audit_compile_dispatch.yml
+++ b/.github/workflows/mep_gate0_audit_compile_dispatch.yml
@@ -1,4 +1,4 @@
-# registry-refresh: G0_AUDIT_COMPILE_DISPATCH
+# registry-refresh: G0_AUDIT_COMMENT_NOFAIL
 name: MEP Gate0 (Audit/Compile/Dispatch)
 on:
   workflow_dispatch:
@@ -21,43 +21,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - name: Gate0 Audit (ARTIFACTS must exist and be OK)
-        shell: bash
-        run: |
-          set -euo pipefail
-          N="${{ inputs.issue_number }}"
-          L="${{ inputs.lane }}"
-          DIR="docs/MEP/ARTIFACTS/${L}/ISSUE_${N}"
-          echo "DIR=${DIR}"
-          test -d "${DIR}" || { echo "::error::ARTIFACT_DIR_MISSING ${DIR}"; exit 2; }
-          AUD="${DIR}/AUDIT.md"
-          DRAFT="${DIR}/MERGED_DRAFT.md"
-          PKT="${DIR}/INPUT_PACKET.md"
-          test -f "${AUD}"   || { echo "::error::AUDIT_MISSING ${AUD}"; exit 2; }
-          test -f "${DRAFT}" || { echo "::error::MERGED_DRAFT_MISSING ${DRAFT}"; exit 2; }
-          test -f "${PKT}"   || { echo "::error::INPUT_PACKET_MISSING ${PKT}"; exit 2; }
-          # 1) AUDIT must not contain "NG"
-          if grep -n -E '\bNG\b' "${AUD}" >/dev/null 2>&1; then
-            echo "::error::AUDIT_NG_FOUND"
-            echo "---- AUDIT.md ----"
-            sed -n '1,120p' "${AUD}" || true
-            exit 2
-          fi
-          # 2) MERGED_DRAFT must not be tiny/empty
-          size="$(wc -c < "${DRAFT}" | tr -d ' ')"
-          if [ "${size}" -lt 50 ]; then
-            echo "::error::MERGED_DRAFT_TOO_SMALL size=${size}"
-            sed -n '1,80p' "${DRAFT}" || true
-            exit 2
-          fi
-          # 3) INPUT_PACKET must point to same issue
-          if ! grep -q -E "^ISSUE_NUMBER:\s*${N}\s*$" "${PKT}"; then
-            echo "::error::INPUT_PACKET_ISSUE_MISMATCH"
-            sed -n '1,80p' "${PKT}" || true
-            exit 2
-          fi
-          echo "G0_AUDIT_OK"
-      - name: Gate0 Dispatch (comment /mep run to Issue)
+      - name: Gate0 Audit + Comment (never hard-fail)
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -65,6 +29,42 @@ jobs:
         run: |
           set -euo pipefail
           N="${{ inputs.issue_number }}"
-          echo "[G0] commenting /mep run to issue #${N}"
-          gh api "repos/${REPO}/issues/${N}/comments" -f body="/mep run" >/dev/null
-          echo "G0_DISPATCH_OK"
+          L="${{ inputs.lane }}"
+          DIR="docs/MEP/ARTIFACTS/${L}/ISSUE_${N}"
+          say () {
+            gh api "repos/${REPO}/issues/${N}/comments" -f body="$1" >/dev/null || true
+          }
+          header="[MEP][G0] AUDIT RESULT"
+          if [ ! -d "${DIR}" ]; then
+            say "${header}\n\nSTOP_REASON: ARTIFACT_DIR_MISSING\nDIR: ${DIR}\n\nAction:\n- Run standalone artifact build first (Issue loop) to generate ARTIFACTS."
+            exit 0
+          fi
+          AUD="${DIR}/AUDIT.md"
+          DRAFT="${DIR}/MERGED_DRAFT.md"
+          PKT="${DIR}/INPUT_PACKET.md"
+          if [ ! -f "${AUD}" ] || [ ! -f "${DRAFT}" ] || [ ! -f "${PKT}" ]; then
+            say "${header}\n\nSTOP_REASON: ARTIFACT_FILES_MISSING\nDIR: ${DIR}\n\nMissing:\n- AUDIT.md? $([ -f "${AUD}" ] && echo OK || echo NG)\n- MERGED_DRAFT.md? $([ -f "${DRAFT}" ] && echo OK || echo NG)\n- INPUT_PACKET.md? $([ -f "${PKT}" ] && echo OK || echo NG)\n\nAction:\n- Re-run artifact generation for this issue."
+            exit 0
+          fi
+          # read flags from INPUT_PACKET
+          DOES_NOT_TRIGGER="$(grep -m1 -E '^DOES_NOT_TRIGGER_8GATE:' "${PKT}" | sed -E 's/^DOES_NOT_TRIGGER_8GATE:\s*//;s/\r//g' || true)"
+          SAFE_MODE="$(grep -m1 -E '^SAFE_MODE:' "${PKT}" | sed -E 's/^SAFE_MODE:\s*//;s/\r//g' || true)"
+          # conditions
+          NG=0
+          if grep -n -E '\bNG\b' "${AUD}" >/dev/null 2>&1; then NG=1; fi
+          size="$(wc -c < "${DRAFT}" | tr -d ' ')"
+          if [ "${size}" -lt 50 ]; then NG=1; fi
+          if ! grep -q -E "^ISSUE_NUMBER:\s*${N}\s*$" "${PKT}"; then NG=1; fi
+          if [ "${NG}" -eq 1 ]; then
+            say "${header}\n\nSTOP_REASON: AUDIT_NG\nSAFE_MODE: ${SAFE_MODE}\nDOES_NOT_TRIGGER_8GATE: ${DOES_NOT_TRIGGER}\nDIR: ${DIR}\n\nAUDIT (head):\n$(sed -n '1,80p' "${AUD}")\n\nDRAFT_SIZE(bytes): ${size}\n\nAction:\n- Put non-empty draft body into Issue #${N}\n- Re-run artifact generation\n- Re-run Gate0"
+            exit 0
+          fi
+          # AUDIT OK
+          if [ "${DOES_NOT_TRIGGER}" = "true" ]; then
+            say "${header}\n\nAUDIT: OK\nSAFE_MODE: ${SAFE_MODE}\nDOES_NOT_TRIGGER_8GATE: true\nDIR: ${DIR}\n\nNext:\n- This packet is marked as NOT triggering 8-gate.\n- If you want to run 8-gate, set DOES_NOT_TRIGGER_8GATE:false and re-generate INPUT_PACKET."
+            exit 0
+          fi
+          # dispatch 8-gate entry by commenting /mep run
+          say "${header}\n\nAUDIT: OK\nSAFE_MODE: ${SAFE_MODE}\nDOES_NOT_TRIGGER_8GATE: false\nDIR: ${DIR}\n\nNext:\n- Dispatching 8-gate via issue comment: /mep run"
+          gh api "repos/${REPO}/issues/${N}/comments" -f body="/mep run" >/dev/null || true
+          exit 0


### PR DESCRIPTION
Gate0 audit should not fail the workflow on AUDIT_NG; it should comment STOP_REASON to the issue and exit 0. Also respects DOES_NOT_TRIGGER_8GATE.