### PR TITLE
fix(actions): repair github-script comment step

### DIFF
--- a/.github/workflows/mep_standalone_autoloop_dispatch.yml
+++ b/.github/workflows/mep_standalone_autoloop_dispatch.yml
@@ -91,27 +91,23 @@ jobs:
       - name: Comment "できました" with pointers
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const issue = Number('${{ inputs.issue_number }}');
-            const runUrl = `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`;
+            const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
+            const runUrl = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}';
             const body = [
-              "できました（Standalone AutoLoop / Dispatch）",
-              "",
-              `- Run: ${runUrl}`,
-              `- Download: Actions Artifacts → MEP_STANDALONE_ARTIFACTS_ISSUE_${issue}`,
-              `- Repo path (merged): docs/MEP/ARTIFACTS/<LANE>/ISSUE_${issue}/`,
-              "",
-              "出力（必須）:",
-              "- AUDIT.md",
-              "- MERGED_DRAFT.md（草案本文1つ）",
-              "- INPUT_PACKET.md（8ゲート入口へ差し込み可能）",
-              "- RUN_SUMMARY.md",
-              "- RESTART_PACKET.txt"
-            ].join("\n");
-            await github.rest.issues.createComment({
-          owner: context.repo.owner,
-          repo: context.repo.repo,
-          issue_number: issue,
-              body
-            });
-
+              'できました（Standalone AutoLoop / Dispatch）',
+              '',
+              '- Run: ' + runUrl,
+              '- Download: Actions Artifacts → MEP_STANDALONE_ARTIFACTS_ISSUE_' + issue,
+              '- Repo path (merged): docs/MEP/ARTIFACTS/<LANE>/ISSUE_' + issue + '/',
+              '',
+              '出力（必須）:',
+              '- AUDIT.md',
+              '- MERGED_DRAFT.md（草案本文1つ）',
+              '- INPUT_PACKET.md（8ゲート入口へ差し込み可能）',
+              '- RUN_SUMMARY.md',
+              '- RESTART_PACKET.txt'
+            ].join('\\n');
+            await github.rest.issues.createComment({ owner, repo, issue_number: issue, body });


### PR DESCRIPTION
Fix Standalone Dispatch comment step:
- actions/github-script@v7: remove invalid with: inputs (owner/repo/issue_number)
- replace script with safe JS (no template literals), prevents SyntaxError