### PR TITLE
chore(actions): registry refresh standalone dispatch workflow

### DIFF
--- a/.github/workflows/mep_standalone_autoloop_dispatch.yml
+++ b/.github/workflows/mep_standalone_autoloop_dispatch.yml
@@ -111,3 +111,5 @@ jobs:
               '- RESTART_PACKET.txt'
             ].join('\\n');
             await github.rest.issues.createComment({ owner, repo, issue_number: issue, body });
+
+# registry-refresh 20260219T151523Z


### PR DESCRIPTION
Registry refresh to fix 422 workflow_dispatch trigger mismatch.