### PR TITLE
chore(actions): register standalone dispatch workflow v2

### DIFF
--- a/.github/workflows/mep_standalone_autoloop_dispatch_v2.yml
+++ b/.github/workflows/mep_standalone_autoloop_dispatch_v2.yml
@@ -1,0 +1,117 @@
+name: MEP Standalone AutoLoop (Dispatch)
+
+on:
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "GitHub Issue number containing the draft"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: mep-standalone-dispatch-${{ inputs.issue_number }}
+  cancel-in-progress: true
+
+jobs:
+  build-artifacts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build pseudo event json (from issue)
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ inputs.issue_number }}
+          GITHUB_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          mkdir -p _tmp
+          gh api "repos/${GH_REPO}/issues/${ISSUE_NUMBER}" > _tmp/issue.json
+          python3 - << 'PY'
+          import json, pathlib
+          issue = json.loads(pathlib.Path("_tmp/issue.json").read_text(encoding="utf-8"))
+          ev = {"issue": issue}
+          pathlib.Path("_tmp/event.json").write_text(json.dumps(ev, ensure_ascii=False), encoding="utf-8")
+          PY
+          echo "EVENT_JSON=_tmp/event.json" >> "$GITHUB_ENV"
+
+      - name: Generate artifacts (SYSTEM/BUSINESS) from Issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}`n          GH_REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ inputs.issue_number }}
+          GITHUB_EVENT_PATH: ${{ env.EVENT_JSON }}
+          GITHUB_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          python3 tools/issue_artifact_loop.py
+
+      - name: Upload workflow artifacts (downloadable)
+        uses: actions/upload-artifact@v4
+        with:
+          name: MEP_STANDALONE_ARTIFACTS_ISSUE_${{ inputs.issue_number }}
+          path: docs/MEP/ARTIFACTS/**/ISSUE_${{ inputs.issue_number }}/
+
+      - name: Create PR to store artifacts in repo
+        id: cpr
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "MEP: issue artifacts ISSUE #${{ inputs.issue_number }}"
+          title: "MEP: issue artifacts ISSUE #${{ inputs.issue_number }}"
+          body: |
+            Standalone AutoLoop (Dispatch) generated artifacts.
+            - Issue: #${{ inputs.issue_number }}
+            - Download: Actions artifact "MEP_STANDALONE_ARTIFACTS_ISSUE_${{ inputs.issue_number }}"
+          branch: auto/standalone_dispatch_${{ inputs.issue_number }}_${{ github.run_id }}
+          base: main
+          add-paths: |
+            docs/MEP/ARTIFACTS/
+
+      - name: Auto-merge artifacts PR (gh cli)
+        if: steps.cpr.outputs.pull-request-number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUM: ${{ steps.cpr.outputs.pull-request-number }}
+        run: |
+          set -euo pipefail
+          echo "[auto-merge] trigger only (no waiting)"
+          echo "PR_NUMBER=${PR_NUMBER:-}"
+          if [ -z "${PR_NUMBER:-}" ]; then
+            echo "PR_NUMBER is empty -> exit 0 (no-op)"
+            exit 0
+          fi
+          gh pr merge "$PR_NUMBER" --squash --auto --delete-branch || true
+          exit 0
+      - name: Comment "できました" with pointers
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issue = Number('${{ inputs.issue_number }}');
+            const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
+            const runUrl = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}';
+            const body = [
+              'できました（Standalone AutoLoop / Dispatch）',
+              '',
+              '- Run: ' + runUrl,
+              '- Download: Actions Artifacts → MEP_STANDALONE_ARTIFACTS_ISSUE_' + issue,
+              '- Repo path (merged): docs/MEP/ARTIFACTS/<LANE>/ISSUE_' + issue + '/',
+              '',
+              '出力（必須）:',
+              '- AUDIT.md',
+              '- MERGED_DRAFT.md（草案本文1つ）',
+              '- INPUT_PACKET.md（8ゲート入口へ差し込み可能）',
+              '- RUN_SUMMARY.md',
+              '- RESTART_PACKET.txt'
+            ].join('\\n');
+            await github.rest.issues.createComment({ owner, repo, issue_number: issue, body });
+
+# registry-refresh 20260219T151523Z
+
+# registry-v2 20260219T152015Z


### PR DESCRIPTION
Create a new workflow file name to force GitHub registry refresh. Use v2 for dispatch (workflow_dispatch).