### PR TITLE
feat(actions): standalone dispatch entry wrapper for v2

### DIFF
--- a/.github/workflows/mep_standalone_autoloop_dispatch_entry.yml
+++ b/.github/workflows/mep_standalone_autoloop_dispatch_entry.yml
@@ -1,0 +1,17 @@
+name: MEP Standalone AutoLoop (Dispatch Entry)
+on:
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "GitHub Issue number containing the draft"
+        required: true
+        type: string
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+jobs:
+  call-v2:
+    uses: ./.github/workflows/mep_standalone_autoloop_dispatch_v2.yml
+    with:
+      issue_number: ${{ inputs.issue_number }}

--- a/.github/workflows/mep_standalone_autoloop_dispatch_v2.yml
+++ b/.github/workflows/mep_standalone_autoloop_dispatch_v2.yml
@@ -5,6 +5,12 @@ name: MEP Standalone AutoLoop (Dispatch)
 
 
 on:
+  workflow_call:
+    inputs:
+      issue_number:
+        description: "GitHub Issue number containing the draft"
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       issue_number:


### PR DESCRIPTION
Workaround for v2 dispatch 422: add workflow_call to v2 and introduce a workflow_dispatch entry wrapper that calls v2.