### PR TITLE
fix(actions): repair v2 yaml literal newline contamination

### DIFF
--- a/.github/workflows/mep_standalone_autoloop_dispatch_v2.yml
+++ b/.github/workflows/mep_standalone_autoloop_dispatch_v2.yml
@@ -124,7 +124,8 @@ jobs:
         env:
 
 
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}`n          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
 
 
           ISSUE_NUMBER: ${{ inputs.issue_number }}


### PR DESCRIPTION
Fix called workflow parse error: replace literal 
 sequence that collapsed GH_TOKEN and GH_REPO into one line back into a real newline.