### PR TITLE
MEP: fix issue_artifact_loop.py (missing pathlib import)

### DIFF
--- a/tools/issue_artifact_loop.py
+++ b/tools/issue_artifact_loop.py
@@ -1,4 +1,5 @@
 import re
+import pathlib
 #!/usr/bin/env python3
 import json, os, hashlib
 from pathlib import Path


### PR DESCRIPTION
Fix NameError: issue_artifact_loop.py used pathlib without importing it. Adds import and keeps behavior unchanged.