### PR TITLE
Fix Standalone AutoLoop: import pathlib (NameError)

### DIFF
--- a/tools/issue_artifact_loop.py
+++ b/tools/issue_artifact_loop.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import hashlib
+import pathlib
 import json
 import os
 import re


### PR DESCRIPTION
Context:
- Standalone AutoLoop (Dispatch Entry) failed at step "Generate artifacts (SYSTEM/BUSINESS) from Issue"
- Run: 22203018997 / Job: 64220430904
- Root cause: NameError: pathlib is not defined (tools/issue_artifact_loop.py)
Fix:
- Add missing "import pathlib" so audit_body_from_artifacts can build artifact paths.
Expected:
- Standalone AutoLoop can generate artifacts and proceed to upload/PR/merge/comment.