### PR TITLE
Fix /mep run handler: mep_issueops_run.yml indentation

### DIFF
--- a/.github/workflows/mep_issueops_run.yml
+++ b/.github/workflows/mep_issueops_run.yml
@@ -17,12 +17,11 @@ permissions:
 
 jobs:
   issueops_run:
-        if: >-
+    if: >-
       (github.event_name == 'issues') ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request == null &&
        startsWith(github.event.comment.body, '/mep run'))
-
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -43,3 +42,4 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GITHUB_TOKEN: ${{ github.token }}
         run: python tools/agent/issueops.py
+


### PR DESCRIPTION
Problem:
- /mep run comment triggers only Issue Comment Smoke (echo), but not the real dispatcher.
Root cause:
- .github/workflows/mep_issueops_run.yml has broken indentation for jobs.issueops_run.if, making the workflow invalid and ignored by Actions.
Fix:
- Correct indentation for the job-level if: and its multiline condition.
Expected:
- issue_comment with "/mep run" triggers mep_issueops_run, which runs tools/agent/issueops.py and dispatches Gate0/Standalone.