### PR TITLE
Fix IssueOps: fetch latest comment safely (no paginate/page)

### DIFF
--- a/tools/agent/issueops.py
+++ b/tools/agent/issueops.py
@@ -51,7 +51,7 @@ def should_run(issue, latest_comment_body):
 
 
 def fetch_latest_comment(repo, issue_number):
-    comments = gh_json([f"repos/{repo}/issues/{issue_number}/comments", "--paginate", "-f", "per_page=1", "-f", "page=1"])
+    comments = gh_json([f"/repos/{repo}/issues/{issue_number}/comments", "-f", "per_page=1", "-f", "sort=created", "-f", "direction=desc"])
     if comments:
         return comments[-1].get("body") or ""
     return ""
@@ -220,3 +220,4 @@ def main():
 
 if __name__ == "__main__":
     sys.exit(main())
+


### PR DESCRIPTION
Context:
- mep_issueops_run.yml now triggers, but IssueOps fails at fetch_latest_comment().
- Root cause: gh api call uses --paginate with per_page/page args and exits non-zero.
Fix:
- Fetch only the latest comment with per_page=1 + sort=created + direction=desc (no paginate, no page).
Expected:
- IssueOps completes and can proceed to dispatch next workflows (Gate0/Standalone/8-gate).