### PR TITLE
Fix Gate12 health: param() must be first statement

### DIFF
--- a/tools/mep_health_generate.ps1
+++ b/tools/mep_health_generate.ps1
@@ -1,5 +1,3 @@
-Set-StrictMode -Version Latest
-$ErrorActionPreference = "Stop"
 param(
   [string]$RepoRoot = ".",
   [string]$OutDir = "docs/MEP_STATUS",
@@ -7,6 +5,8 @@ param(
   [string]$Bundle = "docs/MEP/MEP_BUNDLE.md",
   [string]$SSOT = "docs/MEP/MEP_SSOT_MASTER.md"
 )
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
 function Read-Text([string]$p) {
   if (Test-Path -LiteralPath $p) { return (Get-Content -LiteralPath $p -Raw) }
   return $null


### PR DESCRIPTION
Fixes Actions ParserError by moving param() to top of tools/mep_health_generate.ps1.