### PR TITLE
Fix IssueOps: configure git identity for commits

### DIFF
--- a/tools/agent/issueops.py
+++ b/tools/agent/issueops.py
@@ -46,11 +46,18 @@ def utc_now():
 
 # MEP_ISSUEOPS_GIT_IDENTITY
 def ensure_git_identity():
-    # Ensure git commit works on Actions runner (repo-local config).
+    # Ensure git commit works on GitHub-hosted runners (env + global + repo-local).
+    import os as _os
+    _os.environ.setdefault("GIT_AUTHOR_NAME", "github-actions")
+    _os.environ.setdefault("GIT_AUTHOR_EMAIL", "actions@users.noreply.github.com")
+    _os.environ.setdefault("GIT_COMMITTER_NAME", "github-actions")
+    _os.environ.setdefault("GIT_COMMITTER_EMAIL", "actions@users.noreply.github.com")
+    # Global (covers cases where git refuses empty ident even if repo-local is set)
+    run(["git", "config", "--global", "user.name", "github-actions"])
+    run(["git", "config", "--global", "user.email", "actions@users.noreply.github.com"])
+    # Repo-local (preferred)
     run(["git", "config", "user.name", "github-actions"])
     run(["git", "config", "user.email", "actions@users.noreply.github.com"])
-
-
 def canonicalize(text: str) -> str:
     return text.replace("\r\n", "\n").replace("\r", "\n").strip()
 
@@ -253,6 +260,7 @@ def main():
 
 if __name__ == "__main__":
     sys.exit(main())
+
 
 
 


### PR DESCRIPTION
Context:
- IssueOps fails in Actions with: "Author identity unknown" and "fatal: empty ident name" when running `git commit`.
Fix:
- In IssueOps, set repo-local git identity before any commit:
  user.name=github-actions
  user.email=actions@users.noreply.github.com
Expected:
- IssueOps can create commits deterministically on GitHub-hosted runners without relying on workflow-global git config.