### PR TITLE
MEP: fix IssueOps workflow (git identity + contents write)

### DIFF
--- a/.github/workflows/mep_issueops_run.yml
+++ b/.github/workflows/mep_issueops_run.yml
@@ -1,10 +1,10 @@
-# registry-refresh: WIRE_ISSUE_COMMENT_MEP_RUN
+# registry-refresh: FIX_ISSUEOPS_GIT_IDENTITY_AND_CONTENTS_WRITE
 name: MEP IssueOps Run (Issue Comment)
 on:
   issue_comment:
     types: [created]
 permissions:
-  contents: read
+  contents: write
   issues: write
   pull-requests: write
   actions: write
@@ -22,10 +22,20 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install pyyaml
+      - name: Configure git identity (required for commit)
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name  "mep-issueops"
+          git config user.email "mep-issueops@users.noreply.github.com"
       - name: Run IssueOps
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO:  ${{ github.repository }}
+          GIT_AUTHOR_NAME: "mep-issueops"
+          GIT_AUTHOR_EMAIL: "mep-issueops@users.noreply.github.com"
+          GIT_COMMITTER_NAME: "mep-issueops"
+          GIT_COMMITTER_EMAIL: "mep-issueops@users.noreply.github.com"
         run: |
           set -euo pipefail
           python tools/agent/issueops.py


### PR DESCRIPTION
Fix issue_comment IssueOps failures: set git user.name/email; set contents:write; add author/committer env vars.