### PR TITLE
MEP: fix IssueOps branch name (escape regression)

### DIFF
--- a/tools/agent/issueops.py
+++ b/tools/agent/issueops.py
@@ -167,7 +167,7 @@ def write_draft(run_id, issue_body):
 
 
 def git_pr_flow(repo, run_id, issue_number):
-    branch = f"mep/issueops-run-{run_id.lower()}-\{_issueops_unique_suffix()\}"
+    branch = f"mep/issueops-run-{run_id.lower()}-{_issueops_unique_suffix()}"
     run(["git", "checkout", "-b", branch])
     run(["git", "add", "mep/inbox", "mep/run_state.json", "docs/MEP/STATUS.md", "docs/MEP/HANDOFF_AUDIT.md", "docs/MEP/HANDOFF_WORK.md"])
     run(["git", "commit", "-m", f"chore(mep): issueops intake {run_id} (issue #{issue_number})"])


### PR DESCRIPTION
Fix SyntaxError introduced by escaped braces in f-string (\\{...\\}). Replace with proper { ... } so IssueOps can run.