### PR TITLE
Fix Standalone v2: NOOP on PR without issue_number

### DIFF
--- a/.github/workflows/mep_standalone_autoloop_dispatch_v2.yml
+++ b/.github/workflows/mep_standalone_autoloop_dispatch_v2.yml
@@ -35,11 +35,11 @@ permissions:
 
 
 concurrency:
-  group: mep-standalone-dispatch-${{ inputs.issue_number || github.run_id }}
+  group: mep-standalone-dispatch-${{ github.run_id }}
   cancel-in-progress: true
 jobs:
   noop-pr:
-    if: ${{ github.event_name == 'pull_request' && (inputs.issue_number == '' || inputs.issue_number == null) }}
+    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
       - name: NOOP for PR checks (issue_number not provided)
@@ -47,7 +47,7 @@ jobs:
           echo "NOOP: mep_standalone_autoloop_dispatch_v2.yml on pull_request without inputs.issue_number"
           echo "This workflow is a required check; real execution happens via workflow_dispatch/workflow_call with issue_number."
   build-artifacts:
-    if: ${{ inputs.issue_number != '' }}
+    if: ${{ github.event_name != 'pull_request' && inputs.issue_number != '' }}
     runs-on: ubuntu-latest
     steps:
 
@@ -337,4 +337,5 @@ jobs:
 
 
 # debug-push 20260219T152650Z
+
 


### PR DESCRIPTION
Problem:
- Required check "MEP Standalone AutoLoop (Dispatch)" runs on pull_request, but inputs.issue_number is empty.
- build-artifacts step calls: gh api repos/${GH_REPO}/issues/${ISSUE_NUMBER} and fails with 404 when ISSUE_NUMBER is empty.
Fix:
- Add noop-pr job that succeeds on pull_request when issue_number is missing.
- Guard build-artifacts job with: if: ${{ inputs.issue_number != '' }}
- Make concurrency group safe with fallback to github.run_id.
Expected:
- PR checks stay green.
- Real Standalone execution still works via workflow_dispatch/workflow_call (issue_number provided).