### PR TITLE
MEP: IssueOps unique branch per run (avoid push collision)

### DIFF
--- a/tools/agent/issueops.py
+++ b/tools/agent/issueops.py
@@ -167,7 +167,9 @@ def write_draft(run_id, issue_body):
 
 
 def git_pr_flow(repo, run_id, issue_number):
-    branch = f"mep/issueops-run-{run_id.lower()}-{_issueops_unique_suffix()}"
+    uniq = (os.environ.get("GITHUB_RUN_ID") or "").strip() or datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    branch = f"mep/issueops-run-{run_id.lower()}-{_issueops_unique_suffix()}-{uniq}"
+
     run(["git", "checkout", "-b", branch])
     run(["git", "add", "mep/inbox", "mep/run_state.json", "docs/MEP/STATUS.md", "docs/MEP/HANDOFF_AUDIT.md", "docs/MEP/HANDOFF_WORK.md"])
     run(["git", "commit", "-m", f"chore(mep): issueops intake {run_id} (issue #{issue_number})"])


### PR DESCRIPTION
Fix IssueOps failure: deterministic branch caused git push reject (fetch first). Append unique suffix (GITHUB_RUN_ID or UTC).