### PR TITLE
Fix IssueOps: dispatch Gate0 after successful run

### DIFF
--- a/.github/workflows/mep_issueops_run.yml
+++ b/.github/workflows/mep_issueops_run.yml
@@ -39,3 +39,13 @@ jobs:
         run: |
           set -euo pipefail
           python tools/agent/issueops.py
+
+      - name: Dispatch Gate0 (Audit/Compile/Dispatch)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          echo "Dispatching Gate0 for issue #${ISSUE_NUMBER}"
+          gh workflow run .github/workflows/mep_gate0_audit_compile_dispatch.yml -f issue_number="${ISSUE_NUMBER}"


### PR DESCRIPTION
Problem:
- IssueOps workflow completes, but no downstream workflow_dispatch/repository_dispatch runs appear.
- Intake PRs are created by app/github-actions and do not get checks (GITHUB_TOKEN behavior), so the loop stalls.
Fix:
- In mep_issueops_run.yml, after "Run IssueOps", dispatch Gate0 via gh workflow run:
  .github/workflows/mep_gate0_audit_compile_dispatch.yml with input issue_number=${{ github.event.issue.number }}
Expected:
- Each /mep run -> IssueOps success -> Gate0 workflow_dispatch run appears, enabling the 8-gate chain to proceed.