### PR TITLE
Fix Gate0: dispatch downstream workflow (issue_number)

### DIFF
--- a/.github/workflows/mep_gate0_audit_compile_dispatch.yml
+++ b/.github/workflows/mep_gate0_audit_compile_dispatch.yml
@@ -69,6 +69,13 @@ jobs:
           # dispatch 8-gate entry by commenting /mep run
           say "${header}\n\nAUDIT: OK\nSAFE_MODE: ${SAFE_MODE}\nDOES_NOT_TRIGGER_8GATE: false\nDIR: ${DIR}\n\nNext:\n- Dispatching 8-gate via issue comment: /mep run"
           gh api "repos/${REPO}/issues/${N}/comments" -f body="/mep run" >/dev/null || true
+          echo ""
+          echo "Dispatching downstream workflow: .github/workflows/mep_8gate_entry_filter.yml"
+          if [ -z "${N:-}" ]; then
+            echo "N(issue_number) is empty; skip downstream dispatch."
+          else
+            gh workflow run ".github/workflows/mep_8gate_entry_filter.yml" -f issue_number="${N}" >/dev/null
+          fi
           exit 0
 
 # Dispatch downstream workflow (from Gate0)


### PR DESCRIPTION
Problem:
- Gate0 only audits/comments and does not start downstream workflows, so 8-gate never begins.
Fix:
- Gate0 dispatches a downstream workflow via gh workflow run with input issue_number.
- Selected downstream workflow: .github/workflows/mep_8gate_entry_filter.yml
- Ensure actions: write permission.
Expected:
- IssueOps -> Gate0 -> downstream workflow_dispatch starts reliably.