### PR TITLE
mep: stabilize OP-1 push runs (re-add narrow push trigger)

### DIFF
--- a/.github/workflows/mep_writeback_bundle_dispatch_entry.yml
+++ b/.github/workflows/mep_writeback_bundle_dispatch_entry.yml
@@ -1,4 +1,4 @@
-# reindex: force workflow registration refresh 2026-02-20T13:40:08Z
+# reindex: force workflow registration refresh 2026-02-20T13:49:22Z
 name: MEP Writeback Bundle (Entry)
 on:
   workflow_dispatch:
@@ -19,6 +19,13 @@ on:
         description: "write handoff files (optional)"
         required: false
         default: "false"
+  push:
+    branches: [main]
+    paths:
+      - "docs/MEP/**"
+      - "docs/MEP_SUB/**"
+      - "tools/**"
+      - ".github/workflows/mep_writeback_bundle_dispatch_entry.yml"
 permissions:
   contents: write
   pull-requests: write


### PR DESCRIPTION
Purpose:
- OP-1 workflow is showing push-triggered failure runs with jobs=0 even after dispatch-only/inputs fixes.
Change:
- Re-add a narrow push trigger (main + limited paths) so push-origin runs generate jobs and can succeed.
Safety:
- writeback job stays guarded to workflow_dispatch only; push runs will not perform writeback.
Expected:
- push runs stop failing (jobs>0) and the red loop disappears.