### PR TITLE
ci: add workflow-lint (actionlint) for PR

### DIFF
--- a/.github/workflows/workflow_lint_pr.yml
+++ b/.github/workflows/workflow_lint_pr.yml
@@ -1,0 +1,16 @@
+name: workflow-lint
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: actionlint
+        uses: rhysd/actionlint@v1


### PR DESCRIPTION
Purpose:
- Prevent broken workflow YAML from reaching main.
Change:
- Add workflow-lint (actionlint) on pull_request for .github/workflows/**.
Next:
- Add required check name "workflow-lint / actionlint" to Ruleset if desired.