### PR TITLE
Fix Gate0: dedicated 8-gate dispatch step (remove duplicate embed)

### DIFF
--- a/.github/workflows/mep_gate0_audit_compile_dispatch.yml
+++ b/.github/workflows/mep_gate0_audit_compile_dispatch.yml
@@ -80,15 +80,12 @@ jobs:
             say "${header}\n\nAUDIT: OK\nSAFE_MODE: ${SAFE_MODE}\nDOES_NOT_TRIGGER_8GATE: true\nDIR: ${DIR}\n\nNext:\n- This packet is marked as NOT triggering 8-gate.\n- If you want to run 8-gate, set DOES_NOT_TRIGGER_8GATE:false and re-generate INPUT_PACKET."
             exit 0
           fi
-          # dispatch 8-gate entry by commenting /mep run
           say "${header}\n\nAUDIT: OK\nSAFE_MODE: ${SAFE_MODE}\nDOES_NOT_TRIGGER_8GATE: false\nDIR: ${DIR}\n\nNext:\n- Dispatching 8-gate via issue comment: /mep run"
           gh api "repos/${REPO}/issues/${N}/comments" -f body="/mep run" >/dev/null || true
           echo ""
-          echo "Dispatching downstream workflow: .github/workflows/mep_8gate_entry_filter.yml"
           if [ -z "${N:-}" ]; then
             echo "N(issue_number) is empty; skip downstream dispatch."
           else
-            gh workflow run ".github/workflows/mep_8gate_entry_filter.yml" -f issue_number="${N}" >/dev/null
           fi
           exit 0
 


### PR DESCRIPTION
Problem:
- Gate0 had two dispatch paths for 8-gate:
  (1) dedicated step "Dispatch 8-gate entry"
  (2) older embedded dispatch inside the Audit+Comment step
  This can cause double-dispatch and makes behavior harder to reason about.
Fix:
- Keep the dedicated step only.
- Remove the embedded duplicate dispatch lines.
Expected:
- Gate0 run shows a separate "Dispatch 8-gate entry" step with success/failure visible in Jobs/Steps (no log download).