### PR TITLE
Fix Gate0: dispatch 8-gate entry via packet_path

### DIFF
--- a/.github/workflows/mep_gate0_audit_compile_dispatch.yml
+++ b/.github/workflows/mep_gate0_audit_compile_dispatch.yml
@@ -34,7 +34,7 @@ jobs:
             exit 0
           fi
           echo "Dispatching .github/workflows/mep_8gate_entry_filter.yml for issue #${N}"
-          gh workflow run ".github/workflows/mep_8gate_entry_filter.yml" -f issue_number="${N}"
+          gh workflow run ".github/workflows/mep_8gate_entry_filter.yml" -f packet_path="${PKT}"
 
       - name: Gate0 Audit + Comment (never hard-fail)
         shell: bash
@@ -90,5 +90,6 @@ jobs:
           exit 0
 
 # Dispatch downstream workflow (from Gate0)
+
 
 


### PR DESCRIPTION
Problem:
- Gate0 tries to dispatch 8-gate entry with: issue_number=${N}
- But mep_8gate_entry_filter.yml expects workflow_dispatch input: packet_path
- Result: Dispatch 8-gate entry step always fails.
Fix:
- Change Gate0 dispatch to:
  gh workflow run .github/workflows/mep_8gate_entry_filter.yml -f packet_path="${PKT}"
  where PKT is docs/MEP/ARTIFACTS/<LANE>/ISSUE_<N>/INPUT_PACKET.md
Expected:
- Gate0 "Dispatch 8-gate entry" becomes success.
- A new workflow_dispatch run for "MEP 8-Gate Entry (Packet Filter)" appears after /mep run.