### PR TITLE
[codex] Mark repository retired

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-﻿MEP entrypoint: START_HERE.md
+> RETIRED: This repository is not current MEP truth. See `Osuu-ops/mep-runtime-scaffold` and its repo retirement ledger.
+
+MEP entrypoint: START_HERE.md
 
 
 BAT report canary

--- a/RETIRED_REPO.md
+++ b/RETIRED_REPO.md
@@ -1,0 +1,11 @@
+# Retired Repository
+
+This repository is retired.
+
+Canonical MEP is maintained in:
+- Osuu-ops/mep-runtime-scaffold
+
+Do not use this repository as a source of current MEP truth.
+
+This repository is retained temporarily for audit/recovery only.
+Deletion requires approval in the canonical MEP repo retirement ledger.

--- a/platform/MEP/90_CHANGES/CURRENT_SCOPE.md
+++ b/platform/MEP/90_CHANGES/CURRENT_SCOPE.md
@@ -2,6 +2,8 @@
 ## 変更対象（Scope-IN）
 - docs/MEP/MEP_BUNDLE.md
 - docs/MEP_SUB/EVIDENCE/MEP_BUNDLE.md
+- README.md
+- RETIRED_REPO.md
 - .github/workflows/scope_guard_pr.yml
 - .github/workflows/mep_required_checks_ssot_guard_pr.yml
 - .github/workflows/mep_entry_gate_pr.yml


### PR DESCRIPTION
## Summary

- Adds `RETIRED_REPO.md` to make this repository visibly retired.
- Adds a README banner pointing operators back to `Osuu-ops/mep-runtime-scaffold` as current MEP truth.

## Reason

This repository is classified by the current MEP retirement ledger as legacy/quarantined. The marker prevents Codex/GPT/UI operators from treating this repo as the current MEP entrypoint while preserving it for audit/recovery until a later explicit deletion decision.

## Validation

- `git diff --check` passed locally before commit.
- Direct push to `main` was correctly blocked by repository rules, so this change is proposed through PR.

## Non-Assertions

- This PR does not delete or archive the repository.
- This PR does not store secrets.
- This PR does not promote this repository back into current MEP truth.

Signed-by: Osuu-ops